### PR TITLE
feat(fastly): detect drift between Pulumi state and live Fastly

### DIFF
--- a/bin/fastly-drift-audit
+++ b/bin/fastly-drift-audit
@@ -27,6 +27,7 @@ and the rejected alternatives.
 
 import json
 import sys
+import traceback
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +66,12 @@ SECRET_SIGIL = "4dabf18193072939515e22adb298388d"  # noqa: S105  # pragma: allow
 
 # State output key -> the path segment of the matching Fastly version endpoint.
 # The two spellings differ, which is the whole reason this mapping is explicit.
+#
+# Every name-keyed child collection the estate actually uses belongs here. A
+# collection merely absent from this dict is not reported as anything at all,
+# so an omission reads exactly like a clean result -- the same "unmeasured
+# looks identical to healthy" trap the unauditable/empty distinction exists to
+# avoid, just moved up a level.
 AUDITED_COLLECTIONS = {
     "snippets": "snippet",
     "conditions": "condition",
@@ -73,11 +80,23 @@ AUDITED_COLLECTIONS = {
     "domains": "domain",
     "requestSettings": "request_settings",
     "dictionaries": "dictionary",
+    "cacheSettings": "cache_settings",
+    "gzips": "gzip",
+    "responseObjects": "response_object",
+    "loggingHttps": "logging/https",
 }
 
 ALERT = "ALERT"
 INFO = "info"
 SKIP = "skip"
+
+# Drift and a broken audit have to be distinguishable. Concourse classifies
+# every nonzero exit as `failed` and fires the same hook for both, so without a
+# separate code an S3 or Fastly outage would announce confirmed drift.
+EXIT_CLEAN = 0
+EXIT_DRIFT = 1
+EXIT_USAGE = 2
+EXIT_ERROR = 3
 
 
 @dataclass(frozen=True)
@@ -388,8 +407,8 @@ def report(reports: list[ServiceReport], stack_count: int) -> int:
             "\nPulumi state claims these objects exist and Fastly does not have "
             f"them. Repair with the targeted refresh runbook: {RUNBOOK_URL}"
         )
-        return 1
-    return 0
+        return EXIT_DRIFT
+    return EXIT_CLEAN
 
 
 @app.command
@@ -408,7 +427,7 @@ def audit(
     if project:
         if unknown := set(project) - projects:
             print(f"Not declared in this repo: {sorted(unknown)}", file=sys.stderr)
-            return 2
+            return EXIT_USAGE
         projects = set(project)
 
     reader = fastly_reader()
@@ -444,7 +463,7 @@ def replay(
     """
     if project not in declared_projects(repo_root):
         print(f"Not declared in this repo: {project}", file=sys.stderr)
-        return 2
+        return EXIT_USAGE
 
     reader = fastly_reader()
     s3_client = boto3.client("s3")
@@ -454,9 +473,15 @@ def replay(
     services = declared_services(project, stack, json.loads(body))
     if not services:
         print(f"No Fastly services in {project}/{stack}", file=sys.stderr)
-        return 2
+        return EXIT_USAGE
     return report([audit_service(reader, s, version) for s in services], 1)
 
 
 if __name__ == "__main__":
-    sys.exit(app())
+    try:
+        sys.exit(app())
+    except Exception:
+        # Not a bare `raise`: an uncaught traceback also exits 1, which is
+        # indistinguishable from "drift found" by exit code alone.
+        traceback.print_exc()
+        sys.exit(EXIT_ERROR)

--- a/bin/fastly-drift-audit
+++ b/bin/fastly-drift-audit
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Compare the Fastly child-object names in Pulumi state against live Fastly.
+
+hq#12449: a VCL snippet whose name contained an illegal `/` was rejected by the
+Fastly API mid-apply, but the failed Pulumi run persisted the full *desired*
+snippet set into the resource's state outputs anyway. The provider's `SetDiff`
+then read the never-created snippet back as `Unmodified`, so no later
+`pulumi up` could heal it -- QA and Production served without the redirect for
+days while every deploy reported success.
+
+Nothing noticed because nothing compares Pulumi's state to Fastly's reality:
+every Fastly-bearing stack runs `refresh_stack=False`, set *because* the stack
+has Fastly resources. `audit` closes that gap. It walks every `ServiceVcl` in
+every stack this repo declares, resolves the version Fastly is actually
+serving, and reports any named child object that state claims exists and the
+live service does not have. `replay` does the same for one stack against one
+explicit version; Fastly versions are immutable, so that is both the regression
+test for the original incident and the way to verify a repair.
+
+Read-only by construction: S3 GETs against the checkpoint bucket and Fastly
+GETs with the read-only `global_read_api_key`. No Pulumi CLI, no
+`PULUMI_CONFIG_PASSPHRASE`, no ability to mutate state.
+
+See docs/adr/0011-fastly-drift-detection-by-name-set-audit.md for the decision
+and the rejected alternatives.
+"""
+
+import json
+import sys
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Annotated, Any
+
+import boto3
+import cyclopts
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from bridge.secrets.sops import read_yaml_secrets
+
+app = cyclopts.App(
+    help=(
+        "Compare the Fastly child-object names recorded in Pulumi state against "
+        "the version Fastly is actually serving."
+    )
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATE_BUCKET = "mitol-pulumi-state"
+STATE_PREFIX = ".pulumi/stacks/"
+SERVICE_VCL_TYPE = "fastly:index/serviceVcl:ServiceVcl"
+FASTLY_API_ROOT = "https://api.fastly.com"
+REQUEST_TIMEOUT_SECONDS = 30
+RUNBOOK_URL = (
+    "https://engineering.ol.mit.edu/platform_services/cloud_infrastructure/"
+    "fastly_pulumi_state_drift/"
+)
+
+# Pulumi's public marker for a secret-wrapped value. Not a credential -- it is a
+# fixed sentinel key the engine writes in place of the real value.
+SECRET_SIGIL = "4dabf18193072939515e22adb298388d"  # noqa: S105  # pragma: allowlist secret
+
+# State output key -> the path segment of the matching Fastly version endpoint.
+# The two spellings differ, which is the whole reason this mapping is explicit.
+AUDITED_COLLECTIONS = {
+    "snippets": "snippet",
+    "conditions": "condition",
+    "headers": "header",
+    "backends": "backend",
+    "domains": "domain",
+    "requestSettings": "request_settings",
+    "dictionaries": "dictionary",
+}
+
+ALERT = "ALERT"
+INFO = "info"
+SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class DeclaredCollection:
+    """One child collection as Pulumi state records it.
+
+    ``auditable`` false is deliberately distinct from an empty ``names``: a
+    collection we cannot read and a collection that is genuinely empty produce
+    identical set differences, and only one of them is good news.
+    """
+
+    names: frozenset[str]
+    auditable: bool = True
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class DeclaredService:
+    """One Fastly service as a single stack's checkpoint declares it."""
+
+    project: str
+    stack: str
+    service_id: str
+    state_active_version: int | None
+    collections: Mapping[str, DeclaredCollection]
+
+    @property
+    def label(self) -> str:
+        """Identify the service in report output."""
+        return f"{self.project}/{self.stack} {self.service_id}"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One difference between declared and live, at one severity."""
+
+    level: str
+    kind: str
+    collection: str = ""
+    names: tuple[str, ...] = ()
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ServiceReport:
+    """Every finding for one service, against the version it was compared to."""
+
+    service: DeclaredService
+    live_version: int | None
+    findings: tuple[Finding, ...] = field(default_factory=tuple)
+
+
+def declared_projects(repo_root: Path) -> set[str]:
+    """Every Pulumi project name this repo declares, from ``src/**/Pulumi.yaml``.
+
+    Scope comes from the repo and never from an S3 listing. The bucket retains
+    checkpoints for deleted projects -- ``ol-infrastructure-fastly`` and
+    ``ol-infrastructure-mitxonline-application`` still point at the same live
+    service IDs as the current ``ol-application-*`` stacks, hundreds of
+    versions stale. Auditing those reports the entire live service as drift.
+    """
+    names = {
+        name
+        for path in sorted((repo_root / "src").rglob("Pulumi.yaml"))
+        if isinstance(name := (yaml.safe_load(path.read_text()) or {}).get("name"), str)
+    }
+    if not names:
+        # An empty scope audits nothing and reports clean, which is
+        # indistinguishable from a healthy estate. Fail instead.
+        msg = f"No Pulumi projects found under {repo_root / 'src'}"
+        raise RuntimeError(msg)
+    return names
+
+
+def read_collection(raw: object) -> DeclaredCollection:
+    """Extract the member names of one child collection from a state output."""
+    if raw is None:
+        return DeclaredCollection(frozenset())
+    if isinstance(raw, dict) and SECRET_SIGIL in raw:
+        return DeclaredCollection(
+            frozenset(), auditable=False, reason="secret-wrapped in state"
+        )
+    if not isinstance(raw, list):
+        return DeclaredCollection(
+            frozenset(),
+            auditable=False,
+            reason=f"unexpected {type(raw).__name__} in state",
+        )
+    # A member that is not a dict, or carries no string name, cannot be
+    # compared. Dropping it silently would shrink the declared set and so err
+    # toward reporting clean -- the wrong direction for a detector -- so the
+    # whole collection is marked unreadable instead.
+    if any(not isinstance(m, dict) or not isinstance(m.get("name"), str) for m in raw):
+        return DeclaredCollection(
+            frozenset(), auditable=False, reason="member without a string name"
+        )
+    return DeclaredCollection(frozenset(m["name"] for m in raw))
+
+
+def declared_services(
+    project: str, stack: str, checkpoint: dict[str, Any]
+) -> list[DeclaredService]:
+    """Every live ``ServiceVcl`` recorded in one stack checkpoint."""
+    latest = (checkpoint.get("checkpoint") or {}).get("latest") or {}
+    services = []
+    for resource in latest.get("resources") or []:
+        # `delete: true` marks a resource pending deletion; it is not the
+        # authority for what should be live.
+        if resource.get("type") != SERVICE_VCL_TYPE or resource.get("delete"):
+            continue
+        outputs = resource.get("outputs") or {}
+        service_id = outputs.get("id")
+        if not isinstance(service_id, str):
+            continue
+        active_version = outputs.get("activeVersion")
+        services.append(
+            DeclaredService(
+                project=project,
+                stack=stack,
+                service_id=service_id,
+                state_active_version=(
+                    active_version if isinstance(active_version, int) else None
+                ),
+                collections={
+                    key: read_collection(outputs.get(key))
+                    for key in AUDITED_COLLECTIONS
+                },
+            )
+        )
+    return services
+
+
+def iter_checkpoints(
+    s3_client: Any, projects: set[str]
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    """Yield ``(project, stack, checkpoint)`` for every declared project."""
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for project in sorted(projects):
+        prefix = f"{STATE_PREFIX}{project}/"
+        for page in paginator.paginate(Bucket=STATE_BUCKET, Prefix=prefix):
+            for entry in page.get("Contents") or []:
+                key = entry["Key"]
+                # Also excludes the `.json.bak` backups sitting alongside.
+                if not key.endswith(".json"):
+                    continue
+                body = s3_client.get_object(Bucket=STATE_BUCKET, Key=key)["Body"].read()
+                yield project, key[len(prefix) : -len(".json")], json.loads(body)
+
+
+def serving_version(details: Mapping[str, Any]) -> int | None:
+    """Return the version number Fastly reports as active, if any."""
+    for version in details.get("versions") or []:
+        if isinstance(version, dict) and version.get("active"):
+            number = version.get("number")
+            if isinstance(number, int):
+                return number
+    return None
+
+
+def live_names(payload: object) -> frozenset[str]:
+    """Extract member names from a Fastly version collection response."""
+    if not isinstance(payload, list):
+        msg = f"Expected a list from the Fastly API, got {type(payload).__name__}"
+        raise TypeError(msg)
+    return frozenset(
+        member["name"]
+        for member in payload
+        if isinstance(member, dict) and isinstance(member.get("name"), str)
+    )
+
+
+class FastlyReader:
+    """Read-only Fastly API client scoped to the calls this audit makes."""
+
+    def __init__(self, token: str, session: requests.Session | None = None) -> None:
+        """Authenticate every request with a read-only Fastly token."""
+        self._session = session or requests.Session()
+        self._session.headers.update(
+            {"Fastly-Key": token, "Accept": "application/json"}
+        )
+
+    def _get(self, path: str) -> Any:
+        response = self._session.get(
+            f"{FASTLY_API_ROOT}{path}", timeout=REQUEST_TIMEOUT_SECONDS
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def serving_version(self, service_id: str) -> int | None:
+        """Resolve the version currently serving traffic for a service."""
+        return serving_version(self._get(f"/service/{service_id}/details"))
+
+    def collection_names(
+        self, service_id: str, version: int, endpoint: str
+    ) -> frozenset[str]:
+        """List the member names of one collection on one service version."""
+        return live_names(
+            self._get(f"/service/{service_id}/version/{version}/{endpoint}")
+        )
+
+
+def compare(
+    service: DeclaredService,
+    live_version: int | None,
+    live_collections: Mapping[str, frozenset[str]],
+) -> tuple[Finding, ...]:
+    """Diff declared against live names for one service.
+
+    Only ``declared-but-absent`` is an alert. That set difference is the
+    hq#12449 failure mode exactly: state asserts an object exists on the
+    service and it does not. ``live-but-undeclared`` and a version mismatch
+    are ordinary consequences of a manual UI edit, so they are reported and
+    do not fail.
+    """
+    if live_version is None:
+        return (
+            Finding(SKIP, "no-active-version", detail="no version is serving traffic"),
+        )
+    findings = []
+    if (
+        service.state_active_version is not None
+        and service.state_active_version != live_version
+    ):
+        findings.append(
+            Finding(
+                INFO,
+                "active-version-mismatch",
+                detail=f"state {service.state_active_version}, live {live_version}",
+            )
+        )
+    for key, declared in sorted(service.collections.items()):
+        if not declared.auditable:
+            findings.append(
+                Finding(INFO, "unauditable", collection=key, detail=declared.reason)
+            )
+            continue
+        live = live_collections[key]
+        if absent := declared.names - live:
+            findings.append(
+                Finding(
+                    ALERT,
+                    "declared-but-absent",
+                    collection=key,
+                    names=tuple(sorted(absent)),
+                )
+            )
+        if undeclared := live - declared.names:
+            findings.append(
+                Finding(
+                    INFO,
+                    "live-but-undeclared",
+                    collection=key,
+                    names=tuple(sorted(undeclared)),
+                )
+            )
+    return tuple(findings)
+
+
+def audit_service(
+    reader: FastlyReader, service: DeclaredService, version: int | None
+) -> ServiceReport:
+    """Fetch the live side for one service and diff it against state.
+
+    The comparison is always against the version Fastly is *serving*, not the
+    version state believes is active -- in hq#12449 both were 207 and it was
+    the names that differed.
+    """
+    if version is None:
+        return ServiceReport(service, None, compare(service, None, {}))
+    live_collections = {
+        key: reader.collection_names(service.service_id, version, endpoint)
+        for key, endpoint in sorted(AUDITED_COLLECTIONS.items())
+        if service.collections[key].auditable
+    }
+    return ServiceReport(service, version, compare(service, version, live_collections))
+
+
+def fastly_reader() -> FastlyReader:
+    """Build a reader on the read-only token, never the admin token."""
+    return FastlyReader(read_yaml_secrets(Path("fastly.yaml"))["global_read_api_key"])
+
+
+def report(reports: list[ServiceReport], stack_count: int) -> int:
+    """Print the findings and return the intended exit code."""
+    print(
+        f"# Fastly drift audit -- {len(reports)} service(s) across "
+        f"{stack_count} stack(s)\n"
+    )
+    alert_count = 0
+    info_count = 0
+    for service_report in reports:
+        if not service_report.findings:
+            continue
+        print(f"  {service_report.service.label}")
+        for finding in service_report.findings:
+            alert_count += finding.level == ALERT
+            info_count += finding.level == INFO
+            target = f" {finding.collection}" if finding.collection else ""
+            detail = finding.detail or ", ".join(finding.names)
+            print(f"    {finding.level:5}{target} {finding.kind}: {detail}")
+        print()
+    print(
+        f"{len(reports)} service(s) audited, {alert_count} alert(s), "
+        f"{info_count} informational."
+    )
+    if alert_count:
+        print(
+            "\nPulumi state claims these objects exist and Fastly does not have "
+            f"them. Repair with the targeted refresh runbook: {RUNBOOK_URL}"
+        )
+        return 1
+    return 0
+
+
+@app.command
+def audit(
+    *,
+    repo_root: Annotated[
+        Path, cyclopts.Parameter(help="Repo checkout to read Pulumi.yaml scope from.")
+    ] = REPO_ROOT,
+    project: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(help="Restrict to these Pulumi projects (repeatable)."),
+    ] = None,
+) -> int:
+    """Audit every Fastly service declared by every stack in this repo."""
+    projects = declared_projects(repo_root)
+    if project:
+        if unknown := set(project) - projects:
+            print(f"Not declared in this repo: {sorted(unknown)}", file=sys.stderr)
+            return 2
+        projects = set(project)
+
+    reader = fastly_reader()
+    s3_client = boto3.client("s3")
+    reports: list[ServiceReport] = []
+    stacks = 0
+    for project_name, stack, checkpoint in iter_checkpoints(s3_client, projects):
+        services = declared_services(project_name, stack, checkpoint)
+        if not services:
+            continue
+        stacks += 1
+        reports.extend(
+            audit_service(reader, service, reader.serving_version(service.service_id))
+            for service in services
+        )
+    return report(reports, stacks)
+
+
+@app.command
+def replay(
+    project: str,
+    stack: str,
+    version: int,
+    *,
+    repo_root: Annotated[
+        Path, cyclopts.Parameter(help="Repo checkout to read Pulumi.yaml scope from.")
+    ] = REPO_ROOT,
+) -> int:
+    """Audit one stack against one explicit Fastly version.
+
+    Fastly versions are immutable, so this replays a historical version to
+    reproduce a past incident or to confirm a repair actually landed.
+    """
+    if project not in declared_projects(repo_root):
+        print(f"Not declared in this repo: {project}", file=sys.stderr)
+        return 2
+
+    reader = fastly_reader()
+    s3_client = boto3.client("s3")
+    body = s3_client.get_object(
+        Bucket=STATE_BUCKET, Key=f"{STATE_PREFIX}{project}/{stack}.json"
+    )["Body"].read()
+    services = declared_services(project, stack, json.loads(body))
+    if not services:
+        print(f"No Fastly services in {project}/{stack}", file=sys.stderr)
+        return 2
+    return report([audit_service(reader, s, version) for s in services], 1)
+
+
+if __name__ == "__main__":
+    sys.exit(app())

--- a/docs/adr/0011-fastly-drift-detection-by-name-set-audit.md
+++ b/docs/adr/0011-fastly-drift-detection-by-name-set-audit.md
@@ -21,10 +21,20 @@ The same class of failure recurred in #5563 with parentheses in two mit-learn ca
 snippet names.
 
 Nothing noticed, because nothing compares Pulumi's state to Fastly's reality. Every
-Fastly-bearing stack runs with `refresh_stack=False` — set *because* the stack has Fastly
-resources, since refresh calls the Fastly API with a token that goes stale mid-rotation
-and fails the whole job. The trigger condition and the detection mechanism are the same
-resource, so coverage is 0% exactly where the risk is 100%.
+Fastly-bearing stack runs with `refresh_stack=False`, so coverage is 0% exactly where the
+risk is 100%.
+
+Those flags are stale scaffolding rather than a standing constraint, which is worth
+stating precisely because the opposite was assumed for a while. They were added in one
+commit (#5134) on 2026-07-27 while the Fastly admin token was mid-rotation, so refresh
+was calling the API with a token being revoked. That rotation completed the same day, the
+replacement token carries no expiry, `fastly.yaml` has otherwise only been rotated in
+2022 and 2024, and `ocw_site` is already back to `True`. So no credential problem blocks
+re-enabling refresh — what does is that refresh writes state before `up`, and a Fastly
+stack refresh drops and re-adds `backends` as secret-flip noise (measured below). The
+deploy-path effect of that is untested, so the flags stay for now and the gap is accepted
+knowingly. It is not a small gap: `refresh_stack=False` disables refresh for the *entire*
+stack, and the affected Production stacks run ~130–172 resources of which 1–5 are Fastly.
 
 #5627 added `validate_vcl_snippet_name()` and closed the *ingress* for this specific
 cause. It does nothing for state that is already wrong, for the other name-keyed child
@@ -37,8 +47,8 @@ object exists on a Fastly service and the live service does not have it."
 
 ### Constraints
 
-- `refresh_stack=False` is load-bearing today and its removal is tracked separately.
-  Detection must not depend on that being fixed first.
+- `refresh_stack=False` is in force on every Fastly-bearing stack today and reverting it
+  is separate work with its own untested risk. Detection must not depend on that first.
 - The check runs against Production. It must not be able to mutate state.
 - The `mitodl/ol-infrastructure` image contains no Pulumi CLI.
 - A nightly check that is not silent when things are healthy gets muted within a week.
@@ -79,8 +89,8 @@ reports for the version currently serving traffic.
 
 **Rationale.** Options 1 and 2 fail the zero-false-positive constraint by a wide margin,
 and option 2 additionally hides the target signal inside its own noise. Option 3 is
-decoupled from the `refresh_stack` work, so it ships now rather than after a credential
-redesign.
+decoupled from the `refresh_stack` work, so it ships now rather than waiting on a change
+to the deploy path.
 
 ### Key Implementation Details
 
@@ -88,16 +98,29 @@ redesign.
   `s3://mitol-pulumi-state/.pulumi/stacks/<project>/<stack>.json` with boto3. The
   resource outputs carry `id`, `activeVersion`, and the name-keyed child collections.
   This needs no Pulumi CLI and no `PULUMI_CONFIG_PASSPHRASE`.
-- **Live side.** `GET /service/<id>/version/<live active version>/<collection>` for
-  `snippet`, `condition`, `header`, `domain`, `request_settings`, and `dictionary`.
-  Authenticated with the existing read-only `global_read_api_key` from SOPS
-  `fastly.yaml`, not the admin token.
+- **Live side.** `GET /service/<id>/version/<live active version>/<collection>` for all
+  eleven name-keyed collections: `snippet`, `condition`, `header`, `backend`, `domain`,
+  `request_settings`, `dictionary`, `cache_settings`, `gzip`, `response_object`, and
+  `logging/https`. Authenticated with the existing read-only `global_read_api_key` from
+  SOPS `fastly.yaml`, not the admin token.
+
+  This list is the detector's entire coverage, so an omission from it is invisible — an
+  unaudited collection produces no findings, which reads exactly like a clean one. The
+  first draft audited seven and silently ignored ~100 live objects across
+  `responseObjects` (27), `cacheSettings` (26), `loggingHttps` (26 readable, 4 secret),
+  and `gzips` (21). Keep `AUDITED_COLLECTIONS` in
+  `bin/fastly-drift-audit` and this list in step.
 - **Compare against the version Fastly is actually serving,** resolved from
   `/service/<id>/details`, rather than the version state believes is active. The question
   is what is serving traffic, not what we think is.
 - **`DECLARED-BUT-ABSENT` fails the job.** That set difference is the #5513/#5563 failure
   mode exactly. `live-but-undeclared` and an `activeVersion` mismatch are reported but do
   not fail, since both are ordinary consequences of a manual UI edit.
+- **Drift exits 1; an audit that could not complete exits 3.** Concourse classifies every
+  nonzero exit as `failed` and fires one hook for all of them, so without distinct codes
+  a Fastly or S3 outage would announce confirmed drift — precisely the false alarm this
+  design is built to avoid. The alert text therefore covers both cases and points at the
+  job output rather than asserting drift.
 - **Delivery:** a nightly Concourse pipeline in the Production `infra` pool, following
   `iam_drift`/`github_drift` in shape, alerting to Slack on failure. Unlike those two it
   does *not* open a pull request — there is no code change to propose. The remedy is the
@@ -116,7 +139,10 @@ Three traps have to be handled or the check false-alarms permanently:
    live service IDs* as the current `ol-application-*` stacks, hundreds of versions stale.
    Scope the scan to project names parsed from `src/**/Pulumi.yaml`, not to an S3 listing.
 3. **`TlsSubscription` also has a `domains` output,** but its members are plain strings.
-   Filter on resource type and skip non-dict members.
+   Filter on resource type, and treat a collection whose members carry no string name as
+   unauditable. Skipping such members individually would also avoid the crash, but it
+   would shrink the *declared* set and therefore shrink `declared - live` — a reader bug
+   would then report clean, which is the wrong direction for a detector to fail in.
 
 ## Consequences
 
@@ -127,10 +153,13 @@ Three traps have to be handled or the check false-alarms permanently:
   can be replayed against the pre-repair v207, which yields exactly
   `DECLARED-BUT-ABSENT: ['Redirect course and program pages to MIT Learn']`. Against the
   repaired v208 it is silent.
-- **Measured silent today.** Full estate run: 36 `ServiceVcl` resources across 32 stacks,
-  81 seconds, `ALERT=0`. The five informational findings are five unauditable `backends`
-  collections and one benign `activeVersion` mismatch (state 14, live 16, all names
-  matching) on `ol-application-edxapp/xpro.Production`.
+- **Measured silent today.** Full estate run over all eleven collections: 36 `ServiceVcl`
+  resources across 32 stacks, `ALERT=0`, ~2.5 minutes. The ten informational findings are
+  five unauditable `backends` collections, four unauditable `loggingHttps`, and one benign
+  `activeVersion` mismatch (state 14, live 16, all names matching) on
+  `ol-application-edxapp/xpro.Production`. Notably the ~100 objects in the four
+  collections added after the first draft all matched, so widening coverage cost no
+  standing noise.
 - Requires **no new IAM and no new credentials.** The Production `infra` pool already has
   `s3:GetObject*`/`s3:ListBucket*` on the bucket via the `pulumi_state` policy module and
   `kms:Decrypt` via `infra`.
@@ -152,8 +181,11 @@ Three traps have to be handled or the check false-alarms permanently:
 
 - Coverage is 32 stacks, not the 8 an earlier estimate suggested: `edxapp` alone carries
   12 stacks and `ocw-site` holds three services per stack.
-- Does not remove the need to fix Fastly token rotation and re-enable `refresh_stack`;
-  it makes that work non-urgent rather than unnecessary.
+- Does not re-enable `refresh_stack`, and so covers only the Fastly slice of those
+  stacks. The ~770 non-Fastly Production resources behind those flags — roughly 180
+  `aws:*` and 60 `vault:*` — remain unrefreshed and unwatched by anything.
+- Does not require fixing Fastly token rotation, which turned out not to be broken. That
+  premise was investigated and dropped; see the Context note above.
 
 ## Implementation Notes
 

--- a/docs/adr/0011-fastly-drift-detection-by-name-set-audit.md
+++ b/docs/adr/0011-fastly-drift-detection-by-name-set-audit.md
@@ -1,0 +1,186 @@
+# 0011. Detect Fastly Drift by Name-Set Audit, Not by Pulumi Refresh
+
+**Status:** Proposed
+**Date:** 2026-08-27
+**Deciders:** Platform Engineering
+**Technical Story:** [hq#12449](https://github.com/mitodl/hq/issues/12449), [ol-infrastructure#5627](https://github.com/mitodl/ol-infrastructure/pull/5627)
+
+## Context
+
+### Current Situation
+
+A VCL snippet named `Handle course/program redirects to MIT Learn` shipped in #5513. The
+`/` is illegal in a Fastly snippet name, so the API returned 400 partway through the
+apply — after Pulumi had already cloned a service version. The failed run still persisted
+the full *desired* snippet set into the resource's state outputs. The provider's `SetDiff`
+then read the never-created snippet back as `Unmodified`, so no subsequent `pulumi up`
+could ever heal it.
+
+QA and Production served without the redirect for days. Every deploy reported success.
+The same class of failure recurred in #5563 with parentheses in two mit-learn cache-key
+snippet names.
+
+Nothing noticed, because nothing compares Pulumi's state to Fastly's reality. Every
+Fastly-bearing stack runs with `refresh_stack=False` — set *because* the stack has Fastly
+resources, since refresh calls the Fastly API with a token that goes stale mid-rotation
+and fails the whole job. The trigger condition and the detection mechanism are the same
+resource, so coverage is 0% exactly where the risk is 100%.
+
+#5627 added `validate_vcl_snippet_name()` and closed the *ingress* for this specific
+cause. It does nothing for state that is already wrong, for the other name-keyed child
+collections, or for drift introduced by hand in the Fastly UI.
+
+### Problem Statement
+
+Detect, without a human in the loop, the condition "Pulumi state claims a named child
+object exists on a Fastly service and the live service does not have it."
+
+### Constraints
+
+- `refresh_stack=False` is load-bearing today and its removal is tracked separately.
+  Detection must not depend on that being fixed first.
+- The check runs against Production. It must not be able to mutate state.
+- The `mitodl/ol-infrastructure` image contains no Pulumi CLI.
+- A nightly check that is not silent when things are healthy gets muted within a week.
+  Zero standing false positives is a hard requirement, not an aspiration.
+
+### Options Considered
+
+1. **Nightly `pulumi preview --refresh`, alert on any non-empty diff**
+   - Pros: Uses the tool we already have; catches every resource type, not just Fastly.
+   - Cons: Measured on `ol-application-mit-learn/CI`, the refresh reports **38** resources
+     with diffs, of which exactly **one** is Fastly. The other 37 are routine Kubernetes
+     churn (13 `VaultStaticSecret`, 5 `VerticalPodAutoscaler`, 5 `Deployment`, 4 KEDA
+     `ScaledObject`, and so on). Fires every night on noise.
+
+2. **The same, filtered to Fastly resources**
+   - Pros: Removes the Kubernetes churn.
+   - Cons: Still permanently non-empty, and the signal is *inverted*. That one
+     `ServiceVcl` refresh-diff is 189 lines containing no real drift at all: `backends`
+     and `loggingHttps` are dropped and re-added because they contain `[secret]` members
+     and the whole collection flips to secret on refresh, plus `requestSettings` gains a
+     provider-default `maxStaleAge: 0`. Meanwhile `snippets` does not appear — because
+     the snippets genuinely matched. The noise is unconditional and the thing we care
+     about is invisible inside it.
+
+3. **Purpose-built name-set audit against the Fastly API**
+   - Pros: Compares exactly the property that broke. No refresh, no admin token, no
+     ability to write state. Measured silent across the whole estate today.
+   - Cons: Bespoke code to maintain; covers Fastly only; compares names, so an edit to a
+     snippet's *body* is out of scope.
+
+## Decision
+
+**Chosen option: 3, a purpose-built name-set audit.**
+
+For every `fastly:index/serviceVcl:ServiceVcl` resource in the estate, compare the set of
+child-object *names* recorded in Pulumi state against the set of names the Fastly API
+reports for the version currently serving traffic.
+
+**Rationale.** Options 1 and 2 fail the zero-false-positive constraint by a wide margin,
+and option 2 additionally hides the target signal inside its own noise. Option 3 is
+decoupled from the `refresh_stack` work, so it ships now rather than after a credential
+redesign.
+
+### Key Implementation Details
+
+- **State side.** Read the checkpoint directly from
+  `s3://mitol-pulumi-state/.pulumi/stacks/<project>/<stack>.json` with boto3. The
+  resource outputs carry `id`, `activeVersion`, and the name-keyed child collections.
+  This needs no Pulumi CLI and no `PULUMI_CONFIG_PASSPHRASE`.
+- **Live side.** `GET /service/<id>/version/<live active version>/<collection>` for
+  `snippet`, `condition`, `header`, `domain`, `request_settings`, and `dictionary`.
+  Authenticated with the existing read-only `global_read_api_key` from SOPS
+  `fastly.yaml`, not the admin token.
+- **Compare against the version Fastly is actually serving,** resolved from
+  `/service/<id>/details`, rather than the version state believes is active. The question
+  is what is serving traffic, not what we think is.
+- **`DECLARED-BUT-ABSENT` fails the job.** That set difference is the #5513/#5563 failure
+  mode exactly. `live-but-undeclared` and an `activeVersion` mismatch are reported but do
+  not fail, since both are ordinary consequences of a manual UI edit.
+- **Delivery:** a nightly Concourse pipeline in the Production `infra` pool, following
+  `iam_drift`/`github_drift` in shape, alerting to Slack on failure. Unlike those two it
+  does *not* open a pull request — there is no code change to propose. The remedy is the
+  targeted `pulumi refresh` + `pulumi up` runbook, which the alert links to.
+
+Three traps have to be handled or the check false-alarms permanently:
+
+1. **Secret-wrapped collections.** `backends` and `loggingHttps` are frequently stored not
+   as a list but as `{"4dabf18193072939515e22adb298388d": ..., "ciphertext": "v1:..."}` — <!-- pragma: allowlist secret -->
+   that first key is Pulumi's public marker for a secret-wrapped value, not a credential.
+   Iterating that yields zero names, and every live backend is then reported as drift.
+   Detect the sigil and mark the collection unauditable rather than empty.
+2. **Orphaned checkpoints.** The bucket holds 324 stack files; only 306 belong to projects
+   this repo still declares. Dead projects `ol-infrastructure-fastly` and
+   `ol-infrastructure-mitxonline-application` retain checkpoints pointing at the *same
+   live service IDs* as the current `ol-application-*` stacks, hundreds of versions stale.
+   Scope the scan to project names parsed from `src/**/Pulumi.yaml`, not to an S3 listing.
+3. **`TlsSubscription` also has a `domains` output,** but its members are plain strings.
+   Filter on resource type and skip non-dict members.
+
+## Consequences
+
+### Positive
+
+- Closes the detection gap that let hq#12449 run for days. **Verified against the real
+  incident:** Fastly versions are immutable, so mitxonline Production's declared snippets
+  can be replayed against the pre-repair v207, which yields exactly
+  `DECLARED-BUT-ABSENT: ['Redirect course and program pages to MIT Learn']`. Against the
+  repaired v208 it is silent.
+- **Measured silent today.** Full estate run: 36 `ServiceVcl` resources across 32 stacks,
+  81 seconds, `ALERT=0`. The five informational findings are five unauditable `backends`
+  collections and one benign `activeVersion` mismatch (state 14, live 16, all names
+  matching) on `ol-application-edxapp/xpro.Production`.
+- Requires **no new IAM and no new credentials.** The Production `infra` pool already has
+  `s3:GetObject*`/`s3:ListBucket*` on the bucket via the `pulumi_state` policy module and
+  `kms:Decrypt` via `infra`.
+- Structurally incapable of mutating state — it only reads S3 and issues Fastly `GET`s
+  with a read-only token.
+- Also catches drift Pulumi cannot see at all, such as a snippet deleted by hand in the
+  Fastly UI.
+
+### Negative
+
+- Compares names only. A changed snippet *body* under an unchanged name is not detected.
+- `backends` and `loggingHttps` stay unauditable while they are secret in state.
+- Bespoke code against an undocumented-but-stable detail: the Pulumi checkpoint JSON
+  layout. A backend format change would break the reader. Mitigated by keeping the
+  parsing in one place, and by the fact that a parse failure fails loudly.
+- Detection latency is up to 24 hours.
+
+### Neutral
+
+- Coverage is 32 stacks, not the 8 an earlier estimate suggested: `edxapp` alone carries
+  12 stacks and `ocw-site` holds three services per stack.
+- Does not remove the need to fix Fastly token rotation and re-enable `refresh_stack`;
+  it makes that work non-urgent rather than unnecessary.
+
+## Implementation Notes
+
+- **Effort Estimate:** 1–2 days. A validated prototype already produced the numbers above.
+- **Risk Level:** Low — read-only, and it runs outside the deploy path.
+- **Dependencies:** None blocking.
+
+## Related Decisions
+
+- [0010. Pingdom Checks Unmanaged in Pulumi State](0010-pingdom-checks-unmanaged-in-pulumi-state.md) — the
+  same underlying theme of Pulumi state disagreeing with a third-party provider.
+- ol-infrastructure#5627 — the preventive half: reject illegal snippet names at preview.
+- platform-engineering-site#67 — the Fastly/Pulumi state-drift repair runbook the alert
+  will point at.
+
+## References
+
+- [Fastly API: VCL snippets](https://www.fastly.com/documentation/reference/api/vcl-services/snippet/)
+- `src/ol_concourse/pipelines/infrastructure/iam_drift/pipeline.py` — the nightly drift
+  pipeline shape this follows.
+
+---
+
+**Review History:**
+
+| Date | Reviewer | Decision | Notes |
+|------|----------|----------|-------|
+| | | | |
+
+**Last Updated:** 2026-08-27

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,6 +167,7 @@ graph LR
 | [0007](0007-clickhouse-llmops-multi-tenant.md) | Multi-Tenant ClickHouse Cluster for LLMOps on Data EKS | Accepted | 2026-02-25 |
 | [0008](0008-concourse-spot-worker-graceful-drain-no-ephemeral.md) | Concourse Spot Worker Graceful Drain Without Ephemeral Mode | Accepted | 2026-04-08 |
 | [0009](0009-deploy-witan-as-shared-multi-tenant-mcp-service.md) | Deploy witan as a Shared, Multi-Tenant MCP Service | Accepted | 2026-07-07 |
+| [0011](0011-fastly-drift-detection-by-name-set-audit.md) | Detect Fastly Drift by Name-Set Audit, Not by Pulumi Refresh | Proposed | 2026-08-27 |
 
 ## Creating a New ADR
 

--- a/src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py
@@ -1,0 +1,159 @@
+"""Nightly comparison of Pulumi's Fastly state against what Fastly is serving.
+
+`bin/fastly-drift-audit audit` reads every stack checkpoint out of
+`s3://mitol-pulumi-state`, pulls the child-object names each `ServiceVcl`
+records, and diffs them against the version Fastly reports as active. A name
+that state claims exists and the live service does not have fails this job.
+
+That gap is why hq#12449 ran for days: an illegal `/` in a VCL snippet name was
+rejected by the Fastly API mid-apply, the failed run persisted the desired
+snippet set into state anyway, and the provider's `SetDiff` then read the
+never-created snippet back as `Unmodified`. No later `pulumi up` could heal it,
+and nothing was comparing the two sides -- every Fastly-bearing stack runs
+`refresh_stack=False`, set *because* the stack has Fastly resources.
+
+Unlike `iam_drift` and `github_drift` this job opens no pull request. There is
+no code change to propose: the declared configuration is already correct and
+it is the state and the live service that disagree. The remedy is a targeted
+`pulumi refresh` + `pulumi up`, so a failure notifies Slack with a link to that
+runbook instead.
+
+Needs no new credentials. The Production `infra` pool already grants the
+`s3:GetObject*`/`s3:ListBucket*` this reads with (the `pulumi_state` policy
+module) and the `kms:Decrypt` that the SOPS read of `fastly.yaml` needs (the
+`infra` module). The audit authenticates to Fastly with the read-only
+`global_read_api_key`, never the admin token, and issues only GETs -- it is
+structurally incapable of changing either Fastly or Pulumi state.
+"""
+
+import sys
+
+from ol_concourse.lib.constants import REGISTRY_IMAGE
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    Platform,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.notifications import notification
+from ol_concourse.lib.resource_types import (
+    slack_notification_resource as slack_notification_resource_type,
+)
+from ol_concourse.lib.resources import git_repo, schedule, slack_notification
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+AWS_REGION = "us-east-1"
+GITHUB_REPOSITORY = "mitodl/ol-infrastructure"
+RUNBOOK_URL = (
+    "https://engineering.ol.mit.edu/platform_services/cloud_infrastructure/"
+    "fastly_pulumi_state_drift/"
+)
+
+ol_infrastructure = git_repo(
+    Identifier("ol-infrastructure"),
+    uri=f"https://github.com/{GITHUB_REPOSITORY}",
+)
+
+drift_schedule = schedule(
+    Identifier("nightly-schedule"),
+    interval="24h",
+    start="02:00",
+    stop="03:00",
+)
+
+ol_infrastructure_image = AnonymousResource(
+    type=REGISTRY_IMAGE,
+    source={
+        "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+        "tag": "latest",
+        "aws_region": ECR_REGION,
+    },
+)
+
+slack_notification_resource = slack_notification(
+    Identifier("slack-notification"), url="((eks.slack_url))"
+)
+
+
+def drift_job() -> Job:
+    """Build the nightly audit job."""
+    return Job(
+        name=Identifier("check-fastly-drift"),
+        plan=[
+            GetStep(get=drift_schedule.name, trigger=True),
+            GetStep(get=ol_infrastructure.name, trigger=False),
+            TaskStep(
+                task=Identifier("audit-fastly-drift"),
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=ol_infrastructure_image,
+                    inputs=[Input(name=ol_infrastructure.name)],
+                    params={
+                        # The checkout, not the image's installed copy: the
+                        # audit derives its scope from the Pulumi.yaml files
+                        # sitting next to the script it runs.
+                        "PYTHONPATH": f"{ol_infrastructure.name}/src",
+                        "AWS_DEFAULT_REGION": AWS_REGION,
+                    },
+                    run=Command(
+                        user="root",
+                        path="sh",
+                        args=[
+                            "-exc",
+                            (
+                                f"python {ol_infrastructure.name}/bin/"
+                                "fastly-drift-audit audit"
+                                f" --repo-root {ol_infrastructure.name}"
+                            ),
+                        ],
+                    ),
+                ),
+                on_failure=notification(
+                    slack_notification_resource,
+                    "Fastly drift detected",
+                    (
+                        "Pulumi state claims a Fastly object exists that the live"
+                        " service does not have -- the hq#12449 failure mode. No"
+                        " `pulumi up` will heal this on its own. Job output lists the"
+                        f" affected services; repair runbook: {RUNBOOK_URL}"
+                    ),
+                    alert_type="failed",
+                ),
+                on_error=notification(
+                    slack_notification_resource,
+                    "Fastly drift audit errored",
+                    (
+                        "The nightly Fastly drift audit failed to run, so the estate"
+                        " is currently unchecked rather than clean. Check the job"
+                        " output."
+                    ),
+                    alert_type="errored",
+                ),
+            ),
+        ],
+    )
+
+
+def fastly_drift_pipeline() -> Pipeline:
+    """Assemble the pipeline."""
+    return Pipeline(
+        resources=[drift_schedule, ol_infrastructure, slack_notification_resource],
+        resource_types=[slack_notification_resource_type()],
+        jobs=[drift_job()],
+    )
+
+
+if __name__ == "__main__":
+    definition_json = fastly_drift_pipeline().model_dump_json(indent=2)
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(definition_json)
+    sys.stdout.write(definition_json)
+    print()  # noqa: T201
+    print("fly -t pr-inf sp -p fastly-drift -c definition.json")  # noqa: T201

--- a/src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py
@@ -115,14 +115,23 @@ def drift_job() -> Job:
                         ],
                     ),
                 ),
+                # Concourse classifies ANY nonzero exit as `failed`, so this one
+                # hook covers both real drift (exit 1) and an audit that could not
+                # complete (exit 3 -- S3, SOPS, or the Fastly API). It must not
+                # assert confirmed drift: announcing the hq#12449 failure mode
+                # every time Fastly has an outage is the false alarm this detector
+                # exists to avoid. The job output distinguishes the two, and
+                # `on_error` still covers Concourse-level step errors.
                 on_failure=notification(
                     slack_notification_resource,
-                    "Fastly drift detected",
+                    "Fastly drift audit failed",
                     (
-                        "Pulumi state claims a Fastly object exists that the live"
-                        " service does not have -- the hq#12449 failure mode. No"
-                        " `pulumi up` will heal this on its own. Job output lists the"
-                        f" affected services; repair runbook: {RUNBOOK_URL}"
+                        "Either Pulumi state claims a Fastly object the live service"
+                        " does not have (the hq#12449 failure mode, which no"
+                        " `pulumi up` will heal on its own), or the audit could not"
+                        " complete and the estate is currently unchecked rather than"
+                        " clean. The job output says which: look for `ALERT` lines."
+                        f" Repair runbook: {RUNBOOK_URL}"
                     ),
                     alert_type="failed",
                 ),
@@ -130,9 +139,9 @@ def drift_job() -> Job:
                     slack_notification_resource,
                     "Fastly drift audit errored",
                     (
-                        "The nightly Fastly drift audit failed to run, so the estate"
-                        " is currently unchecked rather than clean. Check the job"
-                        " output."
+                        "The nightly Fastly drift audit did not run to completion, so"
+                        " the estate is currently unchecked rather than clean. Check"
+                        " the job output."
                     ),
                     alert_type="errored",
                 ),

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -118,10 +118,29 @@ class AppPipelineParams(BaseModel):
             image build. See :class:`SentrySourcemapsConfig`. Left unset, no source
             maps are uploaded.
         refresh_stack (bool): Whether the Pulumi deploy jobs run `pulumi refresh`
-            before `up`. Defaults to True. Set False for apps whose Pulumi code
-            provisions Fastly resources while the Fastly API token is being
-            rotated -- refresh calls the Fastly API with the old token and fails
-            the whole job.
+            before `up`. Defaults to True, which is what every stack outside the
+            list below uses.
+
+            The existing `False` settings are STALE SCAFFOLDING, not a standing
+            constraint. They were added in #5134 on 2026-07-27 while the Fastly
+            admin token was mid-rotation, so refresh was calling the API with a
+            token being revoked. That rotation finished the same day; the
+            replacement token carries no expiry, and `fastly.yaml` has otherwise
+            only been rotated in 2022 and 2024. Nothing rotates today, and
+            `ocw_site` has already been flipped back to True.
+
+            They were left in place deliberately, not because they are needed:
+            refresh runs before `up` and writes state, and a Fastly stack refresh
+            drops and re-adds `backends` as secret-flip noise (see
+            docs/adr/0011-fastly-drift-detection-by-name-set-audit.md), so
+            re-enabling has an unmeasured deploy-path risk. Note the cost of
+            leaving them: this disables refresh for the ENTIRE stack, not just its
+            Fastly resources, and these stacks are ~170 resources of which about 3
+            are Fastly.
+
+            To revert one: `pulumi preview --refresh` that stack first (preview
+            never writes state) to see what `up` would then do, and flip a single
+            pipeline at a time.
     """
 
     app_name: str

--- a/src/ol_concourse/pipelines/infrastructure/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/meta.py
@@ -54,6 +54,10 @@ PIPELINE_CONFIGS: list[tuple[str, str]] = [
         "src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py",
     ),
     (
+        "fastly-drift",
+        "src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py",
+    ),
+    (
         "github-estate-drift",
         "src/ol_concourse/pipelines/infrastructure/github_drift/pipeline.py",
     ),

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -125,10 +125,19 @@ class SimplePulumiParams(BaseModel):
                           issue being closed, preserving the same promotion workflow
                           used within a single chained pipeline.
         refresh_stack: Whether the Pulumi deploy jobs run `pulumi refresh` before
-                      `up`. Defaults to True. Set False for apps whose Pulumi code
-                      provisions Fastly resources while the Fastly API token is
-                      being rotated -- refresh calls the Fastly API with the old
-                      token and fails the whole job.
+                      `up`. Defaults to True.
+
+                      Any existing `False` here is STALE SCAFFOLDING rather than a
+                      standing constraint: added in #5134 on 2026-07-27 while the
+                      Fastly admin token was mid-rotation, a rotation that
+                      finished that same day. The replacement token has no expiry
+                      and nothing rotates today. Left in place only because
+                      re-enabling refresh carries an unmeasured deploy-path risk
+                      (refresh writes state before `up`, and a Fastly refresh
+                      drops and re-adds `backends` as secret-flip noise). See the
+                      fuller note on AppPipelineParams.refresh_stack in
+                      ../k8s_apps/pipeline.py and
+                      docs/adr/0011-fastly-drift-detection-by-name-set-audit.md.
         topology: "deploy-chained" (default) auto-deploys each stage on code
                  change, gated only by the previous stage's promotion issue.
                  "preview-gated" instead gates every stage on a `pulumi preview`

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -218,8 +218,13 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:
             pulumi_fragments.append(
                 pulumi_jobs_chain(
                     edx_pulumi_code,
-                    # edxapp's Pulumi code provisions Fastly resources; refresh
-                    # calls the Fastly API and fails while the token is rotated.
+                    # Stale scaffolding, not a standing constraint: added in #5134
+                    # on 2026-07-27 while the Fastly admin token was mid-rotation,
+                    # which finished the same day. The replacement token has no
+                    # expiry and nothing rotates today. Left set only because
+                    # re-enabling refresh has an unmeasured deploy-path risk -- see
+                    # AppPipelineParams.refresh_stack in
+                    # src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py.
                     refresh_stack=False,
                     # Gate each stage on a preview OF ITSELF. edxapp is the
                     # largest blast radius in the estate and its environments

--- a/tests/scripts/test_fastly_drift_audit.py
+++ b/tests/scripts/test_fastly_drift_audit.py
@@ -16,9 +16,6 @@ import pytest
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "bin" / "fastly-drift-audit"
 
-# The value half of Pulumi's fixed sentinel pair for a secret-wrapped output.
-SENTINEL_VALUE = "1b47061264138c4ac30d75fd1eb44270"  # pragma: allowlist secret
-
 
 def load_audit_module():
     """Load the audit CLI from bin/.
@@ -132,13 +129,16 @@ def test_no_active_version_skips_rather_than_alerting(audit):
 
 
 def test_secret_wrapped_collection_is_unauditable_not_empty(audit):
-    """`backends` is often stored secret-wrapped rather than as a list.
+    """`backends` and `loggingHttps` are sometimes stored secret-wrapped.
 
     Iterating the sigil dict yields zero names, so every live backend would
     read as `live-but-undeclared` on every service, forever.
     """
     collection = audit.read_collection(
-        {audit.SECRET_SIGIL: SENTINEL_VALUE, "ciphertext": "v1:..."}
+        # Detection keys off the sigil, so the value half of Pulumi's sentinel
+        # pair is irrelevant here and is left out rather than tripping secret
+        # scanners with a well-known constant.
+        {audit.SECRET_SIGIL: "<sentinel>", "ciphertext": "v1:..."}
     )
     assert collection.auditable is False
     assert collection.names == frozenset()
@@ -293,3 +293,48 @@ def test_live_names_requires_a_list(audit):
     assert audit.live_names([{"name": "a"}, {"name": "b"}]) == frozenset({"a", "b"})
     with pytest.raises(TypeError, match="Expected a list"):
         audit.live_names({"msg": "Record not found"})
+
+
+# --- Coverage of the collection list itself ---------------------------------
+
+
+def test_every_name_bearing_collection_in_use_is_audited(audit):
+    """An unaudited collection reports nothing, which reads as clean.
+
+    The first draft audited seven collections and silently ignored ~100 live
+    objects across these four. Coverage is the detector's blind spot, so the
+    set is pinned rather than left to drift as collections are adopted.
+    """
+    assert set(audit.AUDITED_COLLECTIONS) == {
+        "snippets",
+        "conditions",
+        "headers",
+        "backends",
+        "domains",
+        "requestSettings",
+        "dictionaries",
+        "cacheSettings",
+        "gzips",
+        "responseObjects",
+        "loggingHttps",
+    }
+
+
+def test_endpoint_paths_are_the_fastly_spellings(audit):
+    """State keys and API path segments differ; a wrong one 404s at runtime."""
+    assert audit.AUDITED_COLLECTIONS["requestSettings"] == "request_settings"
+    assert audit.AUDITED_COLLECTIONS["responseObjects"] == "response_object"
+    assert audit.AUDITED_COLLECTIONS["cacheSettings"] == "cache_settings"
+    assert audit.AUDITED_COLLECTIONS["gzips"] == "gzip"
+    assert audit.AUDITED_COLLECTIONS["loggingHttps"] == "logging/https"
+
+
+def test_drift_and_error_exit_codes_are_distinct(audit):
+    """Concourse calls every nonzero exit `failed` and fires one hook.
+
+    If a crash exited 1 like real drift does, an S3 or Fastly outage would
+    announce confirmed drift every time.
+    """
+    codes = {audit.EXIT_CLEAN, audit.EXIT_DRIFT, audit.EXIT_USAGE, audit.EXIT_ERROR}
+    assert len(codes) == 4
+    assert audit.EXIT_CLEAN == 0

--- a/tests/scripts/test_fastly_drift_audit.py
+++ b/tests/scripts/test_fastly_drift_audit.py
@@ -1,0 +1,295 @@
+"""Tests for bin/fastly-drift-audit.
+
+The three trap cases below each produced a permanently firing false alarm in a
+prototype of this audit. A nightly check that is not silent when the estate is
+healthy gets muted within a week, so each trap is pinned here.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "bin" / "fastly-drift-audit"
+
+# The value half of Pulumi's fixed sentinel pair for a secret-wrapped output.
+SENTINEL_VALUE = "1b47061264138c4ac30d75fd1eb44270"  # pragma: allowlist secret
+
+
+def load_audit_module():
+    """Load the audit CLI from bin/.
+
+    An explicit ``SourceFileLoader`` is required: the script has no ``.py``
+    suffix, so import machinery cannot infer a loader for it.
+    """
+    name = "test_fastly_drift_audit_script"
+    spec = importlib.util.spec_from_file_location(
+        name,
+        SCRIPT_PATH,
+        loader=importlib.machinery.SourceFileLoader(name, str(SCRIPT_PATH)),
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def audit():
+    """Return the loaded audit module."""
+    return load_audit_module()
+
+
+def service(audit, **collections):
+    """Build a DeclaredService whose collections are plain name sets."""
+    return audit.DeclaredService(
+        project="ol-application-mitxonline",
+        stack="Production",
+        service_id="54YRiE18QJhCPQRlVmFHFm",
+        state_active_version=207,
+        collections={
+            key: collections.get(key, audit.DeclaredCollection(frozenset()))
+            for key in audit.AUDITED_COLLECTIONS
+        },
+    )
+
+
+def kinds(findings):
+    """Reduce findings to the tuples the assertions care about."""
+    return {(f.level, f.kind, f.collection) for f in findings}
+
+
+# --- The set-diff direction -------------------------------------------------
+
+
+def test_declared_but_absent_is_the_alert(audit):
+    """hq#12449 exactly: state claims a snippet Fastly does not have."""
+    snippet = "Redirect course and program pages to MIT Learn"
+    findings = audit.compare(
+        service(audit, snippets=audit.DeclaredCollection(frozenset({snippet}))),
+        207,
+        dict.fromkeys(audit.AUDITED_COLLECTIONS, frozenset())
+        | {"snippets": frozenset()},
+    )
+    assert kinds(findings) == {(audit.ALERT, "declared-but-absent", "snippets")}
+    assert findings[0].names == (snippet,)
+
+
+def test_live_but_undeclared_does_not_alert(audit):
+    """An object added by hand in the Fastly UI is reported, not failed.
+
+    Failing on this direction too would make every manual UI edit page
+    somebody overnight, which is how a check gets muted.
+    """
+    findings = audit.compare(
+        service(audit),
+        207,
+        dict.fromkeys(audit.AUDITED_COLLECTIONS, frozenset())
+        | {"snippets": frozenset({"added in the UI"})},
+    )
+    assert kinds(findings) == {(audit.INFO, "live-but-undeclared", "snippets")}
+
+
+def test_matching_names_are_silent(audit):
+    """The healthy case emits nothing at all."""
+    names = frozenset({"one", "two"})
+    assert (
+        audit.compare(
+            service(audit, snippets=audit.DeclaredCollection(names)),
+            207,
+            dict.fromkeys(audit.AUDITED_COLLECTIONS, frozenset()) | {"snippets": names},
+        )
+        == ()
+    )
+
+
+def test_version_mismatch_is_informational_only(audit):
+    """State and live disagreeing on the active version is not the failure.
+
+    In hq#12449 both sides said 207; it was the names that differed. A
+    mismatch alone is an ordinary consequence of a manual UI edit.
+    """
+    findings = audit.compare(
+        service(audit), 209, dict.fromkeys(audit.AUDITED_COLLECTIONS, frozenset())
+    )
+    assert kinds(findings) == {(audit.INFO, "active-version-mismatch", "")}
+
+
+def test_no_active_version_skips_rather_than_alerting(audit):
+    """A service with nothing serving traffic has nothing to compare against."""
+    findings = audit.compare(service(audit), None, {})
+    assert kinds(findings) == {(audit.SKIP, "no-active-version", "")}
+
+
+# --- Trap 1: secret-wrapped collections -------------------------------------
+
+
+def test_secret_wrapped_collection_is_unauditable_not_empty(audit):
+    """`backends` is often stored secret-wrapped rather than as a list.
+
+    Iterating the sigil dict yields zero names, so every live backend would
+    read as `live-but-undeclared` on every service, forever.
+    """
+    collection = audit.read_collection(
+        {audit.SECRET_SIGIL: SENTINEL_VALUE, "ciphertext": "v1:..."}
+    )
+    assert collection.auditable is False
+    assert collection.names == frozenset()
+
+    findings = audit.compare(
+        service(audit, backends=collection),
+        207,
+        dict.fromkeys(audit.AUDITED_COLLECTIONS, frozenset()),
+    )
+    assert kinds(findings) == {(audit.INFO, "unauditable", "backends")}
+
+
+def test_unauditable_and_empty_are_distinguishable(audit):
+    """An absent collection is genuinely empty; an unreadable one is not.
+
+    Collapsing the two would make "we could not check this" indistinguishable
+    from "there is nothing to check".
+    """
+    assert audit.read_collection(None) == audit.DeclaredCollection(frozenset())
+    assert audit.read_collection([]).auditable is True
+    assert audit.read_collection("unexpected").auditable is False
+
+
+# --- Trap 3: non-dict collection members ------------------------------------
+
+
+def test_plain_string_members_are_unauditable(audit):
+    """`TlsSubscription` also has a `domains` output, of plain strings.
+
+    Type filtering keeps those resources out, but a collection whose members
+    carry no name must not silently shrink the declared set -- that errs
+    toward reporting clean, the wrong direction for a detector.
+    """
+    collection = audit.read_collection(["courses.mitxonline.mit.edu"])
+    assert collection.auditable is False
+    assert collection.names == frozenset()
+
+    mixed = audit.read_collection([{"name": "real"}, {"no_name": True}])
+    assert mixed.auditable is False
+
+
+def test_well_formed_collection_yields_its_names(audit):
+    """The ordinary case: a list of dicts reduces to its names."""
+    assert audit.read_collection(
+        [{"name": "a", "content": "..."}, {"name": "b", "content": "..."}]
+    ) == audit.DeclaredCollection(frozenset({"a", "b"}))
+
+
+# --- Trap 2: scope, and checkpoint parsing ----------------------------------
+
+
+def test_scope_comes_from_declared_projects(audit, tmp_path):
+    """Scope is parsed from src/**/Pulumi.yaml, never from an S3 listing.
+
+    The bucket retains checkpoints for deleted projects that point at the same
+    live service IDs as the current stacks, hundreds of versions stale.
+    """
+    (tmp_path / "src" / "applications" / "mitxonline").mkdir(parents=True)
+    (tmp_path / "src" / "applications" / "mitxonline" / "Pulumi.yaml").write_text(
+        "name: ol-application-mitxonline\nruntime: python\n"
+    )
+    (tmp_path / "src" / "nameless").mkdir(parents=True)
+    (tmp_path / "src" / "nameless" / "Pulumi.yaml").write_text("runtime: python\n")
+
+    assert audit.declared_projects(tmp_path) == {"ol-application-mitxonline"}
+
+
+def test_empty_scope_raises_rather_than_reporting_clean(audit, tmp_path):
+    """Auditing nothing must not look like a healthy estate."""
+    (tmp_path / "src").mkdir()
+    with pytest.raises(RuntimeError, match="No Pulumi projects"):
+        audit.declared_projects(tmp_path)
+
+
+def test_declared_services_reads_service_vcl_resources(audit):
+    """Only ServiceVcl resources are picked out of a stack checkpoint."""
+    checkpoint = {
+        "checkpoint": {
+            "latest": {
+                "resources": [
+                    {
+                        "type": "pulumi:pulumi:Stack",
+                        "outputs": {"id": "not-a-service"},
+                    },
+                    {
+                        "type": audit.SERVICE_VCL_TYPE,
+                        "outputs": {
+                            "id": "54YRiE18QJhCPQRlVmFHFm",
+                            "activeVersion": 208,
+                            "snippets": [{"name": "redirect"}],
+                        },
+                    },
+                ]
+            }
+        }
+    }
+    (found,) = audit.declared_services("proj", "Production", checkpoint)
+    assert found.service_id == "54YRiE18QJhCPQRlVmFHFm"
+    assert found.state_active_version == 208
+    assert found.collections["snippets"].names == frozenset({"redirect"})
+    # Collections the service does not declare are empty, not unauditable.
+    assert found.collections["dictionaries"] == audit.DeclaredCollection(frozenset())
+
+
+def test_resources_pending_deletion_are_not_the_authority(audit):
+    """A `delete: true` resource is not what should be live."""
+    checkpoint = {
+        "checkpoint": {
+            "latest": {
+                "resources": [
+                    {
+                        "type": audit.SERVICE_VCL_TYPE,
+                        "delete": True,
+                        "outputs": {"id": "doomed"},
+                    }
+                ]
+            }
+        }
+    }
+    assert audit.declared_services("proj", "Production", checkpoint) == []
+
+
+def test_empty_checkpoint_is_not_an_error(audit):
+    """A stack with no deployment yet has no services, and that is fine."""
+    assert audit.declared_services("proj", "Production", {}) == []
+    assert audit.declared_services("proj", "Production", {"checkpoint": {}}) == []
+
+
+# --- Live-side parsing ------------------------------------------------------
+
+
+def test_serving_version_picks_the_active_one(audit):
+    """The comparison target is the serving version, not the highest one."""
+    details = {
+        "versions": [
+            {"number": 207, "active": False},
+            {"number": 208, "active": True},
+            {"number": 209, "active": False},
+        ]
+    }
+    assert audit.serving_version(details) == 208
+
+
+def test_serving_version_is_none_when_nothing_is_active(audit):
+    """A service with no active version reports None rather than guessing."""
+    assert audit.serving_version({"versions": [{"number": 1, "active": False}]}) is None
+    assert audit.serving_version({}) is None
+
+
+def test_live_names_requires_a_list(audit):
+    """A Fastly error body must fail loudly, not read as an empty collection."""
+    assert audit.live_names([{"name": "a"}, {"name": "b"}]) == frozenset({"a", "b"})
+    with pytest.raises(TypeError, match="Expected a list"):
+        audit.live_names({"msg": "Record not found"})


### PR DESCRIPTION
### What are the relevant tickets?

Preventive follow-up to https://github.com/mitodl/hq/issues/12449. Companion to #5627, which closes the ingress for the same failure; this closes the detection gap.

### Description (What does it do?)

hq#12449 ran for days with zero signal, and the reason it could is structural: nothing compares Pulumi's Fastly state to Fastly. Every Fastly-bearing stack runs `refresh_stack=False`, set *because* the stack has Fastly resources — so coverage was 0% exactly where the risk is 100%.

- **`bin/fastly-drift-audit audit`** — reads each stack checkpoint straight out of `s3://mitol-pulumi-state` with boto3, pulls the child-object names every `ServiceVcl` records across all 11 name-keyed collections, resolves the version Fastly reports as *serving*, and diffs the name sets. Only `declared-but-absent` fails the run; `live-but-undeclared` and an `activeVersion` mismatch are ordinary consequences of a manual UI edit and are reported instead.
- **`bin/fastly-drift-audit replay <project> <stack> <version>`** — pins one stack against one explicit version. Fastly versions are immutable, so this both regression-tests the original incident and verifies a repair landed.
- **Nightly `fastly-drift` pipeline** on the Production `infra` pool, shaped like `iam_drift` but opening **no pull request** — there is no code change to propose, since the declared config is already correct and it's state and the live service that disagree. A failure notifies Slack with a link to the [state-drift repair runbook](https://engineering.ol.mit.edu/platform_services/cloud_infrastructure/fastly_pulumi_state_drift/). Drift exits 1 and an audit that could not complete exits 3, so an upstream outage cannot announce confirmed drift.
- **ADR 0011** records the decision and, more usefully, why the obvious alternative doesn't work: a nightly `preview --refresh` on `ol-application-mit-learn/CI` reports 38 resources with diffs, 37 of them routine Kubernetes churn. Filtering to Fastly leaves a 189-line diff that is entirely secret-flip noise — with `snippets` absent from it *precisely because they matched*. The noise is unconditional and the target signal is invisible inside it.

No new IAM and no new credentials. Verified against `Pulumi.Production.yaml`: the `infra` pool already attaches `pulumi_state` (`s3:GetObject*`/`s3:ListBucket*` on the bucket) and `infra` (`kms:Decrypt` for the SOPS read). Read-only by construction — S3 GETs plus Fastly GETs with `global_read_api_key`, never `admin_api_key`.

Three traps each caused a permanently firing false alarm in an earlier prototype, and each is pinned by a test:

| Trap | Handling |
|---|---|
| `backends` is frequently stored secret-wrapped behind Pulumi's `4dabf…` sigil, so iterating it yields zero names | Marked **unauditable**, a state distinct from empty |
| Dead projects (`ol-infrastructure-fastly`, `ol-infrastructure-mitxonline-application`) retain checkpoints pointing at the *same live service IDs* hundreds of versions stale | Scope comes from `src/**/Pulumi.yaml`, never an S3 listing |
| `TlsSubscription` also has a `domains` output, of plain strings | Type-filtered, and any collection whose members lack a string name is marked unauditable rather than silently shrinking the declared set |

### How can this be tested?

Both controls below were run against the live estate on this branch. Read-only; safe to repeat.

**Negative control** — the check must be silent on a healthy estate, or it gets muted within a week:

```
$ PYTHONPATH=src python bin/fastly-drift-audit audit
36 service(s) audited, 0 alert(s), 10 informational.  # exit 0, ~2.5m
```

The 10 informational lines are 5 secret-wrapped `backends`, 4 secret-wrapped `loggingHttps`, and one benign `activeVersion` mismatch (state 14, live 16, all names matching) on `ol-application-edxapp/xpro.Production`.

**Positive control** — replaying the actual incident against the pre-repair version:

```
$ PYTHONPATH=src python bin/fastly-drift-audit replay ol-application-mitxonline Production 207
  ol-application-mitxonline/Production 54YRiE18QJhCPQRlVmFHFm
    info  active-version-mismatch: state 208, live 207
    ALERT snippets declared-but-absent: Redirect course and program pages to MIT Learn
1 service(s) audited, 1 alert(s), 1 informational.    # exit 1

$ PYTHONPATH=src python bin/fastly-drift-audit replay ol-application-mitxonline Production 208
1 service(s) audited, 0 alert(s), 0 informational.    # exit 0
```

Offline: `uv run pytest tests/scripts/test_fastly_drift_audit.py` — 17 tests, no network. Full suite 920 passed; `ruff` and `mypy` clean on the new files.

Pipeline generation: `PYTHONPATH=src python src/ol_concourse/pipelines/infrastructure/fastly_drift/pipeline.py`, and the meta pipeline emits the `create-fastly-drift` job.

### Additional Context

- **Deliberate deviation from the ADR's trap 3.** The ADR says to skip non-dict collection members. Skipping avoids the crash but is wrong for a detector: silently dropping members shrinks the *declared* set, which shrinks `declared - live`, so a reader bug reports clean. The collection is marked unauditable instead. Same reasoning makes `declared_projects()` raise rather than return an empty scope — auditing zero projects would exit 0.
- `((eks.slack_url))` resolves for this pipeline: `k8s_apps` is also set with `fly -t pr-inf`, the same Concourse team as the infrastructure meta pipeline.
- **Out of scope:** snippet *bodies* (names only), and `backends`/`loggingHttps` while they remain secret in state. Detection latency is up to 24h. None of this removes the need to fix Fastly token rotation and re-enable `refresh_stack` — it makes that work non-urgent rather than unnecessary.
- ADR 0011 is included here as its own commit. It was written earlier alongside #5627 and lost to a rebase before it ever reached a remote.



---

### Review round 2

Copilot caught two things that were the detector's own failure mode leaking back in, plus three ADR inaccuracies. All addressed in `1534243b6`:

- **Coverage.** The audit read 7 collections and silently ignored 4 the estate uses: `responseObjects` (27 live objects), `cacheSettings` (26), `loggingHttps` (26 readable + 4 secret), `gzips` (21). An unaudited collection produces no findings, which is indistinguishable from a clean one. Now audits all 11, with the set pinned by a test. The spec's premise that `loggingHttps` is unauditable was also wrong — 26 of 30 are plain lists.
- **Crash vs. drift.** Concourse calls every nonzero exit `failed` and fires one hook, so an S3/SOPS/Fastly failure exited 1 exactly like real drift and would have paged someone claiming the hq#12449 failure mode on the first upstream outage. Drift now exits 1, an incomplete audit exits 3, and the alert text asserts neither.
- ADR: added `backend` to the endpoint inventory, fixed five-vs-six, and replaced the trap-3 note with the shipped mark-unauditable behavior.

Re-verified live on the widened set: negative control still 0 alerts (the ~100 newly audited objects all matched, so coverage grew at no cost in noise), positive control unchanged, and a nonexistent stack now exits 3.

### One correction to the ADR's premise

While answering a question about the `refresh_stack` follow-up, the reason it was disabled turned out to be wrong — in the ADR and in the pipeline docstrings. `b5b80e85d` corrects it.

`refresh_stack=False` came from a single commit ([#5134](https://github.com/mitodl/ol-infrastructure/commit/388ef2998), 2026-07-27) written while the Fastly admin token was mid-rotation. That rotation completed the same day; the replacement token reports no expiry and authenticates today, and `fastly.yaml` has otherwise only been rotated in 2022 and 2024. `ocw_site` is already back to `True`. So these are stale leftovers, not a property of having Fastly resources — and no credential work is needed to revert them.

No behavior change: the flags stay set. What actually blocks reverting is untested, not credential-related — refresh writes state before `up`, and a Fastly refresh drops and re-adds `backends` as secret-flip noise. The comments now say so, name the cost of leaving them (refresh is off for the *whole* stack — ~770 non-Fastly Production resources, including ~180 `aws:*` and ~60 `vault:*`), and give the revert procedure.
