### PR TITLE
Revert "feat(github): move ol-django to a new library-unmanaged archetype"

### DIFF
--- a/src/ol_infrastructure/saas/github/organization/custom_properties.py
+++ b/src/ol_infrastructure/saas/github/organization/custom_properties.py
@@ -47,12 +47,7 @@ tier_property = github.OrganizationCustomProperties(
     value_type="single_select",
     # Required + default is what makes a NEW repo protected at creation (section 3.5).
     # Without the default a new repo carries no tier, matches no ruleset, and is
-    # unprotected until somebody notices -- the failure `ol-django` showed when this was
-    # written, having been created before any of this existed. Note it is untargeted
-    # AGAIN as of 2026-08-26, but deliberately now: it takes `tier: unmanaged` from the
-    # `library-unmanaged` archetype. Same observable state, opposite meaning -- which is
-    # the whole reason `unmanaged` exists as a value rather than just leaving a repo
-    # unlabelled.
+    # unprotected until somebody notices -- the exact failure `ol-django` shows today.
     required=True,
     default_value=TIER_STANDARD,
     allowed_values=list(TIER_VALUES),

--- a/src/ol_infrastructure/saas/github/organization/custom_properties.py
+++ b/src/ol_infrastructure/saas/github/organization/custom_properties.py
@@ -47,7 +47,8 @@ tier_property = github.OrganizationCustomProperties(
     value_type="single_select",
     # Required + default is what makes a NEW repo protected at creation (section 3.5).
     # Without the default a new repo carries no tier, matches no ruleset, and is
-    # unprotected until somebody notices -- the exact failure `ol-django` shows today.
+    # unprotected until somebody notices -- the failure `ol-django` showed before
+    # phase 3 tiered it, having been created before any of this existed.
     required=True,
     default_value=TIER_STANDARD,
     allowed_values=list(TIER_VALUES),

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -187,10 +187,9 @@ baseline_default_branch = github.OrganizationRuleset(
     opts=ResourceOptions(protect=True),
 )
 
-# Tier-1 is application, library and infrastructure -- 73 repos, having been 74 until
-# `ol-django` moved to the `library-unmanaged` archetype on 2026-08-26. Down to ONE
-# extra rule: an unresolved conversation is feedback that was never answered, and
-# blocking on it costs a reviewer nothing.
+# Tier-1 is application, library and infrastructure -- 74 repos. Down to ONE extra rule:
+# an unresolved conversation is feedback that was never answered, and blocking on it
+# costs a reviewer nothing.
 #
 # `require_last_push_approval` dropped in #5459, having been added on 2026-08-07 with
 # the reasoning that "an approval that predates the last push is not an approval of what

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes-proposed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes-proposed.yaml
@@ -293,6 +293,7 @@ library:
 - ocw_oer_export
 - ol-customizations-nytimes-library
 - ol-data-platform
+- ol-django
 - ol-github-workflows
 - ol-infra-health-checks
 - ol-keycloak
@@ -322,5 +323,3 @@ library:
 - video_translation_demo
 - world_geographic_regions
 - xanalytics
-library-unmanaged:
-- ol-django

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -77,49 +77,10 @@ archetypes:
     tier: tier-1
     visibility: public
 
-  # Published packages and shared libraries: smoot-design, open-edx-plugins, ...
+  # Published packages and shared libraries: ol-django, smoot-design, ...
   library:
     extends: base
     tier: tier-1
-
-  # A library whose release flow writes to its own default branch, and which is
-  # therefore deliberately placed OUTSIDE org-ruleset governance. Today: `ol-django`.
-  #
-  # WHY. `scripts/release.py create --app <pkg> --push` bumps the version, folds
-  # `changelog.d/` into CHANGELOG.md, commits, tags `<dist>/v<version>`, and pushes the
-  # commit AND the tag. Under `tier-1` the commit half is rejected by
-  # `baseline-default-branch`'s `pull_request` rule -- but a tag is a separate ref that
-  # no ruleset here targets, so the tag lands anyway and `ci.yml`'s tag-gated `release`
-  # job publishes to PyPI. The result is a shipped package whose release commit is on no
-  # branch at all: the version bump never reaches `main` and the consumed changelog.d/
-  # entries are never removed, so the NEXT release recomputes from a stale base.
-  #
-  # That is not hypothetical. `mitol-django-payment-gateway/v2026.8.26` is live on PyPI
-  # while `main` still reads 2026.8.10 and still carries the three changelog.d/ entries
-  # that release consumed; 8 of the 30 most recent release tags are orphaned this way.
-  #
-  # WHAT IT COSTS, stated plainly because nothing else will state it. No org ruleset
-  # targets `unmanaged`, and bypass is per-RULESET rather than per-rule, so this does not
-  # merely relax the review requirement -- it also drops `non_fast_forward` and
-  # `deletion` on the default branch of a public, published library. AND SEC-01 EXEMPTS
-  # `unmanaged`, so the audit will not report any of it. This comment is the only record
-  # that the exposure was chosen rather than overlooked.
-  #
-  # WHY AN ARCHETYPE AND NOT `tier: unmanaged` ON THE REPO'S OWN YAML. Because that does
-  # not survive. `_deviations()` in `bin/github-org-inventory` skips `tier` outright, so
-  # the crawl never writes a top-level tier into a repo file -- the next
-  # `crawl --refresh` would regenerate `repos/ol-django.yaml` without it, silently
-  # returning the repo to `library`/`tier-1` and re-breaking the release flow with no
-  # error anywhere. Archetype assignment lives in `archetypes-proposed.yaml`, which is
-  # hand-maintained and preserved across crawls, so it is the only durable place to say
-  # this. Same reason the YAML comment you are reading lives here and not there:
-  # `crawl` regenerates the per-repo files with `yaml.safe_dump`, which drops comments.
-  #
-  # TO RETIRE THIS: fix the push ordering in ol-django's `release.py` so the tag is
-  # pushed only after the branch lands, then move the repo back to `library`.
-  library-unmanaged:
-    extends: library
-    tier: unmanaged
 
   # ol-infrastructure, ol-concourse, dagster.
   infrastructure:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -11,7 +11,7 @@ _visibility: public
 allow_merge_commit: false
 allow_rebase_merge: true
 allow_squash_merge: true
-archetype: library-unmanaged
+archetype: library
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/tiers.py
+++ b/src/ol_infrastructure/saas/github/tiers.py
@@ -25,22 +25,10 @@ TIER_ONE: Final = "tier-1"
 #: repo creation.
 TIER_STANDARD: Final = "standard"
 
-#: Deliberately untargeted: upstream forks, archived repos, and -- since 2026-08-26 --
-#: one ACTIVE repo, `ol-django`, whose release flow pushes a version-bump commit
-#: straight to its default branch. See the `library-unmanaged` archetype in
-#: repositories/data/archetypes.yaml for why, and what it costs.
-#:
-#: THAT THIRD CASE IS NOT LIKE THE OTHER TWO. Forks and archived repos are untargeted
-#: because no ruleset could usefully apply to them -- upstream owns the fork's branch,
-#: and GitHub already refuses writes to an archived repo. An ACTIVE repo here gives up
-#: real protection: no required review, and no `non_fast_forward` or `deletion` cover on
-#: its default branch, because targeting is per-ruleset rather than per-rule. SEC-01
-#: exempts `unmanaged`, so the audit reports none of it. Putting an active repo in this
-#: tier is a security decision, not a classification.
-#:
-#: Distinct from "unlabelled" -- this is a claim that no org ruleset should apply, which
-#: a reviewer can disagree with. Without it, CON-09 could not tell an intentional
-#: exemption from an oversight.
+#: Deliberately untargeted: upstream forks and archived repos. Distinct from
+#: "unlabelled" -- this is a claim that no org ruleset should apply, which a reviewer
+#: can disagree with. Without it, CON-09 could not tell an intentional exemption from
+#: an oversight.
 TIER_UNMANAGED: Final = "unmanaged"
 
 #: Order matters only for readability; GitHub stores allowed_values as a set.


### PR DESCRIPTION
### What are the relevant tickets?

Reverts https://github.com/mitodl/ol-infrastructure/pull/5606 (merge commit `3460038f37b6eb05f66bb321c2f0f32f679a7222`).

### Description (What does it do?)

Puts `ol-django` back on the `library` archetype / `tier-1` and deletes the `library-unmanaged` archetype #5606 added. The revert commit `fd4d1ede4` restores the pre-#5606 tree exactly (`git diff 3460038f^1` was empty at that commit); `9a427b4a2` then fixes one comment the revert restored verbatim and which had since gone stale — see Additional Context.

#5606 moved `ol-django` out of org-ruleset governance so `scripts/release.py create --app <pkg> --push` could push its version-bump commit straight to `main`. That treats the symptom in the wrong place:

- **The defect is in ol-django, not in the tier.** `release.py` pushes the tag such that it survives a failed branch push, so *any* rejection — ruleset, non-fast-forward race, network — publishes to PyPI with no commit on `main`. #5606 said this itself, and noted that the two pre-ruleset orphans (2026-04-29, 2026-06-16) predate these rulesets entirely and were almost certainly races. De-targeting the repo removes one trigger and leaves the mechanism in place.
- **The price was high and invisible.** Targeting is per-ruleset, not per-rule, so `unmanaged` also dropped `non_fast_forward` and `deletion` on the default branch of a public, published library — and SEC-01 exempts `unmanaged`, so the audit reported none of it. A YAML comment was the only record the exposure had been chosen at all.
- **It did not fix the orphaned commit either.** `f346341b` is still reachable only via its tag; that is unchanged by both #5606 and this revert.

The fix belongs in ol-django's `release.py`: push the tag only after the branch push lands.

### How can this be tested?

Fleet data resolves with `ol-django` back under `tier-1`, and tier-1 returns to 74 (#5606 took it 74 → 73):

```
$ uv run python -c "...load_fleet()..."
repos: 316
ol-django entries: 1
  archetype: library | tier: tier-1 | last-crawl properties: {'tier': 'tier-1'}
by tier: Counter({'unmanaged': 242, 'tier-1': 74})
by archetype: Counter({'archived': 140, 'fork': 102, 'library': 61, 'application': 10, 'infrastructure': 3})
```

That total is independently checkable from the archetype counts: library 61 + application 10 + infrastructure 3 = 74. (`_custom_properties` above is the last-crawl snapshot, not live GitHub — see Additional Context for the live check.)

- `uv run pytest tests/ -k "github or fleet or archetype or audit"` → **94 passed** (same baseline #5606 reported)
- `uv run pre-commit run --from-ref origin/main --to-ref HEAD` → all passed (ruff format, ruff check, mypy, yamllint, detect-secrets)
- `git log 3460038f..origin/main -- src/ol_infrastructure/saas/github bin/ src/ol_concourse/pipelines/libraries` → empty; nothing landed on top of #5606 in these paths
- `library-unmanaged` appears in no tracked file after this revert; no repo YAML declares a hyphenated archetype or a top-level `tier:` override, so tier is always archetype-resolved
- `uv run pre-commit run --files .../custom_properties.py` → passed, and the 94 tests re-run green after `9a427b4a2`
- Fleet-count prose is consistent at 74 everywhere it appears (`org_rulesets.py`, `data/README.md`, `bin/github-org-inventory`, `docs/plans/github-org-pulumi-import.md`) — nothing was left at 73

### Additional Context

**#5606 never reached live GitHub.** Checked directly rather than from the committed crawl snapshot:

```
$ gh api repos/mitodl/ol-django/properties/values
[{"property_name":"tier","value":"tier-1"}]
```

Live is `tier-1` and this revert makes declared `tier-1` again, so the CON-11 finding #5606 predicted (declared ≠ live) clears rather than inverting. Two consequences worth stating: no protection is being restored here that was ever actually removed, and the release-flow breakage #5606 set out to fix was never actually fixed in production.

**The tier may never have been what blocked the release push.** `_ADMIN_BYPASS` in [`org_rulesets.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/github/organization/org_rulesets.py#L105-L110) grants `odl-engineering-owners` `bypass_mode="always"` on both rulesets — which covers direct pushes, not just PR merges. Two of the three explanations for #5606's observed `[remote rejected] main -> main` are ruled out by live evidence:

```
$ gh api orgs/mitodl/teams/odl-engineering-owners/memberships/odlbot
{"state":"active","role":"member",...}          # membership is NOT stale

$ gh api repos/mitodl/ol-django/keys
[]                                              # no deploy key, so the pusher has a user identity
```

So a Team bypass actor should apply to that push. What remains is either that the bypass is not live on the ruleset, or that the rejection came from a credential other than odlbot. I could not check the live ruleset — my token lacks `admin:org` (`gh api orgs/mitodl/rulesets` → 404). Someone with that scope can settle it with `gh api orgs/mitodl/rulesets/<id> --jq '.bypass_actors'`, or by reading the declining rule name off the rejection line in the `publish-ol-django-pypi` build log. None of this blocks the revert, but it does bear on whether #5606 was necessary on its own terms.

### Checklist:
- [ ] Do not `pulumi up` this ahead of the ol-django `release.py` push-ordering fix. Applying it rewrites `tier=tier-1` and re-subjects `main` to the approval requirement, and the failure is **not** fail-safe: [`ol_django.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/libraries/ol_django.py#L57-L67) pushes commit and tag together, so a rejected branch push can still publish to PyPI. Either land the `release.py` fix first, or accept a red release job knowingly in the interim.
- [ ] Re-run `bin/github-org-inventory crawl --refresh` after the apply so `_custom_properties` reflects the applied state.

**One non-revert commit, called out so it is not mistaken for revert noise.** `9a427b4a2` retenses a comment in `custom_properties.py` that the revert restored verbatim: "the exact failure `ol-django` shows today". That was accurate pre-#5606 — ol-django predated the custom property, so it carried no tier and matched no ruleset — but `ol-django.yaml` now has `archetype: library` and `_ruleset_count: 2`, so the present tense is false. Flagged independently by Copilot and by a review pass over this branch. The example is kept, since it is what the `required` + `default_value` rationale rests on; only the tense changed.
