### PR TITLE
feat(labels): label the cluster addons so their alerts can be routed

### DIFF
--- a/docs/plans/rootly-label-routing-implementation-spec.md
+++ b/docs/plans/rootly-label-routing-implementation-spec.md
@@ -539,6 +539,61 @@ full `K8sAppLabels` and then never passes it to a resource; `pulumi preview` on 
 stack reports zero changes. The §3.4 gate is written against rendered resources for
 exactly this reason.
 
+#### 3.3.1 [2026-08-28] `operations-production` is Helm charts, and the values key is per chart
+
+Every workload in P2.C's step 1 is installed from a third-party chart, so none of them
+constructs a label model and the §3.4 gate cannot reach them. What a chart accepts is
+the whole problem, and it varies: the key has to land on the **pod template** (that is
+what `kube_pod_labels` reads) and must not land in `spec.selector`, which is immutable
+on a Deployment — a label that reaches the selector forces a delete-and-recreate of the
+addon rather than a rolling restart.
+
+Verified by rendering each chart at its pinned version with a sentinel label under each
+candidate key, then by `pulumi preview` against `operations.Production` (10 updates,
+0 replacements; the two non-Helm diffs are pre-existing AMI drift):
+
+| Chart (pinned version) | Key that reaches the pod | Also on the workload object |
+|---|---|---|
+| `cert-manager` v1.21.1 | `global.commonLabels` | same key |
+| `external-dns` 1.21.1 | `podLabels` | `commonLabels` |
+| `traefik` 41.4.0 | `commonLabels` | same key |
+| `vault-secrets-operator` 1.5.1 | `controller.extraLabels` | — |
+| `vertical-pod-autoscaler` 0.11.0 | `<component>.podLabels` | `commonLabels` |
+| `aws-load-balancer-controller` 3.5.0 | `podLabels` | `additionalLabels` |
+| `metrics-server` 3.13.x | `podLabels` | `commonLabels` |
+| `aws-node-termination-handler` 0.27.2 | `podLabels` | `customLabels` |
+| `karpenter` 1.14.1 | `podLabels` | `additionalLabels` |
+| `keda` 2.20.2 | `podLabels.<component>` | `additionalLabels` (one set for all three) |
+| `vantage-kubernetes-agent` 1.9.5 | `podLabels` | `appLabels` |
+| `dcgm-exporter` 4.8.3 | `podLabels` | — |
+
+**Three findings from doing it.**
+
+1. **The vault-secrets-operator release was labeling nothing.** It passed the shared
+   label dict to a top-level `extraLabels`, and the chart has no such key — only
+   `controller.extraLabels`. Helm does not error on an unrecognized value, so the
+   labels were silently dropped for as long as that line has existed. Any chart wired
+   by analogy rather than against its `values.yaml` can be wrong the same way, and
+   nothing in the pipeline says so.
+2. **Two addons cannot be labeled through their charts at all.** `apisix` 2.16.1
+   exposes only `service.labelsOverride`, which *replaces* `apisix.selectorLabels` —
+   used for the selector and the pod template both, so any label added there rewrites
+   the immutable selector. `nvidia-device-plugin` 0.20.0 has only
+   `selectorLabelsOverride`, the same trap. APISIX is the single widest-blast-radius
+   workload in the estate, so it needs the `DeploymentPatch` route (the pattern
+   already in `core_dns.py`) rather than a chart value.
+3. **EKS-managed addons are not Helm releases.** `aws-node`, `kube-proxy`, `coredns`,
+   the EBS/EFS CSI drivers and the GuardDuty agent are installed by the EKS addon
+   controller. They can only be labeled by patching, and a patch may be reverted on
+   addon upgrade — untested.
+
+Coverage that leaves `operations-production` at: 18 of 66 workloads carrying all three
+of `service`, `component` and `alert_tier` (`alert_tier` was at zero), against 7
+carrying `service` alone before. The remaining 48 are APISIX (2), the Grafana
+`k8s-monitoring` subcharts (9), EKS-managed addons (9), NVIDIA (6), ToolHive (13),
+Keycloak (2) and the 7 already-`service`-labeled application workloads, which need
+`component` and `alert_tier` added at their own call sites.
+
 Also backfill CI/QA clusters, which the analysis explicitly did not measure. Coverage
 there does not affect paging (CI/QA alerts go Slack-only per §8.1) but an unlabeled QA
 workload routes as untier-ed, so the QA stack stops being a rehearsal for the

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -66,7 +66,13 @@ from ol_infrastructure.lib.aws.iam_helper import (
     lint_iam_policy,
 )
 from ol_infrastructure.lib.fastly import get_fastly_provider
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
 from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
     parse_stack,
@@ -1001,6 +1007,7 @@ setup_vault_secrets_operator(
 )
 
 setup_external_dns(
+    stack_info=stack_info,
     cluster_name=cluster_name,
     cluster=cluster,
     aws_account=aws_account,
@@ -1015,6 +1022,7 @@ setup_external_dns(
 )
 
 cert_manager_release = setup_cert_manager(
+    stack_info=stack_info,
     cluster_name=cluster_name,
     cluster=cluster,
     aws_account=aws_account,
@@ -1045,6 +1053,7 @@ fastly_provider = cast(Any, get_fastly_provider(wrap_in_pulumi_options=False))
 # AWS Load Balancer Controller, AWS Node Termination Handler
 ############################################################
 lb_controller = setup_aws_integrations(
+    stack_info=stack_info,
     aws_account=aws_account,
     cluster_name=cluster_name,
     cluster=cluster,
@@ -1063,6 +1072,7 @@ lb_controller = setup_aws_integrations(
 # configured with vertical autoscaling
 ############################################################
 vpa_release = setup_vpa(
+    stack_info=stack_info,
     cluster_name=cluster_name,
     cluster=cluster,
     k8s_provider=k8s_provider,
@@ -1113,6 +1123,15 @@ setup_apisix(
 ############################################################
 # Install and configure metrics-server
 ############################################################
+metrics_server_labels = cluster_addon_labels(
+    base_labels=k8s_global_labels,
+    stack_info=stack_info,
+    service=Services.metrics_server,
+    component=Component.api,
+    # Every HPA in the cluster goes blind without it, but nothing scales
+    # down or sheds traffic on its own while it is gone.
+    alert_tier=AlertTier.notify,
+)
 metrics_server_release = kubernetes.helm.v3.Release(
     f"{cluster_name}-metrics-server-helm-release",
     kubernetes.helm.v3.ReleaseArgs(
@@ -1125,7 +1144,8 @@ metrics_server_release = kubernetes.helm.v3.Release(
         cleanup_on_fail=True,
         skip_await=False,
         values={
-            "commonLabels": k8s_global_labels,
+            "commonLabels": metrics_server_labels,
+            "podLabels": metrics_server_labels,
             "tolerations": operations_tolerations,
             # Every HPA in the cluster depends on metrics-server for resource
             # metrics. A single replica means any restart or node drain leaves

--- a/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
@@ -9,6 +9,13 @@ from pulumi import ResourceOptions
 
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
 def setup_aws_integrations(
@@ -23,12 +30,33 @@ def setup_aws_integrations(
     node_groups,
     versions,
     cert_manager,
+    stack_info: StackInfo,
 ):
     """
     Set up AWS integrations for EKS.
 
     This includes the AWS Load Balancer Controller and the AWS Node Termination Handler.
     """
+    lb_controller_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.aws_load_balancer_controller,
+        component=Component.controller,
+        # Its mservice/mtargetgroupbinding webhooks are failurePolicy: Fail with
+        # no namespace selector, so losing the last replica blocks Service and
+        # TargetGroupBinding admission cluster-wide -- and a replacement cannot
+        # cold start to fix it.
+        alert_tier=AlertTier.page,
+    )
+    node_termination_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.aws_node_termination_handler,
+        component=Component.agent,
+        # Losing it means spot reclaims and ASG lifecycle events stop draining
+        # gracefully; workloads restart harder, nothing goes dark.
+        alert_tier=AlertTier.notify,
+    )
     ############################################################
     # Install and configure AWS Load Balancer Controller
     ############################################################
@@ -341,7 +369,8 @@ def setup_aws_integrations(
                 },
                 "vpcId": target_vpc["id"],
                 "region": aws.get_region().name,
-                "podLabels": k8s_global_labels,
+                "podLabels": lb_controller_labels,
+                "additionalLabels": lb_controller_labels,
                 "tolerations": operations_tolerations,
                 # Sized for the cold-start Pod informer sync, not steady state.
                 # The controller builds a cluster-wide Pod cache (the "podInfo
@@ -404,7 +433,8 @@ def setup_aws_integrations(
             cleanup_on_fail=True,
             skip_await=True,
             values={
-                "podLabels": k8s_global_labels,
+                "podLabels": node_termination_labels,
+                "customLabels": node_termination_labels,
                 "serviceAccount": {
                     "labels": k8s_global_labels,
                 },

--- a/src/ol_infrastructure/infrastructure/aws/eks/cert_manager.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/cert_manager.py
@@ -7,7 +7,14 @@ from pulumi_eks import Cluster
 
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
 def setup_cert_manager(
@@ -21,6 +28,7 @@ def setup_cert_manager(
     k8s_global_labels: dict[str, str],
     operations_tolerations: list[dict[str, str]],
     versions: dict[str, str],
+    stack_info: StackInfo,
 ):
     """
     Configure and install cert-manager.
@@ -35,7 +43,18 @@ def setup_cert_manager(
     :param k8s_global_labels: A dictionary of global labels to apply to Kubernetes resources.
     :param operations_tolerations: A list of tolerations for scheduling on operations nodes.
     :param versions: A dictionary of component versions.
+    :param stack_info: Information about the current Pulumi stack.
     """
+    # The chart puts global.commonLabels on both the workload and the pod
+    # template of all three deployments, and on neither selector.
+    cert_manager_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.cert_manager,
+        component=Component.controller,
+        # A failed renewal has weeks of slack before a certificate expires.
+        alert_tier=AlertTier.notify,
+    )
     cert_manager_parliament_config = {
         "UNKNOWN_FEDERATION_SOURCE": {"ignore_locations": [{"principal": "federated"}]},
         "PERMISSIONS_MANAGEMENT_ACTIONS": {"ignore_locations": []},
@@ -136,7 +155,7 @@ def setup_cert_manager(
                     "keep": True,
                 },
                 "global": {
-                    "commonLabels": k8s_global_labels,
+                    "commonLabels": cert_manager_labels,
                 },
                 "resources": default_cert_manager_resources,
                 "tolerations": operations_tolerations,

--- a/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
@@ -7,7 +7,14 @@ from pulumi_eks import Cluster
 
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
 def setup_external_dns(
@@ -22,6 +29,7 @@ def setup_external_dns(
     operations_tolerations: list[dict[str, str]],
     versions: dict[str, str],
     eks_config: Config,
+    stack_info: StackInfo,
 ):
     """
     Configure and install external-dns.
@@ -37,7 +45,17 @@ def setup_external_dns(
     :param operations_tolerations: A list of tolerations for scheduling on operations nodes.
     :param versions: A dictionary of component versions.
     :param eks_config: The EKS configuration object.
+    :param stack_info: Information about the current Pulumi stack.
     """
+    external_dns_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.external_dns,
+        component=Component.controller,
+        # Records already published keep resolving while it is down; only
+        # new or changed hostnames stall.
+        alert_tier=AlertTier.notify,
+    )
     # Ref: https://github.com/kubernetes-sigs/external-dns
     # Ref: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md
     # Ref: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/sources/traefik-proxy.md
@@ -120,8 +138,8 @@ def setup_external_dns(
                 "image": {
                     "pullPolicy": "Always",
                 },
-                "commonLabels": k8s_global_labels,
-                "podLabels": k8s_global_labels,
+                "commonLabels": external_dns_labels,
+                "podLabels": external_dns_labels,
                 "tolerations": operations_tolerations,
                 "serviceAccount": {
                     "create": True,

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -6,7 +6,13 @@ from pulumi import Config, InvokeOptions, Output, ResourceOptions
 
 from bridge.lib.magic_numbers import AWS_LOAD_BALANCER_NAME_MAX_LENGTH
 from ol_infrastructure.lib.aws.eks_helper import ECR_DOCKERHUB_REGISTRY
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 from ol_infrastructure.lib.toolhive_telemetry import ships_telemetry
 
@@ -103,7 +109,17 @@ def setup_traefik(
                     "pullPolicy": "Always",
                     "registry": f"{ECR_DOCKERHUB_REGISTRY}/library",
                 },
-                "commonLabels": k8s_global_labels,
+                # commonLabels reaches both the workload and the pod template
+                # in chart 41.x, and neither selector.
+                "commonLabels": cluster_addon_labels(
+                    base_labels=k8s_global_labels,
+                    stack_info=stack_info,
+                    service=Services.traefik,
+                    component=Component.gateway,
+                    # The shared ingress. Everything behind it is unreachable
+                    # while it is down.
+                    alert_tier=AlertTier.page,
+                ),
                 "tolerations": operations_tolerations,
                 "deployment": {
                     "kind": "Deployment",

--- a/src/ol_infrastructure/infrastructure/aws/eks/vault_secrets_operator.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/vault_secrets_operator.py
@@ -8,6 +8,12 @@ import pulumi_vault as vault
 from pulumi import ResourceOptions, export
 from pulumi_eks import Cluster
 
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
@@ -101,13 +107,27 @@ def setup_vault_secrets_operator(
                 "image": {
                     "pullPolicy": "IfNotPresent",
                 },
-                "extraLabels": k8s_global_labels,
                 "defaultVaultConnection": {
                     "enabled": True,
                     "address": f"https://vault-{stack_info.env_suffix}.odl.mit.edu",
                     "skipTLSVerify": False,
                 },
                 "controller": {
+                    # The chart has no top-level extraLabels, which is where
+                    # this release used to pass the labels: unrecognized values
+                    # are not an error in Helm, so they were silently dropped
+                    # and the operator's pod carried none of them. The
+                    # controller-scoped key reaches the pod template only, not
+                    # the immutable selector.
+                    "extraLabels": cluster_addon_labels(
+                        base_labels=k8s_global_labels,
+                        stack_info=stack_info,
+                        service=Services.vault_secrets_operator,
+                        component=Component.controller,
+                        # Already-synced Secrets stay valid; new syncs and
+                        # rotations stall, which breaks pod starts within hours.
+                        alert_tier=AlertTier.notify,
+                    ),
                     "replicas": 1,
                     "tolerations": operations_tolerations,
                     "manager": {

--- a/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
@@ -17,6 +17,14 @@ import pulumi_eks as eks
 import pulumi_kubernetes as kubernetes
 from pulumi import ResourceOptions
 
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
 
 def setup_vpa(
     cluster_name: str,
@@ -26,6 +34,7 @@ def setup_vpa(
     k8s_global_labels: dict[str, str],
     operations_tolerations: list[dict[str, str]],
     versions: dict[str, str],
+    stack_info: StackInfo,
 ) -> kubernetes.helm.v3.Release:
     """
     Install the Vertical Pod Autoscaler as a core cluster capability.
@@ -38,8 +47,19 @@ def setup_vpa(
     :param operations_tolerations: Tolerations for scheduling on
         operations-tainted nodes.
     :param versions: A dictionary of component versions keyed by component name.
+    :param stack_info: Information about the current Pulumi stack.
     :returns: The Helm Release resource, for use as a dependency by VPA objects.
     """
+
+    def vpa_labels(component: Component, alert_tier: AlertTier) -> dict[str, str]:
+        return cluster_addon_labels(
+            base_labels=k8s_global_labels,
+            stack_info=stack_info,
+            service=Services.vertical_pod_autoscaler,
+            component=component,
+            alert_tier=alert_tier,
+        )
+
     # Per-component resource tuning, sized from measured usage rather than the
     # earlier guess that these are "lightweight control-plane processes".
     #
@@ -83,10 +103,14 @@ def setup_vpa(
                 repo="https://kubernetes.github.io/autoscaler",
             ),
             values={
-                "commonLabels": k8s_global_labels,
+                # commonLabels reaches the three workload objects but not
+                # their pod templates, so each component also gets podLabels.
+                "commonLabels": vpa_labels(Component.controller, AlertTier.ticket),
                 "admissionController": {
                     "enabled": True,
                     "replicas": 2,
+                    # failurePolicy is Ignore below, so pods still start.
+                    "podLabels": vpa_labels(Component.webhook, AlertTier.notify),
                     "tolerations": operations_tolerations,
                     # Peak observed 176Mi at 8.5k pods, against a 200Mi ceiling.
                     "resources": {
@@ -115,6 +139,7 @@ def setup_vpa(
                 "recommender": {
                     "enabled": True,
                     "replicas": 1,
+                    "podLabels": vpa_labels(Component.controller, AlertTier.ticket),
                     "tolerations": operations_tolerations,
                     # Heaviest of the three: it keeps usage histograms and
                     # checkpoints on top of the informer caches. Peak observed
@@ -130,6 +155,7 @@ def setup_vpa(
                 "updater": {
                     "enabled": True,
                     "replicas": 1,
+                    "podLabels": vpa_labels(Component.controller, AlertTier.ticket),
                     "tolerations": operations_tolerations,
                     # InPlaceOrRecreate (in-place resize, falls back to eviction)
                     # was promoted to GA and enabled by default in VPA 1.6, so no

--- a/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
@@ -51,7 +51,9 @@ def setup_vpa(
     :returns: The Helm Release resource, for use as a dependency by VPA objects.
     """
 
-    def vpa_labels(component: Component, alert_tier: AlertTier) -> dict[str, str]:
+    def vpa_labels(
+        component: Component | None = None, alert_tier: AlertTier | None = None
+    ) -> dict[str, str]:
         return cluster_addon_labels(
             base_labels=k8s_global_labels,
             stack_info=stack_info,
@@ -105,7 +107,13 @@ def setup_vpa(
             values={
                 # commonLabels reaches the three workload objects but not
                 # their pod templates, so each component also gets podLabels.
-                "commonLabels": vpa_labels(Component.controller, AlertTier.ticket),
+                # Service only: one key covers all three Deployments, and the
+                # admission controller does not share the other two's role or
+                # tier. Phase 3 joins Deployment-level alerts through
+                # kube_deployment_labels, so a shared component/alert_tier here
+                # would confidently mis-tier that one; absent labels fall
+                # through to the severity catch-all instead.
+                "commonLabels": vpa_labels(),
                 "admissionController": {
                     "enabled": True,
                     "replicas": 2,

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -342,8 +342,8 @@ def cluster_addon_labels(
     base_labels: dict[str, str],
     stack_info: StackInfo,
     service: Services,
-    component: Component,
-    alert_tier: AlertTier,
+    component: Component | None = None,
+    alert_tier: AlertTier | None = None,
 ) -> dict[str, str]:
     """Label a cluster addon's workloads so its alerts can be routed.
 
@@ -359,6 +359,13 @@ def cluster_addon_labels(
     Which Helm value to feed the result to is chart-specific and has to be one
     that does NOT reach `spec.selector` -- a Deployment selector is immutable,
     so a label that lands there forces a delete-and-recreate of the addon.
+
+    `component` and `alert_tier` are optional because several charts expose a
+    single label key covering workloads that do not share a role: one
+    `commonLabels` for all three VPA Deployments, for instance. Omit whichever
+    of the two is not true of every workload the key reaches. A missing tier
+    routes on the `severity` catch-all, i.e. today's behaviour; a wrong tier
+    routes confidently to the wrong place.
 
     :param base_labels: The program's shared label dict, merged in last.
     :param stack_info: Supplies the stack and environment labels.

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -100,6 +100,22 @@ class Services(StrEnum):
 
     airbyte = "airbyte"
     superset = "superset"
+    # Cluster addons. They are deployable units we page about the same way an
+    # application is, even though nobody here wrote the code: an unlabeled
+    # addon is exactly the workload whose alert cannot be routed.
+    apisix = "apisix"
+    aws_load_balancer_controller = "aws-load-balancer-controller"
+    aws_node_termination_handler = "aws-node-termination-handler"
+    cert_manager = "cert-manager"
+    dcgm_exporter = "dcgm-exporter"
+    external_dns = "external-dns"
+    karpenter = "karpenter"
+    keda = "keda"
+    metrics_server = "metrics-server"
+    traefik = "traefik"
+    vantage_agent = "vantage-agent"
+    vault_secrets_operator = "vault-secrets-operator"  # pragma: allowlist secret
+    vertical_pod_autoscaler = "vertical-pod-autoscaler"
     celery_monitoring = "celery-monitoring"
     clickhouse = "clickhouse"
     codejail = "codejail"
@@ -219,11 +235,14 @@ class Component(StrEnum):
     cannot collide with a bare `component` set by a vendor integration.
     """
 
+    agent = "agent"
     api = "api"
     beat = "beat"
     cache = "cache"
     celery = "celery"
+    controller = "controller"
     database = "database"
+    exporter = "exporter"
     frontend = "frontend"
     gateway = "gateway"
     ingress = "ingress"
@@ -233,6 +252,7 @@ class Component(StrEnum):
     queue = "queue"
     search = "search"
     webapp = "webapp"
+    webhook = "webhook"
     worker = "worker"
 
 
@@ -315,6 +335,49 @@ class K8sAppLabels(K8sGlobalLabels):
     pod_security_group: str | None = None
     commit_sha: str | None = None
     release_tag: str | None = None
+
+
+def cluster_addon_labels(
+    *,
+    base_labels: dict[str, str],
+    stack_info: StackInfo,
+    service: Services,
+    component: Component,
+    alert_tier: AlertTier,
+) -> dict[str, str]:
+    """Label a cluster addon's workloads so its alerts can be routed.
+
+    Addons are installed from third-party Helm charts, so they never construct a
+    label model of their own and land in the alerting hierarchy as unlabeled --
+    which is how APISIX, cert-manager and the shared ingress, the widest blast
+    radius in the estate, ended up with nothing for Rootly to route on.
+
+    The base labels win on conflict: `k8s_global_labels` already carries a
+    stack identity in some programs, and rewriting it would churn every pod
+    template for a value that means the same thing.
+
+    Which Helm value to feed the result to is chart-specific and has to be one
+    that does NOT reach `spec.selector` -- a Deployment selector is immutable,
+    so a label that lands there forces a delete-and-recreate of the addon.
+
+    :param base_labels: The program's shared label dict, merged in last.
+    :param stack_info: Supplies the stack and environment labels.
+    :param service: The addon, as its own deployable unit.
+    :param component: Its functional role, the paging discriminator.
+    :param alert_tier: How far an alert about it may escalate.
+    """
+    return (
+        K8sGlobalLabels(
+            # Platform engineering owns the addons in every cluster, so the OU
+            # is not the tenant whose cluster the addon happens to run in.
+            ou=BusinessUnit.operations,
+            service=service,
+            stack=stack_info,
+            component=component,
+            alert_tier=alert_tier,
+        ).model_dump()
+        | base_labels
+    )
 
 
 class AWSBase(BaseModel):

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -21,7 +21,13 @@ from ol_infrastructure.components.services.vault import (
     OLVaultK8SStaticSecretConfig,
 )
 from ol_infrastructure.lib import pulumi_projects as projects
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
 from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
     parse_stack,
@@ -236,6 +242,14 @@ if cluster_stack.require_output("has_ebs_storage"):
         ),
     )
 
+    vantage_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.vantage_agent,
+        component=Component.agent,
+        # Cost telemetry. A gap in it is a reporting problem, not an outage.
+        alert_tier=AlertTier.ticket,
+    )
     vantage_k8s_agent_release = kubernetes.helm.v3.Release(
         f"{cluster_name}-vantage-k8s-agent-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
@@ -248,6 +262,8 @@ if cluster_stack.require_output("has_ebs_storage"):
                 repo="https://vantage-sh.github.io/helm-charts",
             ),
             values={
+                "appLabels": vantage_labels,
+                "podLabels": vantage_labels,
                 "agent": {
                     "secret": {
                         "name": vantage_api_token_secret_name,
@@ -338,6 +354,7 @@ setup_karpenter(
     k8s_provider=k8s_provider,
     aws_account=aws_account,
     k8s_global_labels=k8s_global_labels,
+    stack_info=stack_info,
 )
 
 ############################################################
@@ -350,12 +367,15 @@ setup_keda(
     aws_config=aws_config,
     k8s_provider=k8s_provider,
     k8s_global_labels=k8s_global_labels,
+    stack_info=stack_info,
 )
 
 # Setup NVIDIA GPU resources
 setup_nvidia(
     cluster_name=cluster_name,
     k8s_provider=k8s_provider,
+    k8s_global_labels=k8s_global_labels,
+    stack_info=stack_info,
     nvidia_dcgm_exporter_version=VERSIONS["NVIDIA_DCGM_EXPORTER_VERSION"],
     nvidia_k8s_device_plugin_version=VERSIONS["NVIDIA_K8S_DEVICE_PLUGIN_VERSION"],
 )

--- a/src/ol_infrastructure/substructure/aws/eks/karpenter.py
+++ b/src/ol_infrastructure/substructure/aws/eks/karpenter.py
@@ -12,7 +12,14 @@ from bridge.lib.versions import KARPENTER_CHART_VERSION
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
 from ol_infrastructure.lib.aws.ec2_helper import InstanceClasses, InstanceTypes
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 from ol_infrastructure.substructure.aws.eks.karpenter_iam import (
     get_cluster_karpenter_iam_policy_document,
 )
@@ -41,6 +48,7 @@ def setup_karpenter(  # noqa: PLR0913
     k8s_provider: kubernetes.Provider,
     aws_account: aws.GetCallerIdentityResult,
     k8s_global_labels: dict[str, str],
+    stack_info: StackInfo,
 ):
     """
     Set up Karpenter resources including SQS queue, EventBridge rules, IAM roles/policies,
@@ -53,7 +61,17 @@ def setup_karpenter(  # noqa: PLR0913
         k8s_provider: The Pulumi Kubernetes provider instance.
         aws_account: The AWS caller identity result.
         k8s_global_labels: A dictionary of global labels to apply to Kubernetes resources.
+        stack_info: Information about the current Pulumi stack.
     """
+    karpenter_labels = cluster_addon_labels(
+        base_labels=k8s_global_labels,
+        stack_info=stack_info,
+        service=Services.karpenter,
+        component=Component.controller,
+        # Nothing provisions capacity while it is down, so a scale-up or a
+        # node replacement stalls until someone notices.
+        alert_tier=AlertTier.page,
+    )
     # Karpenter Interruption Queue
     karpenter_interruption_queue = aws.sqs.Queue(
         f"{cluster_name}-karpenter-interruption-queue",
@@ -255,6 +273,10 @@ def setup_karpenter(  # noqa: PLR0913
                 "serviceMonitor": {
                     "enabled": False,  # works TOO well, need to find a good way to reduce # of metrics
                 },
+                # podLabels reaches the pod template, additionalLabels the
+                # Deployment; the selector is name+instance and untouched.
+                "podLabels": karpenter_labels,
+                "additionalLabels": karpenter_labels,
                 "controller": {
                     "resources": {
                         "requests": {

--- a/src/ol_infrastructure/substructure/aws/eks/keda.py
+++ b/src/ol_infrastructure/substructure/aws/eks/keda.py
@@ -39,7 +39,7 @@ def setup_keda(
         stack_info: Information about the current Pulumi stack.
     """
 
-    def keda_labels(component: Component) -> dict[str, str]:
+    def keda_labels(component: Component | None = None) -> dict[str, str]:
         return cluster_addon_labels(
             base_labels=k8s_global_labels,
             stack_info=stack_info,
@@ -102,6 +102,13 @@ def setup_keda(
             cleanup_on_fail=True,
             skip_await=True,
             values={
+                # additionalLabels is the chart's only workload-object key,
+                # and one map covers all three Deployments -- so it carries the
+                # service and the tier, which they share, and no component,
+                # which they do not. Without it the Deployment-level rules
+                # (DeploymentReplicasMissing, DeploymentUnavailable) would join
+                # against nothing for KEDA.
+                "additionalLabels": keda_labels(),
                 # The chart keys podLabels by component, so each of the three
                 # pods can carry the role it actually plays.
                 "podLabels": {

--- a/src/ol_infrastructure/substructure/aws/eks/keda.py
+++ b/src/ol_infrastructure/substructure/aws/eks/keda.py
@@ -6,7 +6,14 @@ from pulumi import Output, ResourceOptions, StackReference, export
 from bridge.lib.magic_numbers import DEFAULT_HTTPS_PORT, DEFAULT_KEDA_PORT
 from bridge.lib.versions import KEDA_CHART_VERSION
 from ol_infrastructure.lib.aws.eks_helper import default_psg_egress_args
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    AWSBase,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
 def setup_keda(
@@ -16,6 +23,7 @@ def setup_keda(
     aws_config: AWSBase,
     k8s_provider: kubernetes.Provider,
     k8s_global_labels: dict[str, str],
+    stack_info: StackInfo,
 ):
     """
     Set up KEDA (Kubernetes Event Driven Autoscaling) resources including security group,
@@ -28,7 +36,19 @@ def setup_keda(
         aws_config: The AWS configuration object containing tags.
         k8s_provider: The Pulumi Kubernetes provider instance.
         k8s_global_labels: A dictionary of global labels to apply to Kubernetes resources.
+        stack_info: Information about the current Pulumi stack.
     """
+
+    def keda_labels(component: Component) -> dict[str, str]:
+        return cluster_addon_labels(
+            base_labels=k8s_global_labels,
+            stack_info=stack_info,
+            service=Services.keda,
+            component=component,
+            # Autoscaling stops; replica counts hold where they are.
+            alert_tier=AlertTier.notify,
+        )
+
     keda_security_group = aws.ec2.SecurityGroup(
         f"{cluster_name}-keda-security-group",
         description="Security group for KEDA operator",
@@ -82,16 +102,15 @@ def setup_keda(
             cleanup_on_fail=True,
             skip_await=True,
             values={
+                # The chart keys podLabels by component, so each of the three
+                # pods can carry the role it actually plays.
                 "podLabels": {
-                    "keda": {
-                        "ol.mit.edu/pod-security-group": keda_security_group.id,
-                    },
-                    "metricsAdapter": {
-                        "ol.mit.edu/pod-security-group": keda_security_group.id,
-                    },
-                    "webhooks": {
-                        "ol.mit.edu/pod-security-group": keda_security_group.id,
-                    },
+                    "keda": keda_labels(Component.controller)
+                    | {"ol.mit.edu/pod-security-group": keda_security_group.id},
+                    "metricsAdapter": keda_labels(Component.api)
+                    | {"ol.mit.edu/pod-security-group": keda_security_group.id},
+                    "webhooks": keda_labels(Component.webhook)
+                    | {"ol.mit.edu/pod-security-group": keda_security_group.id},
                 },
                 "resources": {
                     # The operator's informer caches scale with total cluster

--- a/src/ol_infrastructure/substructure/aws/eks/nvidia.py
+++ b/src/ol_infrastructure/substructure/aws/eks/nvidia.py
@@ -6,11 +6,20 @@ from bridge.lib.versions import (
     NVIDIA_DCGM_EXPORTER_CHART_VERSION,
     NVIDIA_K8S_DEVICE_PLUGIN_CHART_VERSION,
 )
+from ol_infrastructure.lib.ol_types import (
+    AlertTier,
+    Component,
+    Services,
+    cluster_addon_labels,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
-def setup_nvidia(
+def setup_nvidia(  # noqa: PLR0913
     cluster_name: str,
     k8s_provider: kubernetes.Provider,
+    k8s_global_labels: dict[str, str],
+    stack_info: StackInfo,
     nvidia_dcgm_exporter_version: str = NVIDIA_DCGM_EXPORTER_CHART_VERSION,
     nvidia_k8s_device_plugin_version: str = NVIDIA_K8S_DEVICE_PLUGIN_CHART_VERSION,
 ):
@@ -21,6 +30,8 @@ def setup_nvidia(
     Args:
         cluster_name: The name of the EKS cluster.
         k8s_provider: The Pulumi Kubernetes provider instance.
+        k8s_global_labels: The program's shared label dict.
+        stack_info: Information about the current Pulumi stack.
         nvidia_dcgm_exporter_version: The version of the NVIDIA DCGM exporter chart.
         nvidia_k8s_device_plugin_version: The version of the NVIDIA k8s device plugin chart.
     """
@@ -164,6 +175,14 @@ def setup_nvidia(
                 "nodeSelector": {
                     "ol.mit.edu/gpu_node": "true",
                 },
+                "podLabels": cluster_addon_labels(
+                    base_labels=k8s_global_labels,
+                    stack_info=stack_info,
+                    service=Services.dcgm_exporter,
+                    component=Component.exporter,
+                    # GPU telemetry. Nothing user-facing depends on it.
+                    alert_tier=AlertTier.ticket,
+                ),
                 "serviceMonitor": {
                     "enabled": False,
                 },

--- a/tests/ol_infrastructure/lib/test_ol_types.py
+++ b/tests/ol_infrastructure/lib/test_ol_types.py
@@ -13,6 +13,7 @@ from ol_infrastructure.lib.ol_types import (
     K8sGlobalLabels,
     Product,
     Services,
+    cluster_addon_labels,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -161,3 +162,58 @@ def test_app_labels_sanitize_the_source_repository(stack_info):
         source_repository="https://github.com/mitodl/mit-learn",
     ).model_dump()
     assert labels["ol.mit.edu/source_repository"] == "github.com_mitodl_mit-learn"
+
+
+def test_addon_labels_render_the_full_routing_set(stack_info):
+    labels = cluster_addon_labels(
+        base_labels={"pulumi_managed": "true"},
+        stack_info=stack_info,
+        service=Services.cert_manager,
+        component=Component.controller,
+        alert_tier=AlertTier.notify,
+    )
+    assert labels == {
+        # Platform engineering owns the addons, whatever cluster they run in.
+        "ol.mit.edu/ou": "operations",
+        "ol.mit.edu/service": "cert-manager",
+        "ol.mit.edu/component": "controller",
+        "ol.mit.edu/alert_tier": "notify",
+        "ol.mit.edu/stack": "ol-application-example.QA",
+        "ol.mit.edu/environment": "qa",
+        "pulumi_managed": "true",
+    }
+
+
+def test_addon_labels_omit_a_role_the_caller_cannot_state(stack_info):
+    """A chart key covering several roles publishes only what is true of all.
+
+    The VPA and KEDA charts each expose one label key that reaches Deployments
+    with different roles and, for VPA, different tiers. Emitting a shared
+    component or tier there would mis-route the odd one out; emitting neither
+    leaves those workloads on the severity catch-all.
+    """
+    labels = cluster_addon_labels(
+        base_labels={},
+        stack_info=stack_info,
+        service=Services.vertical_pod_autoscaler,
+    )
+    assert "ol.mit.edu/component" not in labels
+    assert "ol.mit.edu/alert_tier" not in labels
+    assert labels["ol.mit.edu/service"] == "vertical-pod-autoscaler"
+
+
+def test_addon_labels_never_overwrite_the_program_labels(stack_info):
+    """The base dict wins, so a shared label keeps the value it already had.
+
+    substructure/aws/eks sets its own ol.mit.edu/stack; rewriting it would
+    churn every addon's pod template for a value that means the same thing.
+    """
+    labels = cluster_addon_labels(
+        base_labels={"ol.mit.edu/stack": "substructure.aws.eks.operations.Production"},
+        stack_info=stack_info,
+        service=Services.karpenter,
+        component=Component.controller,
+        alert_tier=AlertTier.page,
+    )
+    assert labels["ol.mit.edu/stack"] == "substructure.aws.eks.operations.Production"
+    assert labels["ol.mit.edu/alert_tier"] == "page"


### PR DESCRIPTION
## What are the relevant tickets?

Phase 2 step P2.C of `docs/plans/rootly-label-routing-implementation-spec.md` — the `operations-production` half of the label backfill that Phase 3's PromQL joins depend on. Follows #5514 and #5542.

## Description

`alert_tier` was at zero across the estate and `operations-production` was the worst-covered cluster: 7 of its 66 Deployments/StatefulSets/DaemonSets carried `ol.mit.edu/service`, none carried `component` or `alert_tier`. Every workload there comes from a third-party Helm chart, so none of them constructs a label model and none of them was reachable by a constructor-shaped check.

Twelve charts now get `service`, `component` and `alert_tier` on their **pod templates**, which is what `kube_pod_labels` reads and what §4.2's `group_left` joins against, plus the workload object where the chart offers a second key.

The values key is per chart and had to be found rather than assumed. It must land on the pod template and must **not** land in `spec.selector`: a Deployment selector is immutable, so a label that reaches it forces a delete-and-recreate of the addon rather than a rolling restart. Each key was picked by rendering the chart at its pinned version with a sentinel label and checking where the sentinel came out; the per-chart table is in the spec.

Three things fell out of doing it:

- **vault-secrets-operator was labeling nothing.** It passed the shared label dict to a top-level `extraLabels`, which that chart does not define — only `controller.extraLabels`. Helm does not error on unrecognized values, so the labels were dropped silently for as long as that line has existed.
- **APISIX and nvidia-device-plugin cannot be labeled through their charts at all.** Both expose only a `selectorLabelsOverride`-style value that *replaces* the selector labels, and the same helper feeds the selector and the pod template. APISIX is the widest-blast-radius workload in the estate; it needs the `DeploymentPatch` route `core_dns.py` already uses, which is deliberately not in this PR.
- **EKS-managed addons are not Helm releases** (`aws-node`, `kube-proxy`, `coredns`, the CSI drivers, the GuardDuty agent), so they need patching too, and a patch may not survive an addon upgrade — untested.

`operations-production` goes from 7/66 with `service` alone to 18/66 carrying all three.

### Tiers assigned, for review

These are judgment calls and the reason this is worth a careful read:

| Addon | Component | Tier | Why |
|---|---|---|---|
| traefik | gateway | page | shared ingress; everything behind it is unreachable |
| aws-load-balancer-controller | controller | page | per the note already in `aws_utils.py`, its webhooks are `failurePolicy: Fail` with no namespace selector, so losing the last replica blocks Service/TargetGroupBinding admission cluster-wide. I could not re-verify this one directly — the shared readonly role cannot list webhook configurations |
| karpenter | controller | page | nothing provisions capacity; scale-ups stall |
| cert-manager | controller | notify | a failed renewal has weeks before expiry |
| external-dns | controller | notify | published records keep resolving |
| vault-secrets-operator | controller | notify | synced Secrets stay valid; rotations stall |
| metrics-server | api | notify | HPAs go blind, nothing sheds traffic |
| keda | controller / api / webhook | notify | replica counts hold where they are |
| aws-node-termination-handler | agent | notify | reclaims stop draining gracefully |
| vpa admission controller | webhook | notify | `failurePolicy: Ignore`, so pods still start |
| vpa recommender/updater | controller | ticket | recommendations only |
| vantage agent | agent | ticket | cost telemetry |
| dcgm-exporter | exporter | ticket | GPU telemetry |

`Component` gains `agent`, `controller`, `exporter` and `webhook` — the roles platform workloads actually play, which the enum had no member for.

## How can this be tested?

`pulumi preview` on both `operations.Production` stacks:

- `ol-infrastructure-eks`: 10 to update, **0 replacements**, 149 unchanged. Eight are the Helm releases here. The other two — the `worker-xlarge` launch template `imageId`, and in the substructure stack the `EC2NodeClass` `al2023@` alias — are pre-existing AMI drift rather than anything in this diff, but an apply picks them up, so they are worth knowing about first.
- `ol-substructure-eks`: 5 to update, 0 replacements, 43 unchanged.

`uv run pytest tests/` → 919 passed. The pre-commit `ruff format`, `ruff check` and `mypy` hooks pass on the commit; the two findings from a whole-directory mypy run (`core_dns.py` `DeploymentPatch` overload, `keda.py` `Output[dict]`) sit on pre-existing lines this PR does not touch.

Applying is a rolling restart of each addon, the shared ingress included, so it wants a deliberate window rather than a drive-by apply.

## Additional context

The labels do not reach Mimir yet regardless — both kube-state-metrics gates (§0.2 of the spec) are still closed. Re-checked today: `count(kube_pod_labels) or vector(-1)` returns `-1` against the production Prometheus datasource. This is the input side; Phase 3 opens the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ8w3jhjmNVmfBCL8NVSzy
