### PR TITLE
Add Learn AI syllabus endpoint vars for OCW

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
@@ -21,6 +21,7 @@ config:
     GITHUB_WEBHOOK_BRANCH: 'release'
     GTM_ACCOUNT_ID: GTM-MQCSLSQ
     HUGO_CSRF_COOKIE_NAME: learn_csrftoken
+    LEARN_AI_SYLLABUS_ENDPOINT: https://api.learn.mit.edu/ai/http/syllabus_agent/
     MAILGUN_FROM_EMAIL: 'MIT OCW <no-reply@ocw.mail.odl.mit.edu'
     MAILGUN_SENDER_DOMAIN: 'ocw.mail.odl.mit.edu'
     MAILGUN_URL: https://api.mailgun.net/v3/ocw.mail.odl.mit.edu

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
@@ -23,6 +23,7 @@ config:
     GITHUB_WEBHOOK_BRANCH: 'release-candidate'
     GTM_ACCOUNT_ID: GTM-57BZ8PN
     HUGO_CSRF_COOKIE_NAME: learn_rc_csrftoken
+    LEARN_AI_SYLLABUS_ENDPOINT: https://api.rc.learn.mit.edu/ai/http/syllabus_agent/
     MAILGUN_FROM_EMAIL: 'MIT OCW <no-reply@ocw-rc.mail.odl.mit.edu'
     MAILGUN_SENDER_DOMAIN: 'ocw-rc.mail.odl.mit.edu'
     MAILGUN_URL: https://api.mailgun.net/v3/ocw-rc.mail.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/12848.

### Description (What does it do?)
This PR adds the `LEARN_AI_SYLLABUS_ENDPOINT` variable to both QA and production for OCW Studio.

### How can this be tested?
This can be tested end-to-end once the corresponding OCW Studio PR that passes this into the theme pipeline is deployed. For just this PR, verify that the relevant URLs for the Learn AI syllabus endpoint look correct.