### PR TITLE
fix(aws): ship the cross-environment Glue deny as a managed policy

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -275,36 +275,43 @@ if starrocks_config.get_bool("oidc_enabled"):
 _DATA_LAKE_ENVS = ("QA", "Production")
 
 if starrocks_config.get_bool("enable_data_lake_integration"):
+    _dw_stacks = {}
     for _data_lake_env in _DATA_LAKE_ENVS:
-        _dw_stack = make_stack_reference(projects.DATA_WAREHOUSE, _data_lake_env)
+        _dw_stacks[_data_lake_env] = make_stack_reference(
+            projects.DATA_WAREHOUSE, _data_lake_env
+        )
         iam.RolePolicyAttachment(
             f"starrocks-data-lake-policy-{stack_info.env_suffix}-{_data_lake_env}",
-            policy_arn=_dw_stack.require_output(
+            policy_arn=_dw_stacks[_data_lake_env].require_output(
                 "data_lake_query_engine_iam_policy_arn"
             ),
             role=starrocks_auth_binding.irsa_role.name,
             opts=ResourceOptions(parent=starrocks_auth_binding),
         )
 
-    # The attachments above hand this role both environments' catalogs, which
-    # for a lower environment means handing it production. The guard against
-    # that has to be an inline policy on this role: the managed policies are
-    # shared across environments, so a Deny placed in one of them also lands on
-    # the production role and revokes production's access to its own catalog.
-    # Empty in production, which is the environment being protected.
-    _cross_environment_glue_denial = cross_environment_glue_denial(
-        stack_info.env_suffix
-    )
-    if _cross_environment_glue_denial:
-        iam.RolePolicy(
+    # The attachments above hand this role both environments' catalogs, which for
+    # a lower environment means handing it production. The guard has to be scoped
+    # to this role rather than folded into either policy above, since those are
+    # shared across environments and a Deny in one of them also lands on the
+    # production role and revokes production's access to its own catalog.
+    #
+    # It is attached as a managed policy, not an inline one: the Concourse deploy
+    # role has iam:AttachRolePolicy but not iam:PutRolePolicy, so an inline policy
+    # cannot be applied from CI. Gate on the helper rather than on the presence of
+    # the stack output -- it is empty in production, where no such policy exists.
+    if cross_environment_glue_denial(stack_info.env_suffix):
+        # Reuse the reference from the loop when this environment is one of the
+        # data lake envs; a second StackReference to the same stack is a
+        # duplicate-URN error. CI is not in _DATA_LAKE_ENVS and needs its own.
+        _same_env_dw_stack = _dw_stacks.get(stack_info.name) or make_stack_reference(
+            projects.DATA_WAREHOUSE, stack_info.name
+        )
+        iam.RolePolicyAttachment(
             f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-cross-environment-glue-denial",
-            role=starrocks_auth_binding.irsa_role.name,
-            policy=json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": _cross_environment_glue_denial,
-                }
+            policy_arn=_same_env_dw_stack.require_output(
+                "data_lake_cross_environment_glue_denial_policy_arn"
             ),
+            role=starrocks_auth_binding.irsa_role.name,
             opts=ResourceOptions(parent=starrocks_auth_binding),
         )
 

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -285,15 +285,13 @@ query_engine_permissions: list[dict[str, str | list[str]]] = [
 ]
 
 # The cross-environment Deny deliberately does not belong in this document.
-# Unlike the inline policies in applications/{airbyte,dagster,open_metadata},
-# this is a shared managed policy, and applications/starrocks attaches every
-# environment's copy to every StarRocks IRSA role so each instance can query
-# both data lake catalogs. A Deny embedded here travels onto those foreign
-# principals: the QA copy landed its "deny production" statement on the
-# production role, where an explicit Deny beat the Allow from the production
-# copy attached alongside it, and production StarRocks lost the production Glue
-# catalog. The Deny constrains a principal, not a grant, so it is attached to
-# the StarRocks role itself in applications/starrocks.
+# applications/starrocks attaches every environment's copy of this policy to
+# every StarRocks IRSA role so each instance can query both data lake catalogs.
+# A Deny embedded here travels onto those foreign principals: the QA copy landed
+# its "deny production" statement on the production role, where an explicit Deny
+# beat the Allow from the production copy attached alongside it, and production
+# StarRocks lost the production Glue catalog. The Deny constrains a principal,
+# not a grant, so it ships as its own policy below.
 query_engine_iam_permissions = {
     "Version": "2012-10-17",
     "Statement": query_engine_permissions,
@@ -313,6 +311,41 @@ query_engine_iam_policy = iam.Policy(
 )
 
 export("data_lake_query_engine_iam_policy_arn", query_engine_iam_policy.arn)
+
+# A standalone managed policy rather than an inline RolePolicy on each principal.
+# The Concourse deploy role is granted iam:CreatePolicy, iam:CreatePolicyVersion
+# and iam:AttachRolePolicy but NOT iam:PutRolePolicy, so an inline policy cannot
+# be applied from CI at all -- it fails with AccessDenied while the surrounding
+# managed-policy update succeeds, which strands the environment with the Allow
+# published and the Deny missing. Keep this as a managed policy attached to the
+# specific roles that need it; see cross_environment_glue_denial.
+#
+# Empty in production, which is the environment being protected, so no policy is
+# created there and consumers must gate on the same helper before referencing
+# the export.
+cross_environment_glue_denial_statements = cross_environment_glue_denial(
+    stack_info.env_suffix
+)
+if cross_environment_glue_denial_statements:
+    cross_environment_glue_denial_policy = iam.Policy(
+        f"data-lake-cross-environment-glue-denial-policy-{stack_info.env_suffix}",
+        name=f"data-lake-cross-environment-glue-denial-policy-{stack_info.env_suffix}",
+        path=f"/ol-data/etl-policy-{stack_info.env_suffix}/",
+        policy=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": cross_environment_glue_denial_statements,
+            }
+        ),
+        description=(
+            "Denies this environment's data lake identities any Glue action on a "
+            "protected environment's catalog"
+        ),
+    )
+    export(
+        "data_lake_cross_environment_glue_denial_policy_arn",
+        cross_environment_glue_denial_policy.arn,
+    )
 
 # The external query engine (Starburst Galaxy) cross-account trust role is only
 # configured for environments that actually connect an external query engine to
@@ -363,14 +396,11 @@ if query_engine_aws_account_id and query_engine_aws_external_id:
 
     # Carried on the role rather than in the policy above, for the reason given
     # where that policy is built. Empty in production.
-    query_engine_glue_denial = cross_environment_glue_denial(stack_info.env_suffix)
-    if query_engine_glue_denial:
-        iam.RolePolicy(
+    if cross_environment_glue_denial_statements:
+        iam.RolePolicyAttachment(
             f"data-lake-query-engine-role-glue-denial-{stack_info.env_suffix}",
+            policy_arn=cross_environment_glue_denial_policy.arn,
             role=query_engine_role.name,
-            policy=json.dumps(
-                {"Version": "2012-10-17", "Statement": query_engine_glue_denial}
-            ),
         )
 
     export("sql_engine_role_arn", query_engine_role.arn)

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -402,14 +402,22 @@ def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
     undone by a later Allow, and widening a grant for some unrelated reason is
     the way this would realistically regress.
 
-    Attach the result to the principal being constrained -- an inline role policy
-    -- and never to a managed policy that is shared across environments. A Deny
-    applies to whichever principal holds the document, not to the environment
-    that generated it, so a shared policy carries it onto every role it is
-    attached to. That is how the production StarRocks role ended up holding QA's
-    "deny production" statement and losing the production Glue catalog: an
-    explicit Deny cannot be undone by the Allow in the production policy attached
-    beside it.
+    Attach the result to the principal being constrained, and never to a policy
+    that is shared across environments. A Deny applies to whichever principal
+    holds the document, not to the environment that generated it, so a shared
+    policy carries it onto every role it is attached to. That is how the
+    production StarRocks role ended up holding QA's "deny production" statement
+    and losing the production Glue catalog: an explicit Deny cannot be undone by
+    the Allow in the production policy attached beside it.
+
+    Ship it as a dedicated managed policy attached to those principals, not as an
+    inline ``iam.RolePolicy``. The Concourse deploy role is granted
+    ``iam:CreatePolicy``, ``iam:CreatePolicyVersion`` and ``iam:AttachRolePolicy``
+    but not ``iam:PutRolePolicy``, so an inline policy fails from CI with
+    AccessDenied while the surrounding managed-policy update succeeds -- which
+    publishes the Allow and strands the environment without the Deny. A
+    ``pulumi preview`` run under a developer's own credentials does not catch
+    this, because those credentials do have ``iam:PutRolePolicy``.
 
     ``arn:aws:glue:*:*:catalog`` is deliberately absent, and must stay absent.
     Every Glue operation requires permission on the catalog, so denying it would

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -415,9 +415,12 @@ def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
     ``iam:CreatePolicy``, ``iam:CreatePolicyVersion`` and ``iam:AttachRolePolicy``
     but not ``iam:PutRolePolicy``, so an inline policy fails from CI with
     AccessDenied while the surrounding managed-policy update succeeds -- which
-    publishes the Allow and strands the environment without the Deny. A
-    ``pulumi preview`` run under a developer's own credentials does not catch
-    this, because those credentials do have ``iam:PutRolePolicy``.
+    publishes the Allow and strands the environment without the Deny. Nothing
+    local catches this: a ``pulumi preview`` performs no writes, so it cannot
+    surface a write-permission gap, and a developer applying by hand would not
+    hit it either, since developer credentials do carry ``iam:PutRolePolicy``.
+    Check what the deploy role can actually do before reaching for a new IAM
+    resource type here.
 
     ``arn:aws:glue:*:*:catalog`` is deliberately absent, and must stay absent.
     Every Glue operation requires permission on the catalog, so denying it would

--- a/src/ol_infrastructure/substructure/aws/eks/starrocks.py
+++ b/src/ol_infrastructure/substructure/aws/eks/starrocks.py
@@ -1,5 +1,3 @@
-import json
-
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, ResourceOptions, StackReference, export
 from pulumi_aws import get_caller_identity, iam
@@ -81,18 +79,18 @@ def setup_starrocks(
         role=starrocks_trust_role.role.name,
     )
 
-    # Carried on the role rather than in the managed policy above, which is shared
-    # across environments and so cannot hold a Deny that applies to only one of
-    # them. Empty in production. Defence in depth: the policy's Allow is already
-    # scoped to this environment's namespaces.
-    starrocks_glue_denial = cross_environment_glue_denial(stack_info.env_suffix)
-    if starrocks_glue_denial:
-        iam.RolePolicy(
+    # Scoped to this role rather than folded into the managed policy above, which
+    # is shared across environments and so cannot hold a Deny that applies to only
+    # one of them. Attached as a managed policy because the Concourse deploy role
+    # has iam:AttachRolePolicy but not iam:PutRolePolicy. Empty in production.
+    # Defence in depth: the policy's Allow is already scoped to this environment.
+    if cross_environment_glue_denial(stack_info.env_suffix):
+        iam.RolePolicyAttachment(
             f"{cluster_name}-starrocks-cross-environment-glue-denial",
-            role=starrocks_trust_role.role.name,
-            policy=json.dumps(
-                {"Version": "2012-10-17", "Statement": starrocks_glue_denial}
+            policy_arn=data_warehouse_stack.require_output(
+                "data_lake_cross_environment_glue_denial_policy_arn"
             ),
+            role=starrocks_trust_role.role.name,
         )
 
     # skip_await=False (the default) makes this resource block until Helm confirms


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5651, whose inline
`RolePolicy` form cannot be applied from CI.

- `cross_environment_glue_denial` now ships as its own managed policy per
  non-protected environment, `data-lake-cross-environment-glue-denial-policy-<env>`,
  created in `infrastructure/aws/data_warehouse` and exported as
  `data_lake_cross_environment_glue_denial_policy_arn`.
- `applications/starrocks`, `substructure/aws/eks/starrocks.py` and the Starburst
  query-engine role attach that policy instead of writing an inline one.
- The helper docstring records why an inline policy is not an option here.

The Concourse deploy role is granted `iam:CreatePolicy`, `iam:CreatePolicyVersion`
and `iam:AttachRolePolicy`, but **not** `iam:PutRolePolicy`
(`cicd-policy-pulumi_infra-production-23fc9662a4973a4d82a91dd6591` v2). Every apply
of #5651 therefore failed:

```
AccessDenied: User: .../concourse-instance-role-worker-infra-production-ed1176e/i-0f3a7be2f95db50bc
is not authorized to perform: iam:PutRolePolicy on resource: role data-lake-query-engine-role-qa
because no identity-based policy allows the iam:PutRolePolicy action
```

Pulumi applied the rest of the stack anyway. The managed-policy update that removes
the Deny from the shared document succeeded (publishing `v18`) while its inline
replacement failed, leaving QA holding the production Allow with nothing to override
it -- `glue:GetTable` and `glue:DeleteTable` on `ol_warehouse_production_dimensional`
evaluated to `allowed` from `data-qa-starrocks-lakehouse-trust-role`. CI reached the
same half-state without the exposure, having no Allow that reached production.

Nothing local catches this class of failure: a `pulumi preview` performs no writes,
so it cannot surface a write-permission gap, and a developer applying by hand would
not hit it either, since developer credentials do carry `iam:PutRolePolicy`.

### How can this be tested?
`pulumi preview` on this branch:

- `ol-infrastructure-data-warehouse/QA` -> `+2 create` (the deny policy and its
  attachment to `data-lake-query-engine-role-qa`). 82 unchanged.
- `ol-infrastructure-data-warehouse/CI` -> `+1 create` (policy only; CI has no
  external query-engine role, per the existing comment on that block). 80 unchanged.
- `ol-infrastructure-data-warehouse/Production` -> 82 unchanged, no diff.
- `ol-application-starrocks/lakehouse.Production` -> 39 unchanged, no diff.
- `ol-application-starrocks/lakehouse.QA` -> fails with
  `KeyError: 'data_lake_cross_environment_glue_denial_policy_arn'` until the
  data_warehouse stack above is deployed. That is the intended hard dependency:
  `require_output` fails loudly rather than silently skipping the Deny.

`pre-commit run` (ruff format, ruff check, mypy) passes.

After deploying, the guard must hold in QA:

```
aws iam simulate-principal-policy \
  --policy-source-arn arn:aws:iam::610119931565:role/data-qa-starrocks-lakehouse-trust-role \
  --action-names glue:GetTable glue:DeleteTable \
  --resource-arns arn:aws:glue:us-east-1:610119931565:database/ol_warehouse_production_dimensional
```

must return `explicitDeny`, and the same call against
`data-production-starrocks-lakehouse-trust-role` must return `allowed`.

### Additional Context
Two manual interventions are currently holding production and QA together, and both
are drift this PR does not itself reconcile:

1. `data-lake-query-engine-policy-qa` was rolled back to `v17` by hand to restore the
   QA guard. Pulumi state still believes it is on the deny-less document, so the
   previews above show the shared policy as unchanged and an apply will not touch it.
2. `data-lake-query-engine-policy-qa` was detached from
   `data-production-starrocks-lakehouse-trust-role` by hand, twice, to restore
   production Glue access. `applications/starrocks` Production will re-attach it.

Because `v17` still carries the Deny, re-attachment to the production role breaks
production again. Step 3 in the checklist closes that out; until it is done, the
shared QA policy must stay off the production role.

The deploy order below is the reverse of the one given in #5651, and that inversion
is what caused the exposure. Deny-adding steps come before deny-removing ones, so no
principal ever holds the Allow without the Deny.

### Checklist:
- [ ] Deploy `infrastructure/aws/data_warehouse` QA and CI first, creating the standalone deny policies. The shared policies are untouched, so nothing is unguarded at any point
- [ ] Then deploy `applications/starrocks` and `substructure/aws/eks` for QA and CI, attaching the deny policy to the roles
- [ ] Then reconcile `data-lake-query-engine-policy-qa` (and the CI equivalent) off the manual `v17` rollback to the deny-less document, via `pulumi refresh` then `up`. Only after this is it safe for the production role to hold the QA policy again
- [ ] Confirm with `simulate-principal-policy` that QA is `explicitDeny` and production is `allowed` before considering this done
