### PR TITLE
fix(opik): pin the LLM provider token SSRF guard to strict

### DIFF
--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -263,7 +263,7 @@ opik_helm_release = kubernetes.helm.v3.Release(
                         # "relaxed" is a no-op. The backend defaults to strict
                         # (config.yml destinationGuard), which is what we run
                         # today because chart 2.2.35 sets nothing -- but 2.2.43
-                        # starts shipping "relaxed" in backend.env, and that
+                        # starts shipping "relaxed" in component.backend.env, and that
                         # ConfigMap reaches us through the envFrom below. Upstream
                         # relaxes it because a self-hosted auth service may sit on
                         # a private range. Setting it here keeps the chart bump

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -254,6 +254,24 @@ opik_helm_release = kubernetes.helm.v3.Release(
                         "ANALYTICS_DB_DATABASE_NAME": CLICKHOUSE_DATABASE,
                         "ANALYTICS_DB_USERNAME": CLICKHOUSE_USER,
                         "ANALYTICS_DB_MIGRATIONS_USER": CLICKHOUSE_USER,
+                        # Pinned to opik's own application default rather than
+                        # the chart's. This is the SSRF guard on the token URL
+                        # of an admin-configured custom LLM provider: "strict"
+                        # requires https and refuses loopback, link-local
+                        # (including 169.254.169.254), RFC 1918, IPv6
+                        # unique-local and multicast destinations, while
+                        # "relaxed" is a no-op. The backend defaults to strict
+                        # (config.yml destinationGuard), which is what we run
+                        # today because chart 2.2.35 sets nothing -- but 2.2.43
+                        # starts shipping "relaxed" in backend.env, and that
+                        # ConfigMap reaches us through the envFrom below. Upstream
+                        # relaxes it because a self-hosted auth service may sit on
+                        # a private range. Setting it here keeps the chart bump
+                        # from silently weakening a guard we already run with; if
+                        # a custom provider ever does need an internal token URL,
+                        # this is the knob, and flipping it is then a deliberate
+                        # decision rather than a side effect of a version bump.
+                        "LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD": "strict",
                     },
                     # Layer the VSO-synced credentials Secret on top of the
                     # ConfigMap. Listing the Secret last lets it override the


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Sets `LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "strict"` in opik's `component.backend.env`, so the value we already run is stated rather than inherited.

**This is not a behavior change today. It prevents one tomorrow.**

- Opik's backend defaults `destinationGuard` to `strict` — [`config.yml:1239`](https://github.com/comet-ml/opik/blob/9dde5a09d9e22eda7bbf2ff4e1470fb0138b6709/apps/opik-backend/config.yml#L1239) (`${LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD:-strict}`) and `LlmProviderTokenAuthConfig.java:53` (`Mode destinationGuard = Mode.STRICT`).
- Chart **2.2.35**, which we run now, does not set the variable at all. So production is on `strict`.
- Chart **2.2.43** starts shipping `LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "relaxed"` under `component.backend.env`, and that ConfigMap reaches the backend via the `envFrom` we already configure. Merging #5617 without this flips the guard off as a side effect of a version bump.

**What the guard does.** It is a pre-flight SSRF check on the token URL of an admin-configured custom LLM provider (`infrastructure/llm/customllm/AuthTokenProvider`). `strict` requires `https` and resolves the hostname before connecting, refusing loopback, link-local (including the `169.254.169.254` cloud metadata endpoint), RFC 1918 private ranges, IPv6 unique-local, multicast, and unresolvable hosts. `relaxed` is a no-op.

Upstream's own comment in `config.yml` is explicit about the gap:

> This strict default protects cloud; note that the docker-compose and Helm distributions ship 'relaxed' explicitly, so self-hosted installs are NOT covered by this default

Upstream relaxes it because a self-hosted auth service may legitimately sit on a private range. If a custom provider here ever does need an internal token URL, this line is the knob — and flipping it then is a deliberate decision rather than an invisible consequence of a chart bump.

### How can this be tested?

Verified with `helm template` against both chart versions. The key lives at `component.backend.env`, **not** `backend.env` — I checked the wrong path first and the override silently did nothing, which is worth knowing since the two are easy to confuse:

```
helm template rel opik --version 2.2.43
  -> LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "relaxed"

helm template rel opik --version 2.2.43 \
  --set component.backend.env.LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=strict
  -> LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "strict"

helm template rel opik --version 2.2.35 \
  --set component.backend.env.LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=strict
  -> LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "strict"
```

Rendering against 2.2.35 confirms this is safe to merge **before** #5617 rather than needing to land with it.

The chart's other `component.backend.env` keys still render alongside it — I counted 20 matching `ANALYTICS_DB_*` / `REDIS_URL` / `JAVA_OPTS` — so this overrides a single key rather than replacing the map.

`pre-commit run --files src/ol_infrastructure/applications/opik/__main__.py` passes, mypy included. No `pulumi preview` was run — a reviewer with stack credentials would see a single ConfigMap key added on the current chart.

### Additional Context

Came out of a dependency sweep. #5617 (opik 2.2.35 → 2.2.43) is being held until this lands. That chart bump also adds startup/liveness/readiness probes and a `preStop` sleep to the backend, which we do not override and which upstream added to fix a rollout race — those are worth taking, unlike the guard default.
