### PR TITLE
fix(edxapp): pin Meilisearch indexing memory on mitxonline production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
+++ b/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
@@ -11,9 +11,39 @@
   meilisearch:cpu_request: "250m"
   meilisearch:memory_request: "4Gi"
   meilisearch:memory_limit: "4Gi"
+  meilisearch:max_indexing_memory: "2Gi" # optional, see Sizing below
 ```
 
 The difference between `deploy` and `enabled`. Deploy means "deploy the helm chart" whereas enabled means "enable meilisearch integration in the Open edX platform". You can deploy the chart but not enable it in Open edX if you want to test things out first.
+
+## Sizing
+
+`max_indexing_memory` sets `MEILI_MAX_INDEXING_MEMORY`, the ceiling on the buffer
+Meilisearch fills before flushing a batch to disk. Left unset it defaults to two
+thirds of the machine's total memory, which it measures with the `sysinfo` crate
+— that reads the host's `/proc/meminfo`, not the cgroup. In a container on a
+64GiB node it therefore budgets ~40GiB no matter what `memory_limit` says, never
+flushes early, and leaves the kernel to reclaim inside the cgroup instead. Set it
+to a fraction of `memory_limit` so the two agree, leaving the remainder for the
+process and for page cache over the memory-mapped index. The key is only emitted
+when configured, so stacks that omit it are unchanged.
+
+Note this caps the indexing buffer, not total process memory: Meilisearch also
+memory-maps its index, and those pages count against the cgroup. Sizing the rest
+is a separate question from this knob — check `usedIndexSize`, not `indexSize`,
+before reasoning about how much of an index is real data:
+
+```bash
+kubectl exec -n <namespace> meilisearch-0 -c meilisearch -- \
+  sh -c 'curl -s -H "Authorization: Bearer $MEILI_MASTER_KEY" localhost:7700/stats'
+```
+
+`indexSize` is space *allocated* to the index's LMDB file, including free pages;
+`usedIndexSize` is what is actually occupied. LMDB never returns freed pages to
+the OS, so rewriting documents in place inflates `indexSize` permanently. Only a
+rebuild through the temp-index-and-swap path (a non-incremental
+`./manage.py cms reindex_studio`) reclaims it — `--incremental` writes in place
+and does not.
 
 ## SOPS secrets
 

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -184,6 +184,7 @@ config:
   meilisearch:cpu_request: "250m"
   meilisearch:memory_request: "1Gi"
   meilisearch:memory_limit: "4Gi"
+  meilisearch:max_indexing_memory: "2Gi"
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -152,6 +152,18 @@ def create_meilisearch_resources(
         },
     }
 
+    # Meilisearch sizes its indexing buffer at two thirds of the machine's total
+    # memory, measured with the sysinfo crate, which reads the host's
+    # /proc/meminfo and not the cgroup limit. On the m8i-flex.4xlarge core nodes
+    # that means it budgets ~40Gi inside whatever memory_limit we set, so it
+    # never flushes early and leaves the cgroup to reclaim instead. Pin it so
+    # the budget and the limit agree. Only emitted when configured, so the
+    # stacks that have not been sized for it render unchanged.
+    if max_indexing_memory := meilisearch_config.get("max_indexing_memory"):
+        meilisearch_values["environment"]["MEILI_MAX_INDEXING_MEMORY"] = (
+            max_indexing_memory
+        )
+
     return kubernetes.helm.v3.Release(
         f"ol-{stack_info.env_prefix}-edxapp-meilisearch-helm-release-{stack_info.env_suffix}",
         kubernetes.helm.v3.ReleaseArgs(


### PR DESCRIPTION
### What are the relevant tickets?
Refs https://github.com/mitodl/hq/issues/13014
Overlaps https://github.com/mitodl/ol-infrastructure/pull/5611 — see Additional Context.

### Description (What does it do?)
- Adds an optional `meilisearch:max_indexing_memory` config key, emitted as `MEILI_MAX_INDEXING_MEMORY` only when set, so the other eleven edxapp stacks render unchanged.
- Sets it to `2Gi` for mitxonline production.
- Documents the knob, and how to read `/stats` correctly, in `MEILISEARCH.md`.

Meilisearch sizes its indexing buffer at two thirds of the machine's total memory, which [its docs](https://www.meilisearch.com/docs/resources/self_hosting/performance/ram_multithreading) say it measures with the `sysinfo` crate. That measurement does not account for the container's cgroup limit — see meilisearch/meilisearch#6112, #4393 and #3725 — so on the `m8i-flex.4xlarge` core nodes it budgets roughly 40Gi inside a 4Gi container limit, never flushes a batch early, and leaves the kernel to reclaim instead.

`container_memory_usage_bytes` for `mitxonline-openedx/meilisearch-0` has sat at exactly the limit (`max_over_time(...[7d])` = 4,294,676,480 B) with zero container restarts in 30 days — page cache filling to the limit and being reclaimed, not an OOM.

Resource requests and limits are deliberately **not** changed here. The `meilisearch` PV has a required nodeAffinity of `topology.kubernetes.io/zone In [us-east-1a]`, and the only `ol.mit.edu/core_node=true` node in that zone (`ip-10-13-131-31.ec2.internal`) has 346,069,159 B (330 MiB) of unreserved memory request against 61,414,572,032 B allocatable. Releasing Meilisearch's own 1Gi on pod deletion leaves ~1.32 GiB, so any request above that would leave `meilisearch-0` Pending.

### How can this be tested?
`pre-commit run --files` on the three changed paths: all hooks pass, including ruff and mypy.

`pulumi preview --stack mitxonline.Production` (with `EDXAPP_DOCKER_IMAGE_DIGEST` set to the currently-deployed digest) shows one resource change attributable to this branch:

```
~  kubernetes:helm.sh/v3:Release ol-mitxonline-edxapp-meilisearch-helm-release-production update [diff: ~values]
       + MEILI_MAX_INDEXING_MEMORY: "2Gi"
```

The same preview run against a stashed working tree shows the other diffs in that stack (two `EBSIOBalance` CloudWatch alarms to create, one `cms-edxapp-application-production-deployment` spec update) are pre-existing drift on `main`, not from this branch.

Not applied to any environment yet. To validate after apply, confirm the env var is live in the running process and that the pod came back Ready:

```bash
kubectl exec -n mitxonline-openedx meilisearch-0 -c meilisearch -- env | grep MEILI_MAX_INDEXING_MEMORY
```

### Additional Context
**Applying this rolls the StatefulSet pod, so expect a brief Studio search outage.** No data is touched and there is no database migration; the image tag is unchanged.

The setting was ignored entirely until meilisearch/meilisearch#6212 (merged 2026-03-10, fixing meilisearch/meilisearch#6112, a bumpalo leak present since v1.12). We run v1.53.1, well past that.

This is the safe half of #5611. That PR also raises the memory request 1Gi → 8Gi and CPU 250m → 2, which cannot schedule for the reason described above, and derives its 24Gi limit from `indexSize` (11.91 GiB, the space *allocated* to the LMDB file including free pages) rather than `usedIndexSize` (9.30 GiB, what is actually occupied).

Sizing the pod is better decided after the index stops carrying course content. `/stats` currently reports 1,319,937 documents in `studio_content`; only 966 of them carry the `created` field, which in `openedx/core/djangoapps/content/search/documents.py` is set exclusively by the three library document builders (`searchable_doc_for_library_block`, `searchable_doc_for_collection`, `searchable_doc_for_container`) — course blocks go through `_fields_from_block` and set only `modified`. So the index is ~99.9% course XBlocks, which is being addressed separately.

#5611 needs a decision from its author on whether to reduce it to the remaining parts or close it in favour of that work.
