### PR TITLE
chore(sentry): source the micromasters Sentry DSN from the sentry stack

### DIFF
--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -101,6 +101,7 @@ micromasters_config = Config("micromasters")
 stack_info = parse_stack()
 network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 dns_stack = make_stack_reference(projects.DNS, "default")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 vector_log_proxy_stack = make_stack_reference(
     projects.VECTOR_LOG_PROXY, f"operations.{stack_info.name}"
 )
@@ -385,6 +386,19 @@ micromasters_vault_k8s_policy = vault.Policy(
     policy=Path(__file__).parent.joinpath("micromasters_policy.hcl").read_text(),
 )
 
+# Dedicated single-purpose path for the Sentry DSN, sourced from the
+# ol-infrastructure-sentry stack output. It deliberately does NOT write to
+# secret-micromasters/sentry: that path also holds a hand-managed auth_token
+# with no source in this repo, and is kv-v1 (unversioned) in QA/Production, so
+# a whole-secret overwrite there would silently drop the token. See #5004.
+micromasters_operations_sentry_dsn = vault.generic.Secret(
+    f"micromasters-operations-sentry-dsn-{stack_info.env_suffix}",
+    path="secret-operations/global/micromasters/sentry-dsn",
+    data_json=sentry_stack.require_output("micromasters_sentry_dsn").apply(
+        lambda dsn: json.dumps({"value": dsn})
+    ),
+)
+
 micromasters_vault_k8s_auth_backend_role = vault.kubernetes.AuthBackendRole(
     f"micromasters-vault-k8s-auth-backend-role-{stack_info.env_suffix}",
     role_name="micromasters",
@@ -639,7 +653,9 @@ django_secret = OLVaultK8SSecret(
     opts=secret_opts,
 )
 
-# Static secrets - Sentry credentials
+# Static secrets - Sentry auth token. The DSN used to live alongside it on this
+# path; it now comes from the sentry stack via the dedicated secret-operations
+# path below, leaving the hand-managed auth_token here untouched.
 sentry_secret_name = "micromasters-sentry-secret"  # noqa: S105  # pragma: allowlist secret
 sentry_secret = OLVaultK8SSecret(
     f"micromasters-{stack_info.env_suffix}-sentry-secret",
@@ -656,11 +672,36 @@ sentry_secret = OLVaultK8SSecret(
         exclude_raw=True,
         templates={
             "SENTRY_AUTH_TOKEN": '{{ get .Secrets "auth_token" }}',
-            "SENTRY_DSN": '{{ get .Secrets "dsn" }}',
         },
         vaultauth=vaultauth,
     ),
     opts=secret_opts,
+)
+
+# Static secrets - Sentry DSN, owned by the ol-infrastructure-sentry stack
+sentry_dsn_secret_name = "micromasters-sentry-dsn-secret"  # noqa: S105  # pragma: allowlist secret
+sentry_dsn_secret = OLVaultK8SSecret(
+    f"micromasters-{stack_info.env_suffix}-sentry-dsn-secret",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        name=sentry_dsn_secret_name,
+        namespace=micromasters_namespace,
+        labels=k8s_global_labels,
+        dest_secret_name=sentry_dsn_secret_name,
+        dest_secret_labels=k8s_global_labels,
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path="global/micromasters/sentry-dsn",
+        excludes=[".*"],
+        exclude_raw=True,
+        templates={
+            "SENTRY_DSN": '{{ get .Secrets "value" }}',
+        },
+        vaultauth=vaultauth,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=[vault_k8s_resources, micromasters_operations_sentry_dsn],
+    ),
 )
 
 # Static secrets - CyberSource credentials
@@ -773,6 +814,7 @@ k8s_secret_names = [
     mailgun_secret_name,
     mit_smtp_secret_name,
     redis_creds_secret_name,
+    sentry_dsn_secret_name,
 ]
 k8s_secret_resources = [
     aws_creds_secret,
@@ -789,6 +831,7 @@ k8s_secret_resources = [
     mailgun_secret,
     mit_smtp_secret,
     redis_creds_secret,
+    sentry_dsn_secret,
 ]
 
 k8s_env_vars: dict[str, str | int] = {

--- a/src/ol_infrastructure/applications/micromasters/micromasters_policy.hcl
+++ b/src/ol_infrastructure/applications/micromasters/micromasters_policy.hcl
@@ -25,6 +25,10 @@ path "secret-micromasters/metadata/*" {
   capabilities = ["read", "list"]
 }
 
+path "secret-operations/global/micromasters/sentry-dsn" {
+  capabilities = ["read"]
+}
+
 path "secret-operations/mailgun" {
   capabilities = ["read"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Refs https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
micromasters was still reading `SENTRY_DSN` from `secret-micromasters/sentry`, a hand-populated Vault path. This is deliberately **not** the one-liner the other apps got, because writing the DSN to that path is unsafe:

- The path also holds `auth_token`, a Sentry API token with no source anywhere in this repo. A `vault.generic.Secret` write replaces the whole secret, so it would silently drop the token with nothing to carry it forward from.
- The `secret-micromasters` mount is kv-v2 in CI but **kv-v1 in QA/Production**. kv-v1 has no versioning, so a bad write there is unrecoverable.
- micromasters had no Pulumi-managed Vault writes at all; every one of its `secret-micromasters` paths is read-only from Pulumi's perspective.

So this writes nothing to `secret-micromasters/sentry`. Instead:

- The DSN gets a dedicated path, `secret-operations/global/micromasters/sentry-dsn`, matching the pattern established for mitxonline (#5228) and mit-open (#5230).
- The Sentry K8s secret is split in two: `SENTRY_AUTH_TOKEN` keeps reading the original path, `SENTRY_DSN` reads the new one. `auth_token` is never touched.
- Adds the corresponding read grant to `micromasters_policy.hcl`.
- The new secret is appended to `k8s_secret_names`/`k8s_secret_resources` rather than inserted beside its sibling, keeping the Deployment diff to a single added `secretRef` instead of renumbering every `envFrom` entry.

### How can this be tested?
`pulumi preview` against both mount types, no deletes or replacements in either:

| Stack | Result |
|---|---|
| QA (kv-v1) | `+ 4 to create`, `~ 9 to update`, 115 unchanged |
| CI (kv-v2) | `+ 4 to create`, `~ 8 to update`, 116 unchanged |

Both show the `SENTRY_DSN` template removed from the existing sentry secret and added to the new one, and `secret-micromasters/sentry` itself unmodified. (QA's extra update is a pre-existing `pulumi:providers:vault` 7.11.1 → 7.12.0 bump, unrelated to this change.)

Post-merge, verify the micromasters pods still have both `SENTRY_DSN` and `SENTRY_AUTH_TOKEN` populated, and that `secret-micromasters/sentry` still holds its `auth_token`.
