### PR TITLE
fix(open-metadata): size omjob-operator memory from measurement

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -789,11 +789,31 @@ open_metadata_application = kubernetes.helm.v3.Release(
                     "eks.amazonaws.com/role-arn": open_metadata_irsa_role.role.arn,
                 },
             },
+            # The chart defaults omjobOperator to 256Mi/128Mi, which is well under
+            # what this actually uses. Measured on data-production over 7 days to
+            # 2026-08-31: working set idles at ~215Mi right after a restart, climbs
+            # monotonically, and gets OOMKilled at the 256Mi ceiling having peaked at
+            # 254Mi - 11 kills in 7 days, roughly one every 15 hours. The old 128Mi
+            # request understated real usage (p50 ~230Mi) by nearly half, so the
+            # scheduler was placing this pod as if it were tiny.
+            # Not version-specific: the same sawtooth shows on 1.13.3, 1.13.4 and
+            # (in QA) 2.0.0, while CI on 2.0.0 never restarts. It tracks OMJob volume,
+            # so the busiest environment is the most exposed.
+            # The 254Mi peak is a CENSORED observation - the container is killed at the
+            # limit, so real demand is unknown and could be higher. 1Gi is deliberately
+            # generous to uncover the true plateau rather than to be a tight fit; once
+            # a few days of unclipped data exist, re-measure and set this from the
+            # observed ceiling. If the climb never plateaus it is a leak in
+            # omjob-operator and belongs upstream.
             "omjobOperator": {
                 "enabled": True,
                 "image": {
                     "repository": "docker.getcollate.io/openmetadata/omjob-operator",
                     "tag": OPEN_METADATA_VERSION,
+                },
+                "resources": {
+                    "requests": {"cpu": "100m", "memory": "256Mi"},
+                    "limits": {"cpu": "500m", "memory": "1Gi"},
                 },
             },
             "envFrom": [


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sets an explicit `omjobOperator.resources` block instead of inheriting the chart default of 256Mi limit / 128Mi request. New values: **limit 1Gi, request 256Mi.** CPU is unchanged.

The operator is being OOMKilled on a loop in production. Measured on `data-production` over the 7 days to 2026-08-31, `container_memory_working_set_bytes` for `container="operator"` in the `open-metadata` namespace (7 days is the window queried; the behaviour may well predate it, but that is not something this PR claims):

| | |
|---|---|
| floor after a restart | ~190–224Mi |
| p50 | ~230Mi |
| peak before the kill | **254Mi** (99.3% of the 256Mi limit) |
| OOMKills | **11 in 7 days**, roughly one every 15 hours |

The shape is a clean sawtooth: the working set climbs monotonically from the floor and the container dies at the ceiling. It idles at ~85% of its limit with essentially no headroom. The old 128Mi request understated real usage by nearly half, so the scheduler was placing a ~230Mi pod as though it were a 128Mi one — that part is a node-packing problem independent of the crashes.

**This is not a 2.0.0 regression.** The metric series carry the image tag, and within this window the same sawtooth appears on `omjob-operator:1.13.3` and `1.13.4` in production. QA on 2.0.0 shows the same thing (restartCount 8, OOMKilled, exit 137). CI on 2.0.0 has never restarted — 0 in 37h. The variable is OMJob volume, not version, so the busiest environment is the most exposed and production is the one that has been paying for it.

### How can this be tested?
- `pulumi preview --stack QA` — `2 to update, 71 unchanged`. QA is already on 2.0.0, so the diff is the `resources` block alone, which isolates this change.
- `pulumi preview --stack Production` — `2 to update, 76 unchanged`. Production also picks up `omjobOperator.image.tag "1.13.4" => "2.0.0"` here, because production has not yet taken the OM 2.0 upgrade. That is intentional and desirable: the operator gets the larger limit in the same rollout that moves it to 2.0.0, rather than going to 2.0.0 on the old limit first.
- `pre-commit run` on the changed file: all hooks pass, ruff and mypy included.
- Verified against the 2.0.0 chart's `values.yaml` that `omjobOperator.resources` is a real value with exactly the `100m/128Mi` request and `500m/256Mi` limit defaults observed live, so the override shape matches what the chart consumes.
- CPU left alone deliberately: `container_cpu_cfs_throttled_periods_total / container_cpu_cfs_periods_total` over the last hour is **0**. Memory is the only pressure.

After deploy, confirm `restartCount` stops advancing on `openmetadata-omjob-operator` in the target cluster. That is the real test and it takes a couple of days to be meaningful, since the current cycle is ~15 hours.

### Additional Context
**1Gi is deliberately generous and is not presented as the right long-term number.** The 254Mi peak is a *censored* observation — the container is killed at the limit, so actual demand is unknown and could be higher. You cannot size confidently from a clipped distribution. The intent is to get several days of unclipped data, see where the working set actually plateaus, then set the limit from that. Picking a tighter value like 512Mi now risks buying a slower crash rather than a fix.

If the climb never plateaus, this is a memory leak in omjob-operator rather than an undersized limit, and the workaround (a bigger limit, or a scheduled restart) should be accompanied by an upstream report. The follow-up is tracked at `tk-omjob-operator-was-oomkilled-once-on-2-0-0-in-qa-439fa3`.

Worth knowing about the blast radius so far: this degrades rather than halts. Over the same window 5 of 10 QA ingestion jobs completed normally, and the operator restarts and carries on each time. It surfaced only because restartCount was checked deliberately — nothing alerts on it.
