### PR TITLE
docs(grafana-alerting): a freshly-imported rule group is not UI drift

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -216,6 +216,30 @@ Two things to check first:
    breaks live silences, and dead-links the Grafana URL embedded in every past
    Rootly alert.
 
+Between the import and the first apply, every preview of the stack reports the
+imported group as `~ update` with `diff: ~disableProvenance,rules`, on an
+otherwise-empty diff and regardless of what the preview was actually run for.
+That is the pending adoption showing itself, not drift: `rules` is the live
+hand-made rule against what the code now declares, and `disableProvenance` is
+unset in the imported state against the provider's `false` default. Both settle
+on the first apply and do not re-diff, so `disable_provenance` does not need
+setting explicitly in code.
+
+The three MIT Learn synthetic-monitoring groups were misread this way in
+2026-08 and filed as UI drift about to be silently reverted. The rules' own
+version history (`GET /api/v1/provisioning/alert-rules/{uid}/versions`) settled
+it: across all three, the only human edits were the original 2026-04 creation
+and two self-reverted experiments (a 24-second pause/unpause, a trailing slash
+on an instance label put back 9 minutes later). Nothing hand-tuned existed to
+lose. **Read that endpoint before assuming a rule was edited in the UI** — it
+names the author and timestamp of every version, and distinguishes a real hand
+edit from an adoption that has not been applied yet.
+
+After the first apply the rules report `provenance: "api"` and the Grafana UI
+refuses to edit them, so this drift class cannot recur for an adopted group —
+which is also why a genuine post-adoption change has to come through this
+program rather than the UI.
+
 ### Adding a new log alert rule
 
 Same pattern, but open the relevant file in `log_rules/` and use a LogQL

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -236,9 +236,9 @@ names the author and timestamp of every version, and distinguishes a real hand
 edit from an adoption that has not been applied yet.
 
 After the first apply the rules report `provenance: "api"` and the Grafana UI
-refuses to edit them, so this drift class cannot recur for an adopted group —
-which is also why a genuine post-adoption change has to come through this
-program rather than the UI.
+refuses to edit them, so UI-originated drift cannot recur for an adopted group.
+Changes should therefore be made through this program, although another client
+with provisioning-API access can still modify the group.
 
 ### Adding a new log alert rule
 


### PR DESCRIPTION
## What are the relevant tickets?

Closes the investigation tracked as `tk-grafana-alerting-resolve-pre-existing-drift-on-t-2ef704`.

## Description (What does it do?)

Adds a section to `grafana_alerting/CLAUDE.md` explaining that a rule group between `pulumi import` and its first `pulumi up` previews as `~ update` with `diff: ~disableProvenance,rules` on an otherwise-empty diff, and that this is the pending adoption rather than someone editing the rule in the Grafana UI. Names the version-history endpoint as the way to tell the two apart.

## Why is this needed?

The three MIT Learn synthetic-monitoring groups showed exactly that diff during an unrelated preview on 2026-08-14 and were filed as hand-tuned UI edits that the next apply would silently revert. That reading was wrong, and it cost an investigation to establish. Writing down the distinction is cheaper than repeating it on the next adoption.

## What I verified

- `pulumi preview --cwd src/ol_infrastructure/infrastructure/grafana_alerting --stack Production` is clean: `37 unchanged`, no diff on any of the three groups. `disable_provenance` does not need setting in code.
- Live rule definitions (`GET /api/v1/provisioning/folder/grafana-synthetic-monitoring-app/rule-groups/{group}`) match what `synthetic_monitoring.py` declares, on all three groups.
- Version history (`GET /api/v1/provisioning/alert-rules/{uid}/versions`) on all three fast rules: the only human-authored versions are the original 2026-04-16 creations and two self-reverted experiments — a 24-second pause/unpause on the NextJS rule (2026-06-10) and a trailing slash on the API rule's instance label, put back nine minutes later by the same person (2026-07-28). Every version from the 2026-08-14 adoption onward is authored by `pulumi_grafana_alerts`. No hand-tuned threshold existed to lose.
- All nine Pulumi-managed rules in that folder report `provenance: "api"`, so the Grafana UI now refuses to edit them.

## Does this require changes to application code or configuration?

No. Documentation only; no Pulumi resources change.

## Does this PR involve a change to production infrastructure?

No.