### PR TITLE
fix(aws): keep the cross-environment Glue deny off shared managed policies

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -32,6 +32,7 @@ from ol_infrastructure.lib.aws.eks_helper import (
     check_cluster_namespace,
     setup_k8s_provider,
 )
+from ol_infrastructure.lib.aws.iam_helper import cross_environment_glue_denial
 from ol_infrastructure.lib.ol_types import (
     Application,
     AWSBase,
@@ -282,6 +283,28 @@ if starrocks_config.get_bool("enable_data_lake_integration"):
                 "data_lake_query_engine_iam_policy_arn"
             ),
             role=starrocks_auth_binding.irsa_role.name,
+            opts=ResourceOptions(parent=starrocks_auth_binding),
+        )
+
+    # The attachments above hand this role both environments' catalogs, which
+    # for a lower environment means handing it production. The guard against
+    # that has to be an inline policy on this role: the managed policies are
+    # shared across environments, so a Deny placed in one of them also lands on
+    # the production role and revokes production's access to its own catalog.
+    # Empty in production, which is the environment being protected.
+    _cross_environment_glue_denial = cross_environment_glue_denial(
+        stack_info.env_suffix
+    )
+    if _cross_environment_glue_denial:
+        iam.RolePolicy(
+            f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-cross-environment-glue-denial",
+            role=starrocks_auth_binding.irsa_role.name,
+            policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": _cross_environment_glue_denial,
+                }
+            ),
             opts=ResourceOptions(parent=starrocks_auth_binding),
         )
 

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -13,7 +13,6 @@ from pulumi_aws import athena, glue, iam, s3
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.iam_helper import (
-    cross_environment_glue_denial,
     data_lake_glue_resources,
     lint_iam_policy,
 )
@@ -284,10 +283,19 @@ query_engine_permissions: list[dict[str, str | list[str]]] = [
     },
 ]
 
+# The cross-environment Deny deliberately does not belong in this document.
+# Unlike the inline policies in applications/{airbyte,dagster,open_metadata},
+# this is a shared managed policy, and applications/starrocks attaches every
+# environment's copy to every StarRocks IRSA role so each instance can query
+# both data lake catalogs. A Deny embedded here travels onto those foreign
+# principals: the QA copy landed its "deny production" statement on the
+# production role, where an explicit Deny beat the Allow from the production
+# copy attached alongside it, and production StarRocks lost the production Glue
+# catalog. The Deny constrains a principal, not a grant, so it is attached to
+# the StarRocks role itself in applications/starrocks.
 query_engine_iam_permissions = {
     "Version": "2012-10-17",
-    "Statement": query_engine_permissions
-    + cross_environment_glue_denial(stack_info.env_suffix),
+    "Statement": query_engine_permissions,
 }
 
 # Create instance profile for granting access to S3 buckets

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -13,6 +13,7 @@ from pulumi_aws import athena, glue, iam, s3
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.iam_helper import (
+    cross_environment_glue_denial,
     data_lake_glue_resources,
     lint_iam_policy,
 )
@@ -359,5 +360,17 @@ if query_engine_aws_account_id and query_engine_aws_external_id:
         policy_arn=query_engine_iam_policy.arn,
         role=query_engine_role.name,
     )
+
+    # Carried on the role rather than in the policy above, for the reason given
+    # where that policy is built. Empty in production.
+    query_engine_glue_denial = cross_environment_glue_denial(stack_info.env_suffix)
+    if query_engine_glue_denial:
+        iam.RolePolicy(
+            f"data-lake-query-engine-role-glue-denial-{stack_info.env_suffix}",
+            role=query_engine_role.name,
+            policy=json.dumps(
+                {"Version": "2012-10-17", "Statement": query_engine_glue_denial}
+            ),
+        )
 
     export("sql_engine_role_arn", query_engine_role.arn)

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -402,6 +402,15 @@ def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
     undone by a later Allow, and widening a grant for some unrelated reason is
     the way this would realistically regress.
 
+    Attach the result to the principal being constrained -- an inline role policy
+    -- and never to a managed policy that is shared across environments. A Deny
+    applies to whichever principal holds the document, not to the environment
+    that generated it, so a shared policy carries it onto every role it is
+    attached to. That is how the production StarRocks role ended up holding QA's
+    "deny production" statement and losing the production Glue catalog: an
+    explicit Deny cannot be undone by the Allow in the production policy attached
+    beside it.
+
     ``arn:aws:glue:*:*:catalog`` is deliberately absent, and must stay absent.
     Every Glue operation requires permission on the catalog, so denying it would
     deny every Glue call these identities make -- including the ones against

--- a/src/ol_infrastructure/substructure/aws/eks/starrocks.py
+++ b/src/ol_infrastructure/substructure/aws/eks/starrocks.py
@@ -1,3 +1,5 @@
+import json
+
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, ResourceOptions, StackReference, export
 from pulumi_aws import get_caller_identity, iam
@@ -9,6 +11,7 @@ from ol_infrastructure.components.aws.eks import (
 )
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import check_cluster_namespace
+from ol_infrastructure.lib.aws.iam_helper import cross_environment_glue_denial
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import (
     StackInfo,
@@ -77,6 +80,20 @@ def setup_starrocks(
         policy_arn=data_lake_query_engine_iam_policy_arn,
         role=starrocks_trust_role.role.name,
     )
+
+    # Carried on the role rather than in the managed policy above, which is shared
+    # across environments and so cannot hold a Deny that applies to only one of
+    # them. Empty in production. Defence in depth: the policy's Allow is already
+    # scoped to this environment's namespaces.
+    starrocks_glue_denial = cross_environment_glue_denial(stack_info.env_suffix)
+    if starrocks_glue_denial:
+        iam.RolePolicy(
+            f"{cluster_name}-starrocks-cross-environment-glue-denial",
+            role=starrocks_trust_role.role.name,
+            policy=json.dumps(
+                {"Version": "2012-10-17", "Statement": starrocks_glue_denial}
+            ),
+        )
 
     # skip_await=False (the default) makes this resource block until Helm confirms
     # the operator is actually deployed. The applications/starrocks stack requires


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Moves the cross-environment Glue Deny out of the shared data-lake query-engine
managed policy and onto the principals it is meant to constrain.

- `infrastructure/aws/data_warehouse` no longer folds `cross_environment_glue_denial`
  into the managed policy document, and attaches it as an inline `RolePolicy` on
  `data-lake-query-engine-role-<env>` instead.
- `applications/starrocks` attaches it as an inline `RolePolicy` on the StarRocks
  IRSA role.
- `substructure/aws/eks/starrocks.py` does the same for the legacy
  `data-<env>-starrocks-trust-role`.
- The `cross_environment_glue_denial` docstring records why it must never go back
  into a shared policy.

Empty in production, so no deny resource is created there.

`applications/starrocks` attaches every environment's copy of the managed policy to
every StarRocks IRSA role, in both directions, so each instance can query both Glue
catalogs. A Deny embedded in that shared document travels onto foreign principals.
The QA copy landed `DenyCrossEnvironmentGlueAccess` on
`data-production-starrocks-lakehouse-trust-role`, where an explicit Deny beat the
Allow from the production copy attached beside it:

```
1064 (HY000): User: arn:aws:sts::610119931565:assumed-role/data-production-starrocks-lakehouse-trust-role/starrocks-glue
is not authorized to perform: glue:GetDatabase on resource:
arn:aws:glue:us-east-1:610119931565:database/ol_warehouse_production_dimensional
with an explicit deny in an identity-based policy:
arn:aws:iam::610119931565:policy/ol-data/etl-policy-qa/data-lake-query-engine-policy-qa
(Service: Glue, Status Code: 400)
```

That dbt run finished `Completed with 8 errors`, one per model under
`models/b2b_analytics/`, so the materialized views behind the mit-learn b2b
dashboard stopped being rebuilt and `ol-analytics-api` returned 500s.

Effective access is unchanged. Four roles hold the QA managed policy:

| Role | Also holds production policy? | Keeps a Deny after this PR |
|---|---|---|
| `data-qa-starrocks-lakehouse-trust-role` | yes | inline, from `applications/starrocks` |
| `data-QA-starrocks-trust-role` | no | inline, from `substructure/aws/eks` |
| `data-lake-query-engine-role-qa` | no | inline, from `data_warehouse` |
| `data-production-starrocks-lakehouse-trust-role` | n/a, is production | none, correctly |

Only the first genuinely needed the explicit Deny; the other two never had an Allow
reaching production in the first place. They keep it as the defence in depth it was.

### How can this be tested?
`pulumi preview` on this branch:

- `ol-infrastructure-data-warehouse/QA` -> `+1 create` (inline deny on
  `data-lake-query-engine-role-qa`), `~1 update` (managed policy loses the
  statement). 81 unchanged.
- `ol-infrastructure-data-warehouse/Production` -> 82 unchanged, no diff.
- `ol-application-starrocks/lakehouse.QA` -> `+1 create`,
  `starrocks-lakehouse-qa-cross-environment-glue-denial` on
  `data-qa-starrocks-lakehouse-trust-role`, carrying the same 12 resource ARNs the
  managed policy did.
- `ol-application-starrocks/lakehouse.Production` -> no deny resource created.
- `ol-substructure-eks/data.QA` -> `+1 create`.
- `ol-substructure-eks/data.Production` -> no deny resource created.

The remaining `~ to update` entries in those previews are pre-existing drift
(kubeconfig key ordering, an APISIX HTTPRoute spec), not from this branch.

`pre-commit run` (ruff format, ruff check, mypy) passes.

The guard is currently `explicitDeny` and must still be after deploying:

```
aws iam simulate-principal-policy \
  --policy-source-arn arn:aws:iam::610119931565:role/data-qa-starrocks-lakehouse-trust-role \
  --action-names glue:GetDatabase \
  --resource-arns arn:aws:glue:us-east-1:610119931565:database/ol_warehouse_production_dimensional
```

and production must stay `allowed`:

```
aws iam simulate-principal-policy \
  --policy-source-arn arn:aws:iam::610119931565:role/data-production-starrocks-lakehouse-trust-role \
  --action-names glue:GetDatabase \
  --resource-arns arn:aws:glue:us-east-1:610119931565:database/ol_warehouse_production_dimensional
```

### Additional Context
`data-lake-query-engine-policy-qa` was detached from
`data-production-starrocks-lakehouse-trust-role` by hand to restore production ahead
of this PR, so that role currently holds only the production policy. This branch does
not remove the cross-environment attachment, so that detach is temporary drift that
the deploy will reconcile.

### Checklist:
- [ ] Deploy `infrastructure/aws/data_warehouse` (QA and Production) first, so the shared policies no longer carry the deny
- [ ] Then deploy `applications/starrocks` and `substructure/aws/eks`, which restore the guard as inline role policies
- [ ] Deploying `applications/starrocks` Production before the first step would re-attach the deny-carrying QA policy and break production Glue access again
