### PR TITLE
fix(sdks): repair qdrant-cloud/rootly get_package() for pulumi 3.259.0

### DIFF
--- a/sdks/qdrant-cloud/pulumi_qdrant_cloud/_utilities.py
+++ b/sdks/qdrant-cloud/pulumi_qdrant_cloud/_utilities.py
@@ -327,30 +327,12 @@ def get_plugin_download_url():
 def get_version():
     return "1.19.3"
 
-_package_lock = asyncio.Lock()
-_package_ref = ...
-async def get_package():
-	global _package_ref
-	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="qdrant-cloud",
-						version=get_version(),
-						value=base64.b64decode("eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL3FkcmFudC9xZHJhbnQtY2xvdWQiLCJ2ZXJzaW9uIjoiMS4xOS4zIn19"),
-					)
-					registerPackageResponse = monitor.RegisterPackage(
-						resource_pb2.RegisterPackageRequest(
-							name="terraform-provider",
-							version="1.1.1",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
-	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
-	# using package with them.
-	if _package_ref is None or _package_ref is ...:
-		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
-	return _package_ref
+async def get_package() -> str:
+	return await pulumi.runtime.register_package(
+		base_provider_name="terraform-provider",
+		base_provider_version="1.1.1",
+		base_provider_download_url=get_plugin_download_url() or "",
+		package_name="qdrant-cloud",
+		package_version=get_version(),
+		base64_parameter="eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL3FkcmFudC9xZHJhbnQtY2xvdWQiLCJ2ZXJzaW9uIjoiMS4xOS4zIn19",
+	)

--- a/sdks/qdrant-cloud/pyproject.toml
+++ b/sdks/qdrant-cloud/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_qdrant_cloud"
   description = "A Pulumi provider dynamically bridged from qdrant-cloud."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.19.3"

--- a/sdks/rootly/pulumi_rootly/_utilities.py
+++ b/sdks/rootly/pulumi_rootly/_utilities.py
@@ -327,31 +327,13 @@ def get_plugin_download_url():
 def get_version():
     return "5.17.2"
 
-_package_lock = asyncio.Lock()
-_package_ref = ...
-async def get_package():
-	global _package_ref
-	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="rootly",
-						version=get_version(),
-						value=base64.b64decode("eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL3Jvb3RseWhxL3Jvb3RseSIsInZlcnNpb24iOiI1LjE3LjIifX0="),
-					)
-					registerPackageResponse = monitor.RegisterPackage(
-						resource_pb2.RegisterPackageRequest(
-							name="terraform-provider",
-							version="1.2.0",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
-	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
-	# using package with them.
-	if _package_ref is None or _package_ref is ...:
-		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
-	return _package_ref
+async def get_package() -> str:
+	return await pulumi.runtime.register_package(
+		base_provider_name="terraform-provider",
+		base_provider_version="1.2.0",
+		base_provider_download_url=get_plugin_download_url() or "",
+		package_name="rootly",
+		package_version=get_version(),
+		base64_parameter="eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL3Jvb3RseWhxL3Jvb3RseSIsInZlcnNpb24iOiI1LjE3LjIifX0=",
+	)
 	

--- a/sdks/rootly/pyproject.toml
+++ b/sdks/rootly/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_rootly"
   description = "A Pulumi provider dynamically bridged from rootly."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "5.17.2"

--- a/uv.lock
+++ b/uv.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "parver", specifier = ">=0.2.1" },
-    { name = "pulumi", specifier = ">=3.165.0,<4.0.0" },
+    { name = "pulumi", specifier = ">=3.247.0,<4.0.0" },
     { name = "semver", specifier = ">=2.8.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.11,<5" },
 ]
@@ -2179,7 +2179,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "parver", specifier = ">=0.2.1" },
-    { name = "pulumi", specifier = ">=3.231.0,<4.0.0" },
+    { name = "pulumi", specifier = ">=3.247.0,<4.0.0" },
     { name = "semver", specifier = ">=2.8.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.11,<5" },
 ]


### PR DESCRIPTION
### What are the relevant tickets?
N/A — surfaced by a mit-learn-pipeline QA deploy failure: https://cicd.odl.mit.edu/teams/infrastructure/pipelines/mit-learn-pipeline/jobs/deploy-ol-application-mit-learn-qa/builds/321

### Description (What does it do?)
`deploy-ol-application-mit-learn-qa` build 321 failed with:

```
AttributeError: module 'pulumi.runtime.settings' has no attribute '_sync_monitor_supports_parameterization'
```

Root cause: #5639 bumped the `pulumi` core package from 3.256.0 to 3.259.0 in `uv.lock`. That pulumi release removed the private `pulumi.runtime.settings._sync_monitor_supports_parameterization` attribute in favor of a new public `pulumi.runtime.register_package()` helper. Both `sdks/qdrant-cloud` and `sdks/rootly` are hand-generated, checked-in provider SDKs whose `_utilities.py:get_package()` still called the removed private attribute, so any resource from either provider crashed at registration time.

- Rewrote `get_package()` in `sdks/qdrant-cloud/pulumi_qdrant_cloud/_utilities.py` and `sdks/rootly/pulumi_rootly/_utilities.py` to call `pulumi.runtime.register_package(...)`, matching the current upstream `pulumi-language-python` codegen template (verified against `pulumi/pulumi` source at `pkg/codegen/python/gen.go`).
- `register_package()` handles its own caching, so the manual `_package_lock`/`_package_ref` bookkeeping was dropped along with it.
- `rootly` was patched preemptively — it has the identical stale pattern and would hit the same crash the next time a rootly resource is touched.

### How can this be tested?
- Reproduced the exact failure locally: loaded the pre-fix `get_package()` from `sdks/qdrant-cloud` against this repo's pinned `pulumi==3.259.0` and confirmed it raises the same `AttributeError: module 'pulumi.runtime.settings' has no attribute '_sync_monitor_supports_parameterization'`.
- With the fix applied, ran `pulumi preview` against the live `mit_learn` `QA` stack — completes cleanly (154 unchanged resources, no errors), including resolving the `organization/ol-infrastructure-qdrant-cloud/mitlearn.QA` `StackReference` where the original failure occurred.

### Additional Context
`sdks/` is excluded from ruff/pre-commit (`pyproject.toml`), consistent with these being generated/vendored files, so no lint changes were needed alongside the fix.
