### PR TITLE
feat(edxapp): enable courseware indexing in production for mitx, mitx-staging, mitxonline

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -54,6 +54,7 @@ config:
     secure: v1:Yh0hsiSt2TTi7gX0:ZIMrOO7lw+EhZ6d+x5UP/Lk/41TOJ/AS2EiQQOQB0SqmR8n3F28uthxe933kplAoSnisJBwiTu3kWztLWCyc7LJqNK7KDMAGlhQY6Ow=
   edxapp:edx_xqueue_secrets:
     secure: v1:jgBYHCVD4xbM2TGu:P0rmQmQm2SYH/pQh928vZq5C5ZRXWQsKvRijEitpVjsIo5YfzyYGM84GOIQQG2FTINUdINXCGkWXHNUsfYFGq1dKcOsrql9n5nUka8k/4bWcqEuyBy0dI0bCpoEf6Ui0hL1On/Or4/rV7itDycwjIsTe7Eq6pE2oLRw+64RV77e3ho9f1M/63BC00rzYynBkaw==
+  edxapp:enable_courseware_index: "true"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     authoring: authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
@@ -66,6 +66,7 @@ config:
     secure: v1:abC4Zew/4Q9nzIm8:ntKKmUgT7z8jIEgKV2EkTbSJ6zcckEH2YHHInsBo8WOGqPNydNkxidhKYZ/bXy8y8E3iBOFF0uRROTyuHhrmzcbGygu01zYGFIBe+v8=
   edxapp:edx_xqueue_secrets:
     secure: v1:MSer6cBbKNVi/Pas:v5XAeVblUaT5pyxdhhk9wn9cVjadZcHscOWhN1nlPHBsCD8/HgEtsvAjtTOWnW/yVMYaMzlIjOxoKvEw0/qNESQj0M7bFKC7/dtfU+qlrWyI0PJEVVmiz9QPLAOvl4rA8In2hJTAmN+BAREDqSRFM9YiOKmdOuoDssTGv+fD1+oC5EcFz4BKPUnbZDQ1
+  edxapp:enable_courseware_index: "true"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     admin_console: admin-console

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -75,6 +75,7 @@ config:
   edxapp:data_platform_domain: bi.ol.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
+  edxapp:enable_courseware_index: "true"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     admin_console: admin-console


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in the SOA architecture-health evaluation project (Typesense course search finding, followed up by https://github.com/mitodl/ol-infrastructure/pull/5422).

### Description (What does it do?)

Flips `edxapp:enable_courseware_index: "true"` in the `mitx`, `mitx-staging`, and `mitxonline` **Production** stack configs. This is the last step of the rollout started in #5422, which enabled the flag in CI and QA only and deliberately left production untouched pending verification.

- `ENABLE_COURSEWARE_INDEX` gates the course-publish signal that enqueues `update_search_index` (edx-platform `cms/djangoapps/contentstore/signals/handlers.py:158`). With it off, nothing has ever written to these three deployments' Typesense clusters, even though `TYPESENSE_ENABLED`/`SEARCH_ENGINE` were already configured for reads.
- Each of these three Production stacks already carries `typesense:enabled: "true"` and `typesense:course_search_enabled: "true"`, so no other config changes are required — the settings-override module added in #5422 (`k8s_configmaps.py:877-898`) will now also assert `SEARCH_ENGINE = "search.typesense.TypesenseEngine"` on top of upstream's clobber.
- Also creates the `reindex-courses` weekly CronJob backstop in each of these three Production namespaces (already shipped for CI/QA in #5422, gated on the same flag).

`xpro` is intentionally excluded: `typesense:enabled: "false"` there, so enabling the flag would route indexing writes to Elasticsearch instead (the estate being retired). That's tracked separately as its own decision.

### How can this be tested?

`pulumi preview --diff` on all three affected stacks shows only the expected changes — `ENABLE_COURSEWARE_INDEX: false => true` in the general/cms/lms configmaps, the settings-override configmap gaining the `SEARCH_ENGINE` re-assertion, and one new CronJob resource created — nothing else touched:

- `mitxonline.Production`: 1 create, 9 update, 6 replace, 225 unchanged
- `mitx.Production`: 1 create, 9 update, 6 replace, 214 unchanged
- `mitx-staging.Production`: 1 create, 10 update, 6 replace, 213 unchanged

QA has been running the identical config for 12 days. Verified directly against the QA Typesense clusters (`GET /collections` on the raft leader pod) before opening this PR:

- mitxonline: `openedx_course_info` (545 docs), `openedx_courseware_content` (59,465 docs)
- mitx: `openedx_course_info` (56 docs), `openedx_courseware_content` (10,751 docs)
- mitx-staging: `openedx_course_info` (5 docs), `openedx_courseware_content` (1,746 docs)
- xpro QA (typesense disabled, as expected): `[]` — zero collections, confirming writes correctly stay off Typesense there

The QA `reindex-courses` CronJob has also completed successfully at least once (`cms-edxapp-reindex-courses-29801250`, `Complete 1/1`, 33h before this check), confirming the backstop sweep works end to end, not just incremental per-publish indexing.

### Additional Context

After this merges and is applied, existing courses in production still need a one-time backfill — the flag only starts *incremental* indexing going forward, and the weekly CronJob won't run until its next scheduled window. Recommend running, per deployment, after deploy:

```
kubectl create job --from=cronjob/cms-edxapp-reindex-courses reindex-courses-backfill-manual -n <namespace>
```

(equivalent to `./manage.py cms reindex_course --active --warning`). Celery capacity was already checked in the original investigation — `update_search_index` lands on the default CMS queue (`edx.cms.core.default`), served by 4+ replicas with KEDA autoscaling to 20, so no dead-queue risk expected, but worth watching queue depth during the initial backfill regardless.