### PR TITLE
Allowlist cache key query param

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -885,6 +885,7 @@ CACHE_KEY_QUERY_PARAM_WHITELIST = [
     "order_id",
     "account_action",
     "account_action_status",
+    "is_new_user",
     # LearningResourceDrawer params (not in mit-learn's registry).
     "syllabus",
     "syllabus_only",


### PR DESCRIPTION
### What are the relevant tickets?
Required to land https://github.com/mitodl/mit-learn/pull/3795

### Description (What does it do?)
In adding a query param to tighten up the new account gtm tracking, it seems that we need to allowlist the query param in Fastly.
