### PR TITLE
fix(open-metadata): set Bedrock embed vars so semantic search initializes

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -722,7 +722,7 @@ open_metadata_application = kubernetes.helm.v3.Release(
             # https://github.com/open-metadata/OpenMetadata/issues/29576
             # Bedrock auth uses the pod's IRSA role (open_metadata_bedrock_iam_policy
             # below) via the AWS default credential provider chain - no API key
-            # needed, just AWS_DEFAULT_REGION.
+            # needed, just the region and the IAM-auth flag below.
             # LOG_FORMAT=json (1.13) enables JSON-structured Dropwizard server logs.
             "extraEnvs": [
                 {
@@ -733,11 +733,43 @@ open_metadata_application = kubernetes.helm.v3.Release(
                     "name": "EMBEDDING_PROVIDER",
                     "value": "bedrock",
                 },
-                # Bedrock's region (parsed by OM from AWS_DEFAULT_REGION per
-                # conf/openmetadata.yaml) and the AWS SDK v2 region-provider
-                # chain (which the IRSA credentials exchange uses internally,
-                # and only recognizes AWS_REGION) read two different env vars -
-                # set both rather than assume one covers the other.
+                # BedrockEmbeddingClient rejects an empty embeddingModelId in its
+                # constructor, and 1.13.x defaults AWS_BEDROCK_EMBED_MODEL_ID to "".
+                # Without this the vector search service never initializes: OM logs a
+                # single ERROR ("Bedrock embedding model ID is required") per pod start
+                # and per reindex, then serves lexical-only results with no further
+                # complaint. Confirmed dead in production from 2026-07-30 through
+                # 2026-08-23 (15 ERRORs, zero successful inits, and no Bedrock
+                # InvokeModel activity in CloudWatch) despite the two settings above.
+                # The dataAssetEmbeddings index alias is created either way, so it is
+                # not evidence that embeddings work.
+                {
+                    "name": "AWS_BEDROCK_EMBED_MODEL_ID",
+                    "value": "amazon.titan-embed-text-v2:0",
+                },
+                # titan-embed-text-v2 supports 1024/512/256. 512 matches the default
+                # OM 2.0 will apply, so the index mapping does not have to change
+                # again at upgrade time.
+                {
+                    "name": "AWS_BEDROCK_EMBEDDING_DIMENSION",
+                    "value": "512",
+                },
+                # Selects the IRSA credential chain over the static access-key fields,
+                # which are empty. 1.13.x defaults this to false; 2.0 defaults it to
+                # true, so it is redundant after the upgrade but harmless.
+                {
+                    "name": "BEDROCK_AWS_IAM_AUTH_ENABLED",
+                    "value": "true",
+                },
+                # Three region vars for three consumers. 1.13.x reads the Bedrock
+                # block's region from AWS_BEDROCK_REGION; 2.0 moved that to
+                # AWS_DEFAULT_REGION (drop AWS_BEDROCK_REGION with the 2.0 bump); and
+                # the AWS SDK v2 region-provider chain used by the IRSA credentials
+                # exchange only recognizes AWS_REGION.
+                {
+                    "name": "AWS_BEDROCK_REGION",
+                    "value": "us-east-1",
+                },
                 {
                     "name": "AWS_DEFAULT_REGION",
                     "value": "us-east-1",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Semantic search has never produced embeddings. `BedrockEmbeddingClient` rejects an empty `embeddingModelId` in its constructor, and 1.13.x defaults `AWS_BEDROCK_EMBED_MODEL_ID` to `""`. The vector search service fails to initialize, OM logs one ERROR, then serves lexical-only results with no further complaint.

Production, `{namespace="open-metadata", container="openmetadata"} |~ "(?i)vector search service"` over 30 days (the retention limit): 15 matches, every one an ERROR, spanning 2026-07-30 20:54 UTC to 2026-08-23 00:30 UTC. Both call paths appear, `OpenMetadataApplication.run` on pod start and `SearchIndexApp.execute` on the scheduled reindex. Corroborated by the absence of any Bedrock embedding traffic: `aws cloudwatch list-metrics --namespace AWS/Bedrock` in us-east-1 returns 41 metrics across 6 `ModelId` dimensions, none of them a titan or embed model.

```
ERROR org.openmetadata.service.search.SearchRepository
"Failed to initialize vector search service: Bedrock embedding model ID is required"
java.lang.IllegalArgumentException: Bedrock embedding model ID is required
  at BedrockEmbeddingClient.<init>(BedrockEmbeddingClient.java:59)
  at SearchRepository.createEmbeddingClient(SearchRepository.java:3363)
  at SearchRepository.initializeVectorSearchService(SearchRepository.java:454)
```

Adds four `extraEnvs` entries:

- `AWS_BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v2:0` is the fix.
- `AWS_BEDROCK_EMBEDDING_DIMENSION=512`. titan-embed-text-v2 has configurable output dimensions, and 512 is what OM 2.0 defaults to, so the index mapping does not have to change twice.
- `BEDROCK_AWS_IAM_AUTH_ENABLED=true` selects the IRSA credential chain over the static access-key fields, which are empty. 1.13.x defaults false, 2.0 defaults true.
- `AWS_BEDROCK_REGION=us-east-1`. 1.13.x reads the Bedrock block's region from this var; 2.0 moved it to `AWS_DEFAULT_REGION`. Delete this line with the version bump.

Only the first was diagnosed from logs. The other three come from reading [1.13.3's `conf/openmetadata.yaml`](https://github.com/open-metadata/OpenMetadata/blob/1.13.3-release/conf/openmetadata.yaml): the model-id exception fires before any credential or region handling, so it masks whatever fails next.

### How can this be tested?
Not deployed yet. Nothing here has been verified against a running cluster.

Run locally on this branch:

- `pre-commit` clean (ruff format, ruff check, mypy).
- `pulumi preview -s QA` on `src/ol_infrastructure/applications/open_metadata`: `~ 2 to update, 71 unchanged`. One of those two is this change, the Helm release `extraEnvs`; the other is pre-existing drift described under Additional Context.

After `pulumi up`, to validate:

1. `kubectl -n open-metadata rollout restart deploy/openmetadata`, then confirm the ERROR is gone. Loki: `{namespace="open-metadata", container="openmetadata"} |~ "(?i)vector search service"` should return nothing after the restart timestamp.
2. Run the Search Indexing application with "Recreate Indexes" enabled.
3. `aws cloudwatch list-metrics --namespace AWS/Bedrock` should now list a titan-embed `ModelId` dimension. It lists none today, across 41 metrics and 6 ModelIds.

Do not treat the `dataAssetEmbeddings` index alias as evidence. It is currently attached to the search indices (table, glossary_term, dashboard, pipeline, container and others, per the 2026-08-23 rebuild) even though no embeddings exist, which is part of why this went unnoticed.

### Additional Context
The QA preview also shows an unrelated HTTPRoute diff, `spec.rules[0].matches: <null>` removed on `open-metadata-https`. Re-running the preview with this change stashed gives `~ 1 to update` with that same diff, so it is pre-existing drift that will be applied along with this deploy.

No IAM change needed. `amazon.titan-embed-text-v2:0` is ACTIVE in `aws bedrock list-foundation-models --by-output-modality EMBEDDING` for us-east-1, and [the existing Bedrock policy](https://github.com/mitodl/ol-infrastructure/blob/eb4b9e18f42a6b48c035437d781ab3d67a28afb7/src/ol_infrastructure/applications/open_metadata/__main__.py#L550-L559) already allows `bedrock:InvokeModel` on `arn:aws:bedrock:*::foundation-model/amazon.titan-embed-*`, which covers this model.

This lands ahead of the OpenMetadata 2.0 upgrade so there is a working semantic-search baseline to compare against. 2.0 moves embedding config into a new top-level `llmConfiguration` block whose `enabled` defaults to false, while `EMBEDDING_PROVIDER` and `SEMANTIC_SEARCH_ENABLED` keep their names. That upgrade needs `LLM_ENABLED` and `LLM_PROVIDER` added separately, tracked with the rest of the 2.0 work.
