### PR TITLE
fix(open-metadata): wrap comment lines over 88 chars, unbreak trunk ruff-check

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -716,11 +716,12 @@ open_metadata_application = kubernetes.helm.v3.Release(
             # Hybrid search is automatic when SEMANTIC_SEARCH_ENABLED=true; there is no
             # per-query semanticSearch flag. Run the Search Index App after upgrading
             # to populate vector fields in OpenSearch.
-            # 2.0 moved the embedding settings out of naturalLanguageSearch: provider/model
-            # now live under llmConfiguration.embeddings, while credentials live under
-            # llmConfiguration.bedrock.awsConfig. Every env var name below remains except
-            # AWS_BEDROCK_REGION. llmConfiguration's own `enabled` flag gates only the
-            # chat/completion client, not embeddings, so semantic search needs no LLM_* vars.
+            # 2.0 moved the embedding settings out of naturalLanguageSearch:
+            # provider/model now live under llmConfiguration.embeddings, while
+            # credentials live under llmConfiguration.bedrock.awsConfig. Every env var
+            # name below remains except AWS_BEDROCK_REGION. llmConfiguration's own
+            # `enabled` flag gates only the chat/completion client, not embeddings, so
+            # semantic search needs no LLM_* vars.
             # EMBEDDING_PROVIDER=bedrock (not djl): DJL is unusable on the official
             # Alpine/musl-based server image - it fails to load its glibc-linked
             # PyTorch native runtime every time. Unresolved upstream as of 1.13.1:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — split out while addressing feedback on #5649, whose only failing check turned out to be this pre-existing issue on `main`, unrelated to that PR's diff.

### Description (What does it do?)
`#5646` ("feat(open-metadata): upgrade to 2.0.0") added a comment block in `open_metadata/__main__.py` with three lines over the 88-char `ruff` limit (`E501`). `main`'s pre-commit.ci push status has been `failure` since that commit merged, and every PR branched from `main` since then inherits the same failing `ruff-check` on that file regardless of what the PR itself touches.

This just rewraps the comment text — no code or behavior change.

### How can this be tested?
- `uv run pre-commit run ruff-check --files src/ol_infrastructure/applications/open_metadata/__main__.py` — passes.
- `uv run pre-commit run --files src/ol_infrastructure/applications/open_metadata/__main__.py` — full hook set passes.

### Additional Context
Confirmed via `gh api repos/mitodl/ol-infrastructure/commits/main/status` that `main`'s current pre-commit.ci push status is `failure` for this exact reason before this fix.