### PR TITLE
fix(starrocks): stop publishing the whole FE HTTP surface to the internet

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -981,7 +981,31 @@ starrocks_apisix_httproute = OLApisixHTTPRoute(
         OLApisixHTTPRouteConfig(
             route_name=f"{stack_info.env_prefix}-starrocks",
             hosts=[starrocks_config.require("domain")],
-            paths=["/*"],
+            # Publish ONLY the OAuth2 callback. The JDBC OAuth2 flow completes
+            # its token exchange at this path, and nothing else on the FE's HTTP
+            # port is meant to be reachable from the internet.
+            #
+            # This used to be ["/*"], which exposed the whole FE HTTP surface.
+            # StarRocks gates those endpoints on Config.enable_http_auth, which
+            # upstream defaults to false, so they answered anonymously. Measured
+            # against QA on 2026-08-28: /api/show_data returned the cluster's
+            # total data size and /api/show_runtime_info returned FE JVM memory
+            # and thread counts, both with no credentials.
+            #
+            # Do NOT "fix" that by setting enable_http_auth = true instead. The
+            # operator wires the FE's startup, liveness AND readiness probes to
+            # an unauthenticated HTTPGet on /api/health (fe_pod.go:72-74,
+            # HEALTH_API_PATH), and HealthAction.needAuth() returns that same
+            # flag -- so enabling it 401s all three probes and crashloops every
+            # FE pod. The @ConfField comment in Config.java claiming health
+            # probes are "always exempt" does not hold for the FE.
+            #
+            # The FE web dashboard is no longer reachable over this domain. It
+            # only ever accepted native Basic Auth (OIDC users cannot log into
+            # it at all -- StarRocks#75370), so its audience was operators
+            # holding native credentials, who can port-forward instead.
+            paths=["/api/oauth2"],
+            path_match_type="Exact",
             backend_service_name=f"{stack_info.env_prefix}-starrocks-fe-service",
             backend_service_port=8030,
             plugins=[],

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -762,7 +762,10 @@ def _build_fe_config(  # noqa: PLR0913
     prevent FE startup.
 
     When oidc_issuer_url is provided, the full set of oauth2_* FE params is
-    written so that the StarRocks web UI shows the "OAuth2 Login" button.
+    written. Those serve locally-created `IDENTIFIED WITH authentication_oauth2`
+    users and the JDBC driver's browser authorization-code flow; they do not
+    add an "OAuth2 Login" button to the FE web dashboard, which has no OIDC
+    entry point (StarRocks#75370).
     The client secret ends up in a ConfigMap (StarRocks Helm chart limitation);
     access is RBAC-gated and marked as a Pulumi secret so it is not stored
     in plaintext Pulumi state.
@@ -772,7 +775,8 @@ def _build_fe_config(  # noqa: PLR0913
     if oidc_issuer_url is not None:
         _oidc_base = f"{oidc_issuer_url}/protocol/openid-connect"
         conf += (
-            # oauth2_* — web UI "OAuth2 Login" button (browser-redirect flow).
+            # oauth2_* — read by locally-created authentication_oauth2 users
+            # and by the JDBC driver's browser authorization-code flow.
             # StarRocks FE exchanges the authorization code server-side using
             # these credentials; the id_token is stored on the connection context
             # and forwarded to Iceberg REST catalogs when security = JWT.
@@ -859,8 +863,15 @@ if _needs_fe_config:
     fe_spec = cast(dict[str, Any], starrocks_values["starrocksFESpec"])
     _domain = starrocks_config.require("domain")
 
-    # Pull OIDC client credentials from Vault when OIDC is enabled so the FE web
-    # UI can display the "OAuth2 Login" button (requires oauth2_* in fe.conf).
+    # Pull OIDC client credentials from Vault when OIDC is enabled so the
+    # oauth2_* keys can go into fe.conf. Those are what a locally-created
+    # `CREATE USER ... IDENTIFIED WITH authentication_oauth2` account
+    # authenticates against -- the security integration alone is not sufficient
+    # for a user created that way, which is how starrocks:oidc_users works.
+    # They do NOT put an "OAuth2 Login" button on the FE web dashboard: it
+    # answers with `WWW-Authenticate: Basic` unconditionally and has no OIDC
+    # entry point at all (StarRocks#75370). The browser redirect belongs to the
+    # JDBC driver's authorization-code flow, which returns to /api/oauth2.
     _oidc_vault_data: Output | None = None
     if starrocks_config.get_bool("oidc_enabled"):
         _oidc_vault_data = pulumi_vault.generic.get_secret_output(

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -690,9 +690,23 @@ if oidc_enabled:
     # This coexists with keycloak_oauth2 so that:
     #   - Web UI users: keycloak_oauth2 (browser OAuth2 redirect)
     #   - mysql CLI users: keycloak_jwt (pre-fetched id_token via starrocks-auth)
-    # The id_token stored on the connection context is also forwarded to
-    # Iceberg REST catalogs when iceberg.catalog.security = JWT, enabling
-    # per-user identity delegation to the catalog.
+    # Forwarding the id_token to an Iceberg REST catalog under
+    # iceberg.catalog.security = JWT is proven to work (StarRocks 4.1.3 against
+    # Lakekeeper v0.13.1, 2026-08-07: Lakekeeper's audit log showed two distinct
+    # end-user subjects on list_namespaces/create_namespace). It is inert for
+    # this catalog, which is iceberg.catalog.type = glue and has no per-session
+    # token path at all.
+    #
+    # Two caveats for whoever wires up the REST catalog:
+    #   - security = JWT supplies no credential for catalog INITIALIZATION.
+    #     RESTSessionCatalog.initialize() runs with no user session, so
+    #     GET /v1/config goes out unauthenticated and CREATE EXTERNAL CATALOG
+    #     fails against a catalog that requires auth. Pair it with
+    #     iceberg.catalog.oauth2.credential as a bootstrap. This is what
+    #     StarRocks#75792 is actually reporting.
+    #   - The FE metadata cache bypasses the catalog, so catalog-side authz is
+    #     not consulted on cached reads. StarRocks GRANTs stay the query-time
+    #     filter.
     def _build_jwt_integration_sql(args: list[str]) -> str:
         issuer = json.dumps(args[0])[1:-1]
         _n = _JWT_SECURITY_INTEGRATION_NAME

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -688,8 +688,14 @@ if oidc_enabled:
     # to the StarRocks identity.
     #
     # This coexists with keycloak_oauth2 so that:
-    #   - Web UI users: keycloak_oauth2 (browser OAuth2 redirect)
+    #   - JDBC users:      keycloak_oauth2 (the driver opens a browser for the
+    #                      authorization-code exchange; StarRocks completes it
+    #                      server-side at /api/oauth2)
     #   - mysql CLI users: keycloak_jwt (pre-fetched id_token via starrocks-auth)
+    # Neither is the FE web dashboard, which has no OIDC entry point at all --
+    # it answers `WWW-Authenticate: Basic` unconditionally (StarRocks#75370) and
+    # is no longer published externally. Do not widen the APISIX route on the
+    # belief that keycloak_oauth2 needs it.
     # Forwarding the id_token to an Iceberg REST catalog under
     # iceberg.catalog.security = JWT is proven to work (StarRocks 4.1.3 against
     # Lakekeeper v0.13.1, 2026-08-07: Lakekeeper's audit log showed two distinct
@@ -698,12 +704,23 @@ if oidc_enabled:
     # token path at all.
     #
     # Two caveats for whoever wires up the REST catalog:
-    #   - security = JWT supplies no credential for catalog INITIALIZATION.
-    #     RESTSessionCatalog.initialize() runs with no user session, so
-    #     GET /v1/config goes out unauthenticated and CREATE EXTERNAL CATALOG
-    #     fails against a catalog that requires auth. Pair it with
-    #     iceberg.catalog.oauth2.credential as a bootstrap. This is what
-    #     StarRocks#75792 is actually reporting.
+    #   - security = JWT supplies no credential of its own, which breaks two
+    #     different things. Both are cured by pairing it with
+    #     iceberg.catalog.oauth2.credential as a bootstrap:
+    #       * Catalog INITIALIZATION. RESTSessionCatalog.initialize() runs with
+    #         no user session, so GET /v1/config goes out unauthenticated. A
+    #         catalog that requires auth there 401s and CREATE EXTERNAL CATALOG
+    #         fails outright. This is what the 2026-08-07 spike hit against
+    #         Lakekeeper.
+    #       * Token attachment on every LATER call. Where the server does allow
+    #         an anonymous GET /v1/config, the catalog is created and logins
+    #         succeed, but OAuth2SecurityConfigBuilder.build() falls back to
+    #         NONE when neither a static token nor a credential is present, so
+    #         RESTSessionCatalog is initialized without an OAuth2 auth manager
+    #         and the per-session token buildContext() produces is dropped.
+    #         Requests then fail at namespace resolution with "missing bearer
+    #         token". This is StarRocks#75792; the fix is #75811, open and
+    #         unreviewed since 2026-07-03.
     #   - The FE metadata cache bypasses the catalog, so catalog-side authz is
     #     not consulted on cached reads. StarRocks GRANTs stay the query-time
     #     filter.
@@ -753,7 +770,8 @@ if oidc_enabled:
     )
 
     # Point the FE authentication chain at both security integrations.
-    # keycloak_oauth2: web UI browser-redirect OAuth2 flow
+    # keycloak_oauth2: JDBC browser authorization-code flow (not the web UI --
+    #                  the dashboard has no OIDC entry point, StarRocks#75370)
     # keycloak_jwt:    mysql CLI client-plugin flow (id_token pre-fetched)
     # StarRocks persists ADMIN SET FRONTEND CONFIG changes to BDB so they
     # survive pod restarts without requiring a fe.conf change.
@@ -844,8 +862,8 @@ if oidc_enabled:
         f");\n"
         # Attach the group provider to both Security Integrations so that
         # role assignment from Keycloak groups works regardless of whether
-        # the user authenticated via the web UI (keycloak_oauth2) or the
-        # mysql CLI client-plugin flow (keycloak_jwt).
+        # the user authenticated via the JDBC authorization-code flow
+        # (keycloak_oauth2) or the mysql CLI client-plugin flow (keycloak_jwt).
         f"ALTER SECURITY INTEGRATION {_OIDC_SECURITY_INTEGRATION_NAME}\n"
         f"    SET ('group_provider' = '{_group_provider_name}',"
         f" 'permitted_groups' = '{_permitted}');\n"


### PR DESCRIPTION
## What

Narrows the StarRocks APISIX route from `paths=["/*"]` to an `Exact` match on `/api/oauth2`.

## Why

The route published the entire FE HTTP port (8030) on a public domain with `plugins=[]`. StarRocks gates its FE REST endpoints on `Config.enable_http_auth`, which upstream defaults to `false` "for backward compatibility" — `needAuth()` returns that flag on `ShowDataAction`, `ShowRuntimeInfoAction`, `ConnectionAction`, `QueryProgressAction`, `FeatureAction`, `IdleAction` and `HealthAction` (verified against `main`).

Measured against QA on 2026-08-28 with no credentials:

```
GET /api/show_data          200  54376907
GET /api/show_runtime_info  200  {"free_mem":"17970495488","total_mem":"19327352832","thread_cnt":"106",...}
GET /api/health             200  {"online_backend_num":0,"total_backend_num":0,"status":"OK"}
GET /api/connection         400  not valid parameter          (reachable, wants a param)
GET /api/memory_usage       403  only allow access from 127.0.0.1   (separately gated)
```

Production was not probed. It runs the same code and image with the same unset default.

`/api/oauth2` is the configured `redirect_url` and the only path the JDBC OAuth2 flow needs, so this keeps the OIDC path working.

## The fix that looks right and isn't

Setting `enable_http_auth = true` is the obvious move. **Don't** — it crashloops the cluster.

The operator wires the FE's startup, liveness *and* readiness probes to an unauthenticated `HTTPGet` on `/api/health` (`pkg/subcontrollers/fe/fe_pod.go:72-74`, `HEALTH_API_PATH = "/api/health"` in `pkg/k8sutils/templates/pod/spec.go`, operator v1.11.7 — the version we run). `HealthAction.needAuth()` returns `Config.enable_http_auth`. Enabling it 401s all three probes on every FE pod.

The `@ConfField` comment in `Config.java` says internal endpoints including "health/metrics probes" are "always exempt". That is not true for the FE's `/api/health`. I nearly shipped this; the reasoning is now in a comment at the route so the next person doesn't.

## Behavior change

The FE web dashboard is no longer reachable over the public domain. It only ever accepted native Basic Auth — OIDC users cannot log into it at all, which is our open FR [StarRocks#75370](https://github.com/StarRocks/starrocks/issues/75370) — so its audience was operators holding native credentials, who can `kubectl port-forward` instead. Flagging it in case anyone was using it.

Worth knowing alongside this: [StarRocks#67702](https://github.com/StarRocks/starrocks/issues/67702) reports that under an OAuth2 integration the dashboard accepts a username with **no password**. Filed against 3.5.2, auto-closed as stale on 2026-08-03 without ever being triaged, never fixed. Not reproduced on 4.1.4 yet — tracked in witan as `tk-re-file-starrocks-67702-unauthenticated-web-ui-a-2b4c58`.

## Also in this PR

Corrects a comment in `substructure/starrocks/__main__.py` that stated the connection's id_token is forwarded to Iceberg REST catalogs without the two conditions that finding depends on, both established by the 2026-08-07 Lakekeeper spike: `security=JWT` supplies no credential for catalog *initialization* (needs a bootstrap `iceberg.catalog.oauth2.credential`), and the FE metadata cache means catalog-side authz is not consulted on cached reads.

## Testing

`pulumi preview` not run — no stack credentials in this session. Please preview against QA before merging; the route change is what to eyeball. `pre-commit` (ruff, ruff-format, mypy, detect-secrets) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4d6g6aRzV9G8HJ5z9paey