### PR TITLE
feat(opensearch): lift CI and QA open_metadata domains to 3.5

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.open_metadata.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.open_metadata.CI.yaml
@@ -11,6 +11,6 @@ config:
   opensearch:domain_name: "omdci"
   opensearch:cluster_size: "3"
   opensearch:disk_size_gb: "60"
-  opensearch:engine_version: "OpenSearch_3.3"
+  opensearch:engine_version: "OpenSearch_3.5"
   opensearch:public_web: "false"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.open_metadata.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.open_metadata.QA.yaml
@@ -11,6 +11,6 @@ config:
   opensearch:domain_name: "omdq"
   opensearch:cluster_size: "3"
   opensearch:disk_size_gb: "60"
-  opensearch:engine_version: "OpenSearch_3.3"
+  opensearch:engine_version: "OpenSearch_3.5"
   opensearch:public_web: "false"
   opensearch:secured_cluster: "true"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Changes `opensearch:engine_version` from `OpenSearch_3.3` to `OpenSearch_3.5` on the two non-production OpenMetadata search stacks — `Pulumi.open_metadata.CI.yaml` (domain `opensearch-omdci`) and `Pulumi.open_metadata.QA.yaml` (domain `opensearch-omdq`). [`__main__.py:165`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py#L165) reads `search_config.get("engine_version")`, so the per-stack yaml value is the only thing that needs to change. Production (`opensearch-omdp`) is deliberately left on 3.3 and follows separately.

This closes a support-posture gap, not a functional prerequisite. Two points a reviewer should weigh:

- **It is not required for the OpenMetadata 2.0 upgrade** (#5646), and is intentionally decoupled from it. OM 2.0's 3.3.2 minimum is a compatibility-matrix docs entry rather than an enforced gate; a code search over the OpenMetadata Java source returns no hits for a `3.3.2` literal or for `clusterVersion`. An earlier analysis session also established that the k-NN mapping OM 2.0 writes is already live and serving on the 3.3.0 QA cluster — I have not re-measured that here. An in-place, one-way domain upgrade should not share a change window with a major application upgrade.
- **3.5 rather than 3.7** because OM 2.0 ships a shaded OpenSearch `RestHighLevelClient` pinned at 2.6.0 — `<opensearch.version>2.6.0</opensearch.version>` in the root `pom.xml`, byte-identical to 1.13.4's, so the client did not move in this release — and upstream documents no testing above 3.3.x. One family jump keeps the untested client-to-cluster gap as small as possible. `get-compatible-versions` confirms both 3.5 and 3.7 are direct in-place targets from 3.3, so 3.7 remains available later without a stepping stone.

### How can this be tested?
Checked against live AWS (`us-east-1`) and previewed before opening:

- `aws opensearch get-compatible-versions --domain-name opensearch-omdq` returns `SourceVersion: OpenSearch_3.3` → `TargetVersions: ["OpenSearch_3.5", "OpenSearch_3.7"]`. 3.5 is a direct in-place target; no stepping stone.
- Both domains are idle and ready: `opensearch-omdci` and `opensearch-omdq` each report `EngineVersion: OpenSearch_3.3`, `Processing: false`, `UpgradeProcessing: false`.
- `pulumi preview --stack open_metadata.QA` — `1 to update, 3 unchanged`, a plain in-place `engineVersion: "OpenSearch_3.3" => "OpenSearch_3.5"`. **No replacement**, which is the thing that matters here: a replace would destroy the domain.
- `pulumi preview --stack open_metadata.CI` — same, `1 to update, 3 unchanged`.
- `pre-commit run` on both files passes (check-yaml, yamllint, YAML formatter, detect-secrets).

I have not run `pulumi up`. Post-upgrade verification for whoever does: OM UI search returns results, the Explore page paginates, semantic search still returns vector hits (record the `data_asset_embeddings_chunks` doc count immediately before the upgrade and check it survives — it was measured at 1317 in an earlier session, but take a fresh count rather than trusting that number), and no OpenSearch client errors in the OM server logs.

### Additional Context
**AWS in-place OpenSearch upgrades are one-way.** The fallback is a restore from snapshot, not a downgrade. Both domains are 3 x `t3.medium.search`, zone-aware, with no dedicated master nodes, so this is a rolling upgrade on the data nodes themselves; expect degraded search performance during it. Automated snapshots run at hour 0 UTC on `opensearch-omdq`.

Both domains also have a pending AWS service-software update — currently `OpenSearch_3_3_R20260626`, with `OpenSearch_3_3_R20260720-P1` available, about a month behind production. Applying it does **not** move the engine number off 3.3.0, so it is not a substitute for this change, but it is worth applying as part of the same maintenance pass.

### Checklist:
- [ ] Confirm automated snapshot state on `opensearch-omdci` and `opensearch-omdq` before running `pulumi up`
- [ ] Apply the pending `OpenSearch_3_3_R20260720-P1` service-software update
- [ ] Run `pulumi up` on `open_metadata.CI`, verify, then `open_metadata.QA`
- [ ] Open the follow-up for `opensearch-omdp` only after CI and QA have soaked, and not in the same change window as the production OM 2.0 deploy
