### PR TITLE
feat(edxapp): enable residential course features on mitxonline

### DIFF
--- a/src/bridge/secrets/edxapp/mitxonline.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.ci.yaml
@@ -25,6 +25,7 @@ github_access_token: ENC[AES256_GCM,data:A7ba+oo3mUgDfVtYu0jm9hor3vaPgNvprHX8/X8
 meilisearch_master_key: ENC[AES256_GCM,data:36e4lYgbPAGSxTQDC5VYjEcXnyQ7rKRdInkTuLfYL6jdFwBfMeF6g1WVORnEdllYMDf7Ixo9Ty6JcBOdp/Txbw==,iv:gxM4u3F6oeXHCK1pDCjrInrXF6ZmP32mhzbK2iyo7n8=,tag:5l8q5lUp7xBEjE2K5e3fJg==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:H1emHo5/df6MBXpsUNAISxlU+vFTiUzytQ2UPyGjiALVU8jJ9Mlg/feH7JSab8kSZEr4Dl/UyaqkCTVXJtmhKw==,iv:oIwgYgv7YDI0CA0Em3btB0+E6NUCe2w7ZEmfxVasR0k=,tag:d/PgI0UvYdm85rE88EDyeA==,type:str]
 typesense_bootstrap_key: ENC[AES256_GCM,data:UrYqYLW+GfeMxaPpAi7EfMz8r5enWVrSqiQfWGeKLz9tF9iHD+cpRihzQsDDeGbX29JFfnkexBq3L5vhvG7dBg==,iv:EDoCy6tic8She2LNFh4uh37JRj0ALpmC1MkfxUpFJxY=,tag:FpRUhCFVVOcZtnDkF23u2g==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:cCbqLO/gCTCKKiHFmggOp85rj9Yl9BsUHtNlLiWKhboRHb9LgaSM,iv:G6RF9SrSmk6k1DSViktY01PTxEgsr2opTTo4Mz9A3pw=,tag:cULmG8CE2slwsMblIiPagA==,type:str]
 sops:
   hc_vault:
   - created_at: "2025-08-28T20:35:02Z"
@@ -37,7 +38,7 @@ sops:
     aws_profile: ""
     created_at: "2025-08-28T20:35:02Z"
     enc: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAHlqCRlxIfgpLm8bF77GeFQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM+8/juNZp/oUFKTgaAgEQgDuDSA4KTjEQVCLPa8Txo55rBIDSCzCvas0Kca8QUvtVGQ6IlPtKGiftrQ5UD/VxX56lOqJd04shL814HA==
-  lastmodified: "2026-08-31T16:12:19Z"
-  mac: ENC[AES256_GCM,data:yboVIeNnL3s4SnMA8T3fIDtpDgbSqOaIfjwODJNT64yulv09RBa/dBAlpWTJ8U9KL6kfZdBhUsRbmiR201kDp8wJybxPcME4chcsQhMY2gu59uWiTThDTzZxPBKufMJVtL/WbiSc38oMMq8fqve8NmeQhbP52iFooz2mU1XVbAg=,iv:CtjbSwMVrBeKMU/WjVfDvNE0bghcAwGKAaV2eZSubJw=,tag:Z9+R24xfSeDbivdxeHwjdA==,type:str]
+  lastmodified: "2026-08-31T17:31:29Z"
+  mac: ENC[AES256_GCM,data:O2mkHYZE0t0rNsS5Mz6s4HUQjjP5GVXjdzajsl+LzSf3e5jIF0oTfiOBWblFiO13nZj6BU3UUCB8LBXmjlt6hKtpHfDkDPkrCBki8m+bAdDi1RZY7QXD+iFN9foGRGaWt09uavwwxA9e3z2AKUZTQN1mrs8yccsMMuOhrVZq92Y=,iv:OMHdpBVR1NaptBCp7aeQFIsvWLXoURwZL/gfqMcb3AA=,tag:ZSY4B8DRrFGJi6EC+7fGyA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -27,6 +27,7 @@ meilisearch_master_key: ENC[AES256_GCM,data:RF7xIyMIghjz6y+X6ieknbUoNIzLj2EDmi4c
 meilisearch_api_key: ENC[AES256_GCM,data:28MELjHEZlaI1/7Bu0IM2ErwX1BY3JVVTPaF77FU6PjFlapnyUWyHrJ4fsziPS7uyps3RSxcpXgq8JfXU2w6bw==,iv:2Pc0shcPQjFBEiKJk1CHhR620M262n/5QMiKXp6WBlQ=,tag:XA+AqkwY8MZRB27Qoeb7yQ==,type:str]
 typesense_bootstrap_key: ENC[AES256_GCM,data:oVG9YKgGM+2wYg5I83ByNpKwOWBH8p/pytNXV4InQ1OAAphX4zs3xTRLkqCLOAtczMrCIlZKI6iMEubNNl/VSg==,iv:L1QF2MaqDDqPLkRK+h6SBm8lzl+5vUIfONOl8ZezW24=,tag:UFcGsgFs9xL1pkOtphupag==,type:str]
 webhook_access_token: ENC[AES256_GCM,data:71/N9+kkAbgql4T1nB3SrgbUaFIyjY2N720nxbrP,iv:3JSSfCPoFgxPLFEWbIpkBxBwOY5Uw3oYVmVrHWsaEGw=,tag:3IehOaESFE2uy14CVeTqmg==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:qfMn1aFiN8ux65Xf/urbDqvelsw0UuTg6Aa0LZ6q26OEho3Sn+uI,iv:vN3V6aAwtlFWAY2uT6SlH1wzhPnsLwJj7KiCcHKEaPk=,tag:hJxUH1UuIFsTXlGlW/kezg==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-08-18T18:43:15Z"
@@ -39,7 +40,7 @@ sops:
     aws_profile: ""
     created_at: "2026-08-18T18:43:15Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwG8fSPOSUCNnJQpUj8Rdpo7AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLyu5ZyO8QQp601oFAgEQgDt4ujdhwvpykeeS+JAA5C8/iycf1rgbxsDmPrpB6H+hgBsThqrHfZ+7MW/wPnFswYs4c5/xMDRXBgqmvA==
-  lastmodified: "2026-08-31T16:12:20Z"
-  mac: ENC[AES256_GCM,data:gJYFO031P+IM6MtT6hbxRlU+E9SuFqY1ME2mjpKe2mLZoT6GVOXZ8+PA7P7Vwj/uh18sNHxbhWgOPgDO4Z2aXPMQooBmrcRnbe7+O1X4aEJyLhMRuL6PTchRKCOPMVyj8nyEsDzvPfQ99ve7aQI/r+3FQr1lo68yj8VUe4Dem1c=,iv:b7QiAbyzrfNOa7VOD0EZdEBacW/iej1PObqTXuGskGI=,tag:mQUa0/1x+ks0YVCM37owlw==,type:str]
+  lastmodified: "2026-08-31T17:31:04Z"
+  mac: ENC[AES256_GCM,data:YXMS0gkddWsoA3YhdSPjF9QXlsBEQoPIBR8ixWmOuUh1MGxp27RiFvmWoufcVbaIVTDcU8R1C4TuSXBg7VTss5+WOPM2SkkBeNgW9mngvSHPM8zHJEZ/Z8/MebXNA1wqumFwZ+TYVWLVLic8S4f+uyzLRB7PANis/5k0kiFFFxI=,iv:1pT4+9NpnvApa0gFTdQdvZwtpOrOv/qbipSSxJJzCsY=,tag:co1iVrw3UbeQxwRjHM/gOQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -26,6 +26,7 @@ meilisearch_master_key: ENC[AES256_GCM,data:AruMFclrbpvG30v6aCYvtP6F3mcAGerA2hB/
 meilisearch_api_key: ENC[AES256_GCM,data:KgOLFKuVlzhmvAnSgewqLOjXzWFeUGPQ8aJ4NpljIKPKm3zu33w+XA8Lry+0+DI2yQW+auxhC7LHQS/eAIlH3A==,iv:MUgfZfWXgYpjjCPpeYQ1KD3uuC56fvSya+KRgPEzee4=,tag:HDytyH56dJcRcIYZMDi+lQ==,type:str]
 typesense_bootstrap_key: ENC[AES256_GCM,data:6uNFa7No/8hLrgzoKqUhTPUWGoM3URrcW5E+Zye0fFRgZ/9idtwgvi1J6aJCsq1b2pyukfSNQJcWYOurju1rWw==,iv:hMHBo3QIiiWy1FQ4GVuW/jHdrqXgrZ1ESKTQwaOcbsQ=,tag:UeAbCRp60i+FCkvIDA+k4A==,type:str]
 webhook_access_token: ENC[AES256_GCM,data:H0+hjAQCQ+4viU3Z5dG9qA2YDijA3jAW60RfdsBp,iv:R6opuBQF4mZuEdOdtaZGTHTiZgE53DqxeT45+4BRQFs=,tag:oIx8m8jloA0esdy49R6nsQ==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:TnEIm9b08QBTWfD+Y2jrX2QkBS5f1f7ZoQW16KZD8MdfuTEvfhkM,iv:a5+Sm7RqvBDuUU+GHV+kZOD+uG1XuSPlRKBJX4CGJAk=,tag:p9uhkyqeW4yePpyFkZgkRQ==,type:str]
 sops:
   hc_vault:
   - created_at: "2025-08-28T20:37:22Z"
@@ -38,7 +39,7 @@ sops:
     aws_profile: ""
     created_at: "2025-08-28T20:37:22Z"
     enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQECb3uGmATbrEE+B6xsVQT+AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMft5GBa2P5vK52JQsAgEQgDvS/SL4r/yZtgkDuhb90XnqDrfgpAP1+5FnqhTiVLv9fZ9ifhtSMw5GdHQgv1iyiMyBnofkQejlJQkJ6Q==
-  lastmodified: "2026-08-31T16:12:20Z"
-  mac: ENC[AES256_GCM,data:G2VbIcfsqQnBq2Q40aaUS2E97z1D7QPWlNsCpJoK8Fgmv9GuIrdzbNn8ZS0vbNMdGUtKjqnULIUBaOx2GIwfDMpG4/cwIMhe2sp/w2sqXZz9eUWDXX/uCjPmuP7NpatCsj5ORH3JjB31H+b1399+x95JjivcPPBw4OQGItaiqVw=,iv:5WQgwBWxThYTQolyy+kAREJo+mHUcHLjCVPnQidbT2Y=,tag:IBsAAXZiyKif/4/FS1f9BQ==,type:str]
+  lastmodified: "2026-08-31T17:31:53Z"
+  mac: ENC[AES256_GCM,data:b/PGGVA/Cb6TPGQesVb+/KQ6V7TUB0aJI3omP8bzocbzUl851bHOqCH8P/3lwYYxRE1+uRwT1efUM75WGk/IbIt6GbXVfYMa7CoNL9EXuYUtRnFtLQyiYYUntHAgVeKWmDJ3EKx5mFVNEY8QGY7xmUEA8baVP2zVIOu0IIsV7wM=,iv:dH/yL0xwYz3kMYvzoZ8zDkFrOOTroUyrxT2j/aPB3Fk=,tag:LPDMdHQ4GYjCwBTBvzauMA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -56,6 +56,15 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:nTKkM6zA0wbJaq3T:LyxTy566zTW65zkQLLKsFGmCIPmPRB1rkXcsAg37hI+EUTX07XfX5TkpfdyBBRdntiLJ7odzNss=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -56,14 +56,6 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
-  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
-    "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
-  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
-  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
-    "--everyone"]
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -54,14 +54,6 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
-  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
-    "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
-  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
-  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
-    "--everyone"]
   edxapp:canvas_base_url: https://canvas.mit.edu
   edxapp:use_extracted_html_block: "false"
   edxapp:appzi_url: "https://w.appzi.io/w.js?token=Q2pSI"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -54,6 +54,15 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://canvas.mit.edu
   edxapp:use_extracted_html_block: "false"
   edxapp:appzi_url: "https://w.appzi.io/w.js?token=Q2pSI"
   edxapp:business_unit: mitxonline

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -57,14 +57,6 @@ config:
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
   - ["ol_openedx_feedback.feedback_enabled", "--create", "--everyone"]
-  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
-    "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
-  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
-  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
-    "--everyone"]
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -57,6 +57,15 @@ config:
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
   - ["ol_openedx_feedback.feedback_enabled", "--create", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -643,6 +643,10 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
                 "ENABLE_V2_CERT_DISPLAY_SETTINGS": True,
                 "ENABLE_BULK_USER_RETIREMENT": True,
                 "ENABLE_PROCTORED_EXAMS": True,
+                "ENABLE_CANVAS_INTEGRATION": True,
+                "ENABLE_RAPID_RESPONSE_AUTHOR_VIEW": True,
+                "MAX_PROBLEM_RESPONSES_COUNT": 10000,
+                "ENABLE_INSTRUCTOR_BACKGROUND_TASKS": True,
             },
             "OAUTH2_PROVIDER": {
                 "ALLOWED_REDIRECT_URI_SCHEMES": [

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -363,12 +363,15 @@ def _build_interpolated_config_dict(
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":
+        config["CORS_ORIGIN_WHITELIST"].append("https://idp.mit.edu")
         config["CSRF_TRUSTED_ORIGINS"] = [
+            "https://canvas.mit.edu",
             f"https://{domains['lms']}",
             f"https://{domains['studio']}",
         ]
         config.update(
             {
+                "CANVAS_BASE_URL": edxapp_config.require("canvas_base_url"),
                 "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",
                 "MITXONLINE_BASE_URL": f"https://{marketing_domain}/",
                 "ENROLLMENT_WEBHOOK_URL": f"https://{marketing_domain}/api/openedx_webhook/enrollment/",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -770,7 +770,7 @@ def create_k8s_configmaps(  # noqa: PLR0915
     # with the LMS settings, so the entry must live in the LMS config and
     # route explicitly to the CMS worker queue. Excludes mitx-staging, which
     # has no CANVAS_ACCESS_TOKEN wired.
-    if stack_info.env_prefix == "mitx":
+    if stack_info.env_prefix in ("mitx", "mitxonline"):
         lms_general_config_content["CELERYBEAT_SCHEDULE"] = {
             "sync_canvas_due_dates": {
                 "task": "ol_openedx_canvas_integration.cms_tasks.sync_canvas_due_dates_for_all_courses",

--- a/src/ol_infrastructure/applications/edxapp/secrets_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/secrets_builder.py
@@ -108,6 +108,8 @@ def _apply_deployment_secret_overrides(
     # mitxonline-specific configuration
     if env_prefix == "mitxonline":
         secrets["DEEPL_API_KEY"] = '{{ get .Secrets "deepl_api_key" }}'
+        secrets["CANVAS_ACCESS_TOKEN"] = '{{ get .Secrets "canvas_access_token" }}'
+        secrets["YOUTUBE_API_KEY"] = '{{ get .Secrets "youtube_api_key" }}'
 
     # xpro and mitx share email configuration
     if env_prefix in ("xpro", "mitx"):

--- a/tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py
+++ b/tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py
@@ -140,11 +140,11 @@ class TestBuildBaseGeneralSecretsDict:
             lms_domain="mitxonline.example.com",
         )
 
-        # mitxonline should have github and deepl
+        # mitxonline should have github, deepl, canvas, and youtube
         assert "GITHUB_ACCESS_TOKEN" in secrets
         assert "DEEPL_API_KEY" in secrets
-        # But not canvas (mitx-only)
-        assert "CANVAS_ACCESS_TOKEN" not in secrets
+        assert "CANVAS_ACCESS_TOKEN" in secrets
+        assert "YOUTUBE_API_KEY" in secrets
 
     def test_xpro_specific_secrets(self, mock_stack_info_xpro):
         """Test xpro-specific configuration."""


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10825
https://github.com/mitodl/hq/issues/10826

### Description (What does it do?)
Consolidates MITx Residential course support into the mitxonline deployment. This combines the work from #4629 and #4630, which were stale and had too many conflicts to rebase cleanly.

**Secrets (hq-10826):**
- Add `youtube_api_key` to mitxonline secrets (CI, QA, Production)
- Wire `CANVAS_ACCESS_TOKEN` and `YOUTUBE_API_KEY` into the secrets builder for mitxonline

**Config (hq-10825):**
- Enable Canvas integration (`ENABLE_CANVAS_INTEGRATION`, `CANVAS_BASE_URL`)
- Add CORS/CSRF entries for `canvas.mit.edu` and `idp.mit.edu`
- Enable residential-specific feature flags (`ENABLE_RAPID_RESPONSE_AUTHOR_VIEW`, `ENABLE_INSTRUCTOR_BACKGROUND_TASKS`, `MAX_PROBLEM_RESPONSES_COUNT`)
- Add waffle flags for new editors and studio MFE features
- Set `canvas_base_url` per environment (test Instructure for CI/QA, `canvas.mit.edu` for Production)

Supersedes #4629 and #4630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)