### PR TITLE
feat(github): DX-07 fires on stale forks with fork-specific remediation

### DIFF
--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -530,11 +530,20 @@ RULES: tuple[Rule, ...] = (
         "low",
         "active",
         "no push in 12+ months -- archive candidate",
+        # Fires on forks too, deliberately: a fork nobody has synced in a year is as
+        # much a stale-mirror signal as an OL-owned repo is an archive candidate --
+        # exempting forks entirely (the CON-03/SEC-01 pattern) would hide the 58 of 74
+        # 2026-08-24 findings that are forks, and "upstream may itself be abandoned" is
+        # a real question worth surfacing, not noise. What differs is the remediation:
+        # a fork is not ours to archive on staleness alone, so the wording says "check
+        # upstream" rather than "archive it".
         lambda r: (
             (
                 f"last push {r.get('_pushed_at', '?')[:10]}",
-                "active development",
-                "archive it",
+                "active development, or an explicit `archived` archetype",
+                "check whether upstream is still maintained; archive the mirror if not"
+                if r.get("archetype") == "fork"
+                else "archive it",
             )
             if _is_stale(r)
             else None

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -154,6 +154,28 @@ def test_con03_exempts_forks_and_archived() -> None:
     assert "CON-03" in fired([repo(archetype="library", default_branch="master")])
 
 
+def test_dx07_fires_on_stale_forks_too_but_with_different_remediation() -> None:
+    """Unlike CON-03/SEC-01, DX-07 does not exempt forks -- 58 of the 74 stale active
+    repos measured 2026-08-24 are forks, and a fork nobody has synced in a year is a
+    real signal (upstream may itself be dormant), not noise. What has to differ is the
+    remediation: a fork is not ours to archive on staleness alone.
+    """
+    stale_fork = repo(
+        name="stale-fork", archetype="fork", _pushed_at="2020-01-01T00:00:00Z"
+    )
+    stale_owned = repo(
+        name="stale-owned", archetype="library", _pushed_at="2020-01-01T00:00:00Z"
+    )
+    findings = {
+        f.repo: f
+        for f in audit.evaluate([stale_fork, stale_owned])
+        if f.rule_id == "DX-07"
+    }
+    assert findings["stale-owned"].remediation == "archive it"
+    assert findings["stale-fork"].remediation != "archive it"
+    assert "upstream" in findings["stale-fork"].remediation
+
+
 def test_archived_repos_are_out_of_scope_for_active_rules() -> None:
     """An archived repo must not be reported for things nobody can change on it."""
     archived = repo(archived=True, topics=[], description=None, allow_auto_merge=False)


### PR DESCRIPTION
### What are the relevant tickets?
N/A — witan task `tk-dx-07-74-active-repos-have-had-no-push-in-12-mon-bdeb65`, part of the [mitodl GitHub org import project](https://github.com/mitodl/ol-infrastructure/blob/main/docs/plans/github-org-pulumi-import.md).

### Description (What does it do?)
DX-07 flags active repos with no push in 12+ months as archive candidates. Re-running the audit today shows 74 repos fire it — but 58 of those are forks (`archetype: fork`), not OL-owned repos, and "archive it" is the wrong instruction for a fork whose staleness may just mean upstream itself went quiet.

- `audit.py`: DX-07 now checks `archetype` and returns fork-specific remediation ("check whether upstream is still maintained; archive the mirror if not") instead of "archive it" for repos with `archetype: fork`. It deliberately still fires on forks — blanket-exempting them the way CON-03/SEC-01 do would have hidden 58 of the 74 findings instead of just relabeling them.
- Adds a test (`test_dx07_fires_on_stale_forks_too_but_with_different_remediation`) asserting both fork and non-fork stale repos fire, with different remediation text.

No Pulumi/live-state changes — this is audit-tooling logic only.

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/saas/github/test_audit.py -q` — 46 tests pass, including the new one.
- `uv run pre-commit run --files src/ol_infrastructure/saas/github/audit.py tests/ol_infrastructure/saas/github/test_audit.py` — all hooks (ruff, mypy, etc.) pass.
- `uv run bin/github-estate-audit run --axis developer-experience --json` against the committed `data/repos/` — DX-07 still fires 74 times; spot-checked `XBlock` (fork) now reads "check whether upstream is still maintained…" while `dagster` (also a fork of `dagster-io/dagster`, per its committed `description`/`homepage`) gets the same fork wording, and a non-fork stale repo still reads "archive it".

### Additional Context
This does not decide which of the 74 repos actually get archived — that stays a per-repo owner decision per the task (`SEC-15`/`SEC-06`-style reviewed wave), unchanged by this PR. It only fixes the remediation text so the audit report doesn't tell someone to archive a fork on staleness alone.