### PR TITLE
fix(edxapp): source Granian concurrency per install from stack config

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -2,8 +2,9 @@
 
 **Status:** stage 0 merged 2026-07-23 (#5083); stage 1 merged 2026-07-27 (#5135), validated
 in production 2026-08-07; stage 2 merged 2026-08-10 (#5344), validated in production
-2026-08-17; stage 3 `mitxonline` **blocked**, `edxapp` CMS rolled back and **blocked**
-pending retuning (see stage 3), LMS handled separately per install; stage 4 pending
+2026-08-17; stage 3 `mitxonline` **blocked**, `edxapp` LMS and CMS concurrency now
+sourced per install from stack config (see stage 3) -- `mitx`/`mitx-staging` tuned,
+`mitxonline`/`xpro` on holding pins; stage 4 pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -505,12 +506,31 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   handling deliberately rather than discovering mid-incident
   (`tk-xpro-edxapp-is-6-months-stale-still-on-the-hand--43a5a4`).
 
-  **Current decision:** `edxapp` CMS must remain on its restored holding pins. The
-  production outcome above invalidates the earlier claim that CMS was a safe first
-  rollout despite having observable APISIX latency. Another attempt requires per-install
-  concurrency sizing that accounts for burst shape and backpressure, plus a scaling or
-  alerting signal that detects connection saturation; CPU and request rate alone did not.
-  LMS remains a separate per-install decision and does not make CMS unblocked.
+  **Current decision:** `edxapp` concurrency is per install, for CMS as well as LMS.
+  `k8s_resources.py` is shared by four installs, so a value written there is a value
+  written for all four at once -- which is how a default sized for a 0.25 rps authoring
+  instance reached `mitxonline` Studio. Both webapps now read
+  `edxapp:k8s_granian.{lms,cms}` from stack config, alongside `k8s_replicas` and
+  `k8s_resources`. The key is required rather than defaulted: an install's concurrency
+  should be readable in its own stack file, and a new install should have to state a
+  value rather than inherit whatever was last written into shared code.
+
+  | install | LMS | CMS |
+  | --- | --- | --- |
+  | `mitx`, `mitx-staging` | 1 × 8, backpressure 16 | 1 × 8, backpressure 16 |
+  | `mitxonline`, `xpro` | 2 × 32, backpressure 64 | 2 × 32, backpressure 64 |
+
+  This preserves every live value as of 2026-08-28 and reverses only the collateral half
+  of the rollback: #5607 restored the holding pins in shared code, which would also have
+  dragged `mitx` and `mitx-staging` CMS back to 2 workers on their next deploy. Both have
+  run 1 worker × 8 threads since 2026-08-24T17:18Z with a peak blocking queue of 5 (`mitx`)
+  and 0 (`mitx-staging`) and zero container restarts over 3 days; `mitx` CMS does touch its
+  backpressure ceiling of 16, for 52 minutes out of 3 days, which is the signal to watch if
+  its authoring traffic grows.
+
+  Raising `mitxonline` off the holding pins still requires concurrency sizing that accounts
+  for burst shape and backpressure, plus a scaling or alerting signal that detects
+  connection saturation; CPU and request rate alone did not.
 - **Stage 4 — async apps.** `mit_learn`, `learn_ai`: `workers=2→1` for `mit_learn` and an
   explicit `backpressure` for both. No `blocking_threads` involvement. Lowest expected
   impact, sequenced last because it shares no evidence with the WSGI stages.

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -84,12 +84,17 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.ci.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.ci.mitx.mit.edu
   edxapp:backend_preview_domain: preview-staging.ci.mitx.mit.edu
-  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
-  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
-  # so no measurement wait is needed here. See
-  # docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -84,12 +84,17 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.mitx.mit.edu
   edxapp:backend_preview_domain: preview-backend-staging.mitx.mit.edu
-  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
-  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
-  # so no measurement wait is needed here. See
-  # docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -85,12 +85,17 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.qa.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.qa.mitx.mit.edu
   edxapp:backend_preview_domain: preview-staging.qa.mitx.mit.edu
-  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
-  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
-  # so no measurement wait is needed here. See
-  # docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -95,12 +95,17 @@ config:
   edxapp:backend_lms_domain: courses-backend.ci.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend.ci.mitx.mit.edu
   edxapp:backend_preview_domain: preview.ci.mitx.mit.edu
-  # Stage 3 canary for the LMS webapp. Omitting this key keeps the pre-overhaul
-  # holding pins (2 workers x 32 blocking threads); mitx opts in first because its
-  # measured p99 concurrency is 0.27 busy threads against this ceiling of 8, where
-  # mitxonline LMS needs 17.7. See docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
@@ -99,12 +99,17 @@ config:
   edxapp:backend_lms_domain: courses-backend.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend.mitx.mit.edu
   edxapp:backend_preview_domain: preview-backend.mitx.mit.edu
-  # Stage 3 canary for the LMS webapp. Omitting this key keeps the pre-overhaul
-  # holding pins (2 workers x 32 blocking threads); mitx opts in first because its
-  # measured p99 concurrency is 0.27 busy threads against this ceiling of 8, where
-  # mitxonline LMS needs 17.7. See docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -96,12 +96,17 @@ config:
   edxapp:backend_lms_domain: courses-backend.qa.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend.qa.mitx.mit.edu
   edxapp:backend_preview_domain: preview.qa.mitx.mit.edu
-  # Stage 3 canary for the LMS webapp. Omitting this key keeps the pre-overhaul
-  # holding pins (2 workers x 32 blocking threads); mitx opts in first because its
-  # measured p99 concurrency is 0.27 busy threads against this ceiling of 8, where
-  # mitxonline LMS needs 17.7. See docs/plans/granian-configuration-overhaul.md.
+  # Granian concurrency for the LMS and CMS webapps, per install: this stack's
+  # measured p99 demand is well under a ceiling of 8 busy blocking threads, where
+  # mitxonline needs 17.7 (LMS) and saturates 16 (CMS).
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
+    cms:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -104,6 +104,23 @@ config:
   edxapp:autoscaling_lms_cpu_threshold: "70"
   edxapp:autoscaling_cms_requests_threshold: "20"
   edxapp:autoscaling_cms_cpu_threshold: "70"
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       lms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -103,6 +103,23 @@ config:
   edxapp:autoscaling_lms_cpu_threshold: "70"
   edxapp:autoscaling_cms_requests_threshold: "20"
   edxapp:autoscaling_cms_cpu_threshold: "70"
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       lms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -103,6 +103,23 @@ config:
   edxapp:autoscaling_lms_cpu_threshold: "70"
   edxapp:autoscaling_cms_requests_threshold: "20"
   edxapp:autoscaling_cms_cpu_threshold: "70"
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       lms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -67,9 +67,12 @@ config:
   edxapp:sender_email_address: support@edxapp-mail-ci.xpro.mit.edu
   edxapp:enable_xqueue: "false"
   # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
-  # values. This install's traffic does not fit a ceiling of 8 busy blocking
-  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
-  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  # values, retained because xpro has no measurement to size them from. Its
+  # edxapp stack still runs the hand-rolled pre-OLApplicationK8s deployments
+  # (xpro-production-edxapp-{cms,lms}-webapp), so it never reaches this code
+  # path in production; the xpro-openedx namespace emits no granian_* series at
+  # all. Size these from xpro's own traffic once the stack deploys.
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
       workers: 2

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -66,6 +66,23 @@ config:
   edxapp:mail_domain: edxapp-mail-ci.xpro.mit.edu
   edxapp:sender_email_address: support@edxapp-mail-ci.xpro.mit.edu
   edxapp:enable_xqueue: "false"
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
@@ -68,6 +68,23 @@ config:
   edxapp:backend_lms_domain: courses-backend.xpro.mit.edu
   edxapp:backend_studio_domain: studio-backend.xpro.mit.edu
   edxapp:backend_preview_domain: preview-backend.xpro.mit.edu
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
@@ -69,9 +69,12 @@ config:
   edxapp:backend_studio_domain: studio-backend.xpro.mit.edu
   edxapp:backend_preview_domain: preview-backend.xpro.mit.edu
   # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
-  # values. This install's traffic does not fit a ceiling of 8 busy blocking
-  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
-  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  # values, retained because xpro has no measurement to size them from. Its
+  # edxapp stack still runs the hand-rolled pre-OLApplicationK8s deployments
+  # (xpro-production-edxapp-{cms,lms}-webapp), so it never reaches this code
+  # path in production; the xpro-openedx namespace emits no granian_* series at
+  # all. Size these from xpro's own traffic once the stack deploys.
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
       workers: 2

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
@@ -70,9 +70,12 @@ config:
   edxapp:backend_studio_domain: studio-backend.rc.xpro.mit.edu
   edxapp:backend_preview_domain: preview-backend.rc.xpro.mit.edu
   # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
-  # values. This install's traffic does not fit a ceiling of 8 busy blocking
-  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
-  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  # values, retained because xpro has no measurement to size them from. Its
+  # edxapp stack still runs the hand-rolled pre-OLApplicationK8s deployments
+  # (xpro-production-edxapp-{cms,lms}-webapp), so it never reaches this code
+  # path in production; the xpro-openedx namespace emits no granian_* series at
+  # all. Size these from xpro's own traffic once the stack deploys.
+  # See docs/plans/granian-configuration-overhaul.md.
   edxapp:k8s_granian:
     lms:
       workers: 2

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
@@ -69,6 +69,23 @@ config:
   edxapp:backend_lms_domain: courses-backend.rc.xpro.mit.edu
   edxapp:backend_studio_domain: studio-backend.rc.xpro.mit.edu
   edxapp:backend_preview_domain: preview-backend.rc.xpro.mit.edu
+  # Granian concurrency for the LMS and CMS webapps, per install: pre-overhaul
+  # values. This install's traffic does not fit a ceiling of 8 busy blocking
+  # threads -- LMS p99 demand is 17.7, and CMS at backpressure 16 saturated in
+  # production on 2026-08-26. See docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
+    cms:
+      workers: 2
+      runtime_mode: mt
+      runtime_threads: 2
+      blocking_threads: 32
+      backpressure: 64
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -157,39 +157,26 @@ def create_k8s_resources(  # noqa: C901
     replicas_dict = edxapp_config.require_object("k8s_replicas")
     resources_dict = edxapp_config.require_object("k8s_resources")
 
-    # Per-install Granian concurrency for the LMS webapp.
+    # Per-install Granian concurrency, keyed by webapp.
     #
-    # CMS took the component defaults everywhere in stage 3, but LMS cannot: the
-    # measured p99 concurrency demand differs by ~65x across installs (mitxonline
-    # LMS needs 17.7 concurrently-busy blocking threads, mitx LMS needs 0.27), so a
-    # single value is either unsafe for one or wasteful for the other. This file is
-    # shared by every install, so the only place that distinction can live is
-    # per-stack config.
+    # This file is shared by every Open edX install (mitx, mitx-staging,
+    # mitxonline, xpro), so a concurrency value written here is a value written
+    # for all four at once. That is how the 2026-08-26 CMS regression happened:
+    # component defaults that suit a 0.25 rps authoring instance were applied to
+    # mitxonline Studio, whose pods then saturated at 16 active connections and
+    # drove APISIX p95/p99 to 60s while Django spans stayed at 0.2-1.1s.
+    # Measured p99 concurrency demand spans ~65x across installs, so no single
+    # value is right for all of them, and the setting belongs per-stack next to
+    # k8s_replicas and k8s_resources rather than in shared code.
     #
-    # Omitted (the default) means the pre-overhaul holding pins: 2 workers x 32
-    # blocking threads, backpressure 64, runtime-mode mt, runtime-threads 2 -- the
-    # values Granian derived from backlog=128 before the overhaul. An install opts
-    # in by setting edxapp:k8s_granian.lms in its stack config; setting it to an
-    # empty mapping opts in to the component defaults with no overrides.
+    # Required, not defaulted: an install's concurrency should be readable in its
+    # own stack file, and a new install should have to state a value rather than
+    # inherit whatever the last person to edit this file happened to choose.
     #
     # See docs/plans/granian-configuration-overhaul.md stage 3.
-    LMS_GRANIAN_HOLDING_PINS = {
-        "workers": 2,
-        "runtime_mode": "mt",
-        "runtime_threads": 2,
-        "blocking_threads": 32,
-        "backpressure": 64,
-    }
-    # `is None` rather than a falsy check: an explicitly configured empty mapping
-    # means "take the component defaults with no per-install overrides", which is a
-    # real thing for a stack to want and is not the same request as omitting the key.
-    # `or` would collapse the two and silently re-pin such a stack to the old values.
-    _lms_granian_override = (edxapp_config.get_object("k8s_granian") or {}).get("lms")
-    lms_granian_concurrency = (
-        LMS_GRANIAN_HOLDING_PINS
-        if _lms_granian_override is None
-        else _lms_granian_override
-    )
+    granian_dict = edxapp_config.require_object("k8s_granian")
+    lms_granian_concurrency = granian_dict["lms"]
+    cms_granian_concurrency = granian_dict["cms"]
 
     # Get various VPC / network configuration information
     data_vpc = network_stack.require_output("data_vpc")
@@ -816,7 +803,7 @@ def create_k8s_resources(  # noqa: C901
                 application_module="lms.wsgi:application",
                 port=8000,
                 no_ws=True,
-                # Concurrency is per-install; see lms_granian_concurrency above.
+                # Per-install; see granian_dict above.
                 **lms_granian_concurrency,
                 respawn_failed_workers=True,
                 backlog=128,
@@ -1148,22 +1135,8 @@ def create_k8s_resources(  # noqa: C901
                 application_module="cms.wsgi:application",
                 port=8000,
                 no_ws=True,
-                # Restore the pre-overhaul holding pins after the 2026-08-26
-                # mitxonline production rollout showed that the component defaults
-                # cannot absorb Studio's bursty authoring traffic. With 1 worker,
-                # 8 blocking threads, and backpressure 16, every CMS pod repeatedly
-                # saturated at 16 active connections, HTTP readiness fell to 1/3,
-                # and APISIX p95/p99 latency reached 60s while Django spans remained
-                # around 0.2-1.1s. CPU- and request-rate-based autoscaling stayed at
-                # the three-replica floor because it cannot see this connection
-                # backlog. Keep these known-good values until CMS concurrency is
-                # retuned with a saturation-aware scaling signal.
-                # See docs/plans/granian-configuration-overhaul.md stage 3.
-                workers=2,
-                runtime_mode="mt",
-                runtime_threads=2,
-                blocking_threads=32,
-                backpressure=64,
+                # Per-install; see granian_dict above.
+                **cms_granian_concurrency,
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],


### PR DESCRIPTION
## What are the relevant tickets?

`tk-stage-3-adopt-new-granian-defaults-for-mitxonlin-16de40`, project `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`. Follows #5607.

## Description (What does this do?)

`k8s_resources.py` is shared by four Open edX installs (mitx, mitx-staging, mitxonline, xpro), so a concurrency value written there is written for all four at once. That is how the 2026-08-26 CMS regression reached mitxonline Studio. Per #5607's post-mortem, the rollout cut per-pod backpressure 8x (2 workers x 64 to 1 x 16), APISIX p95/p99 reached the 60s histogram ceiling, and Tempo placed 30-59s ahead of a Django span that itself took 0.2-1.1s. `granian_connections_active` for mitxonline CMS pinned at 15-16 through that window and has been back at 50 (p99, 3d) since the rollback.

#5607 mitigated it by restoring the holding pins in shared code. That is correct for mitxonline and collateral damage for the other two: mitx and mitx-staging CMS have run 1 worker x 8 threads since 2026-08-24T17:18Z and would be dragged back to 2 workers on their next deploy.

Both webapps now read `edxapp:k8s_granian.{lms,cms}` from stack config, alongside the existing `k8s_replicas` and `k8s_resources`. The key is required rather than defaulted, so an install's concurrency is readable in its own stack file and a new install has to state a value rather than inherit whatever was last written into shared code.

| install | LMS | CMS |
| --- | --- | --- |
| `mitx`, `mitx-staging` | 1 x 8, backpressure 16 | 1 x 8, backpressure 16 |
| `mitxonline`, `xpro` | 2 x 32, backpressure 64 | 2 x 32, backpressure 64 |

Every value matches what is live as of 2026-08-28, read from the container args on `applications-production` and `residential-production`.

## How can this be tested?

`pulumi preview` against each Production stack:

- **mitxonline.Production**: `238 unchanged`, zero changes. The holding pins are preserved exactly.
- **mitx.Production**: 3 Deployment updates (`--disable-prefetch`, from #5598) plus 2 RDS alarm deletions. No Granian arg diff. Previewing the same stack against `origin/main` instead shows a **4th** Deployment update, on CMS: `[7]: "1" => "2"` (workers), `--runtime-mode mt` reinserted, blocking-threads `8 => 32`, backpressure `16 => 64`, workers-max-rss `1843 => 921`. That is the collateral revert this PR prevents.
- **mitx-staging.Production**: a Vault mount option update, 3 `--disable-prefetch`, 2 RDS alarm deletions. No Granian arg diff.
- **xpro.Production**: previews cleanly and renders `--blocking-threads 32 --backpressure 64`. Its 127 changes are dominated by the pre-existing ~6-month drift on that stack (it still runs the hand-rolled `xpro-production-edxapp-{cms,lms}-webapp` Deployments), unrelated to this PR.

`pre-commit run` over the changed files passes, mypy included.

## Additional notes

mitx CMS does touch its backpressure ceiling of 16, for 52 minutes out of 3 days (`granian_connections_active >= 16`, 1m resolution), with a peak `granian_blocking_queue` of 5 and zero container restarts. mitx-staging CMS: 33 minutes, peak queue 0. Healthy, but the ceiling is the signal to watch if authoring traffic on either grows.

Raising mitxonline off the holding pins still needs concurrency sizing that accounts for burst shape, plus a scaling or alerting signal that sees connection saturation -- CPU and request rate did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgKWpUsasvv1pLGBDhyBo5
