### PR TITLE
feat(dagster): give data_loading the MITx Online app database

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -113,6 +113,16 @@ keycloak_stack = (
     if stack_info.env_suffix in ("ci", "qa", "production")
     else None
 )
+# Same shape as Keycloak: MITx Online is deployed to CI/QA/Production only, so
+# the Dev Dagster stack goes without the host and that source stays unavailable
+# there. Its app database is what the mitxonline_app dlt source reads
+# (RFC 12711 step 8) -- the QA data lake cannot validate the B2B dashboard while
+# it holds nothing from the QA app.
+mitxonline_stack = (
+    make_stack_reference(projects.MITXONLINE, stack_info.name)
+    if stack_info.env_suffix in ("ci", "qa", "production")
+    else None
+)
 
 # VPC and network configuration
 mitodl_zone_id = dns_stack.require_output("odl_zone_id")
@@ -2269,6 +2279,14 @@ for location in code_locations:
             {
                 "name": "KEYCLOAK_DB_HOST",
                 "value": keycloak_stack.require_output("keycloak")["rds_host"],
+            }
+        )
+
+    if name == "data_loading" and mitxonline_stack is not None:
+        deployment["env"].append(
+            {
+                "name": "MITXONLINE_APP_DB_HOST",
+                "value": mitxonline_stack.require_output("mitxonline")["rds_host"],
             }
         )
 

--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -80,6 +80,15 @@ path "postgres-keycloak/creds/readonly/*" {
 path "postgres-keycloak/creds/readonly" {
   capabilities = ["read"]
 }
+# MITx Online application database, ingested by the data_loading dlt pipeline
+# (RFC 12711 step 8). Distinct from mariadb-mitxonline above, which is the
+# Open edX MySQL database for the same deployment.
+path "postgres-mitxonline/creds/readonly/*" {
+  capabilities = ["read"]
+}
+path "postgres-mitxonline/creds/readonly" {
+  capabilities = ["read"]
+}
 path "secret-data/" {
   capabilities = ["list"]
 }


### PR DESCRIPTION
Companion to mitodl/ol-data-platform#2623 (RFC 12711 step 8), which moves the MITx Online application-database ingest from Airbyte to a dlt source in the `data_loading` code location.

That source connects by host and takes short-lived credentials from Vault at connection time (`ol_dlt.database`), so it needs two things this stack owns:

- `MITXONLINE_APP_DB_HOST` on the `data_loading` deployment, from the mitxonline stack's `rds_host` output.
- `read` on `postgres-mitxonline/creds/readonly` in `dagster_server_policy.hcl`. Distinct from the `mariadb-mitxonline` grant already there, which is the Open edX MySQL database for the same deployment.

Same shape as the Keycloak wiring directly above it, including the CI/QA/Production gate — MITx Online has no Dev stack to reference, so the Dev Dagster deployment goes without the host and that source stays unavailable there.

No security-group change is needed: `mitxonline_db_security_group` already admits `data_vpc["security_groups"]["orchestrator"]` (`applications/mitxonline/__main__.py:299`) and the data VPC pod subnet CIDRs (`:306`), the same workaround Keycloak's DB group uses.

## Testing

`pulumi preview --stack QA`: 3 to update, 90 unchanged, no deletes or replaces. The Vault policy diff shows the two added `postgres-mitxonline/creds/readonly` paths, and the user-code Helm release adds exactly one env entry, to the `data_loading` deployment only. The image-tag churn in the same preview is pre-existing drift, not from this change.

`pre-commit run` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6BpXQenXw1t9ao2KWxeoX