### PR TITLE
chore(sentry): source the odl-video-service Sentry DSN from the sentry stack

### DIFF
--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -99,6 +99,7 @@ aws_account = get_caller_identity()
 network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 policy_stack = make_stack_reference(projects.POLICIES, "default")
 dns_stack = make_stack_reference(projects.DNS, "default")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
@@ -666,10 +667,15 @@ ovs_server_vault_mount = vault.Mount(
     ),
     opts=ResourceOptions(delete_before_replace=True),
 )
+# The Sentry DSN is owned by the ol-infrastructure-sentry stack rather than SOPS,
+# so it is merged into the collected secrets here instead of being carried in
+# data.{env}.yaml. See ol-infrastructure#5004.
 ovs_server_secrets = vault.generic.Secret(
     "ovs-server-configuration-secrets",
     path=ovs_server_vault_mount.path.apply("{}/ovs-secrets".format),
-    data_json=json.dumps(secrets),
+    data_json=sentry_stack.require_output("odl_video_service_sentry_dsn").apply(
+        lambda dsn: json.dumps({**secrets, "sentry": {"dsn": dsn}})
+    ),
 )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Refs https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
- OVS was the last application still taking its Sentry DSN from SOPS. The `sentry.dsn` entry was byte-identical (same IV and tag) across `data.ci.yaml`, `data.qa.yaml` and `data.production.yaml` — one hard-coded DSN cargo-culted to every environment.
- The collected SOPS blob is already written wholesale to `secret-odl-video-service/ovs-secrets`, so the DSN is merged into that write from the `ol-infrastructure-sentry` stack output instead of being carried in SOPS. Same shape `ocw_studio` uses.
- Leaves the existing `{{ index .Secrets "sentry" "dsn" }}` template in `k8s_secrets.py` untouched: no new Vault path, no policy change, no new K8s secret.
- Uses the project's Default client key (`odl_video_service_sentry_dsn`), matching every other migrated app. The project's second key, "Eternal Mink", stays exported; both ingest into project `194353`, so error reporting is unaffected either way.

### How can this be tested?
`pulumi preview --stack CI` (with the currently-deployed image digest pinned so the image produces no diff):

```
~ vault:generic:Secret ovs-server-configuration-secrets update [diff: ~dataJson]
Resources:
    ~ 1 to update
    134 unchanged
```

Only `dataJson` on the one secret changes — no replacements, no deletions.

Post-merge, confirm OVS errors still land in the `odl-video-service` Sentry project.

### Verified against Sentry

Confirmed via the Sentry API for `mit-office-of-digital-learning/odl-video-service`:

- Both client keys are **active** and ingest into the **same project, `194353`** — so error reporting continues regardless of which one was previously in use.
  - Default: `f75d3b6abb8f4a30b95769f8f9644ee3` (what this PR uses)
  - Eternal Mink: `7e70a5f1227743959ba1cb1e8db1240f`
- **Neither key has a rate limit configured**, so the differing-per-key-rate-limit concern raised when scoping this work does not apply.
- OVS is actively reporting: issue `ODL-VIDEO-SERVICE-31P` last seen `2026-08-31T16:59:02Z` (12,384 occurrences, `environment:production`, `server_name: ovs-celery-celery-worker-*`, release `0.94.5`). That reporter is the Celery worker in the `odl-video-service` namespace, which sources `SENTRY_DSN` from `ovs-app-secrets` — the secret this PR rewrites.

**This is not a pure source swap: the DSN string itself changes.** The stored SOPS value is 71 bytes; the live DSN is 74 bytes. With the org (`o48788`) and project (`194353`) known, the 3-byte delta is exactly `us.` — i.e. SOPS held a legacy pre-regionalization host (`o48788.ingest.sentry.io`) and the stack output uses the current regional host (`o48788.ingest.us.sentry.io`). Both are valid (Sentry continues to accept legacy hosts, which is why OVS reports fine today), and every other migrated app already uses the regional form. Noting it so the host change isn't a surprise.

Which of the two keys OVS was previously using could **not** be determined: Sentry does not expose the ingesting client key on event payloads, there is no key-usage/stats tool available, and the SOPS plaintext is deliberately unreadable via tooling. Default was chosen for consistency with every other migrated application.

### Additional Context
The now-inert SOPS `sentry:` entries are **not** removed here. `.sops.yaml` requires both an AWS KMS recipient and an `hc_vault_transit_uri` recipient, and re-encrypting without Vault transit access would drop the latter. The Pulumi write overrides those entries, so they are already dead; scrubbing them is tracked as follow-up.

