### PR TITLE
feat(omnigraph): lift QA's per-actor write cap so the engine can be measured

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -45,5 +45,55 @@ config:
   # Cross-checked against storage_prefix at preview time — see the CI
   # config's comment on this same key for why.
   omnigraph:internal_schema_version: 6
+  # ★ QA ONLY, AND IT IS AN INSTRUMENT SETTING, NOT A TUNING. Raised 4 -> 50 so
+  # the data tier's per-actor admission cap stops bounding a measurement OF the
+  # data tier. Neither Production nor CI sets this key, so both stay on
+  # data_tier.py's DEFAULT_PER_ACTOR_INFLIGHT_MAX of 4. Do not copy this there.
+  #
+  # WHY, IN SEQUENCE. omnigraph #531 (in the `edge` build agent-kit#305 pinned)
+  # stages independent tables at the loader's write concurrency instead of a
+  # pinned 1, so the engine should absorb more concurrent writes. Two caps have
+  # each stopped that being measurable, and each was found by reading the
+  # refusal text rather than by guessing:
+  #   1. witan's client-side `_WriteGate`, 4. Raised to 50 for QA in #5671:
+  #      throughput went 6 -> 9 acked, then flattened at 9 for BOTH 16 and 24
+  #      writers.
+  #   2. this cap. With 50 slots client-side, every remaining refusal read
+  #      "actor in-flight count cap 4 exceeded (HTTP 429)" — 44 such lines in
+  #      the witan pod log across two runs, and ZERO from witan's own gate.
+  # The engine has still never been reached. This removes the second cap for
+  # the same reason the first went: at the cap it stays a candidate explanation
+  # for whatever is observed.
+  #
+  # ★ THE SIZING RATIONALE IN data_tier.py IS STALE, WHICH IS WHY THIS MOVES AT
+  # ALL. That comment derives 4 from a 30s deadline — measured 2026-08-12: n=4
+  # wall 15.54s, n=6 31.20s, n=8 51.08s/p50 33.29s, hence "at 4 every admitted
+  # write lands inside the deadline; at 8 the median is past it". The 30s came
+  # from three hardcoded ToolHive constants. ToolHive is GONE (#5448) and the
+  # budget is now 120s (WITAN_REMOTE_CALL_BUDGET_SECONDS), against which even
+  # the n=8 measurement fits with room to spare.
+  #
+  # ★ MEMORY IS NOT THE RISK, AND THIS IS THE LOAD-BEARING SAFETY POINT.
+  # In-flight MEMORY is bounded by per_actor_bytes_max, deliberately left at
+  # its default (256 MiB, sized against the pod's 2Gi limit). That is a
+  # separate and still-enforced per-actor bound, so raising the COUNT does not
+  # raise how many bytes an actor may have in flight: one actor is capped at
+  # 256 MiB whether its count limit is 4 or 50. The count was never the memory
+  # bound — data_tier.py says so itself.
+  #
+  # THE REAL RISK IS TIME, and it is the experiment. Writes are serialised per
+  # graph and the 2026-08-12 numbers show per-write cost RISING with writers
+  # (0.31 -> 0.16 req/s). If #531 did not change that, admitting 50 queues work
+  # past even the 120s budget and the caller gets a 502 of indeterminate
+  # outcome instead of a clean 429. Provoking that on QA is the point — the
+  # probe counts it in its INDETERMINATE bucket, which has been 0 in every run
+  # so far. On Production it would be a regression.
+  #
+  # Unquoted because `__main__.py` reads it with `get_int` and `_bounded_cap`
+  # refuses anything outside 0..u32 — out of range, omnigraph silently reverts
+  # to its OWN upstream defaults (16 in flight, 4 GiB), which are looser than
+  # ours in both directions. 50 is above upstream's 16, deliberately, and well
+  # inside the accepted range.
+  omnigraph:per_actor_inflight_max: 50
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgHdah3681q3jIoMB6EquY0xAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQkBOIyzkj00xRzZ9AgEQgDvOaikBeNnKV3FG4ZgMGvt3MOO4WsufLhs1b/FFH28hvQEuaZnfrQ1oLOS4NHXINUEJweVvuqaQUVj9gg==


### PR DESCRIPTION
Raises `omnigraph:per_actor_inflight_max` from 4 to 50 on the **QA** stack only. Second and last of the two caps standing between the concurrency probe and the omnigraph data tier.

### Why

[#5671](https://github.com/mitodl/ol-infrastructure/pull/5671) raised witan's client-side gate 4 → 50 for QA. Measured against deployed QA immediately after:

| writers | gate 4 | gate 50 |
|---|---|---|
| 16 | 6 acked / 10 refused | **9 acked / 7 refused** |
| 24 | 6 acked / 18 refused | **9 acked / 15 refused** |
| INDETERMINATE / LOST | 0 | **0** |

Throughput rose 6 → 9 and then **flattened at 9 for both 16 and 24 writers**. Every remaining refusal named this cap verbatim:

> `omnigraph mutate was refused by the server's admission cap … actor in-flight count cap 4 exceeded (HTTP 429, too_many_requests)`

Attribution counted from the witan pod log across both runs, not inferred: **44** per-actor/429 refusal lines, **0** from witan's own gate. Server-side outcomes 18 ok / 22 error, matching 9+9 acked and 7+15 refused with no gap either direction.

So the engine has still never been reached. This removes the second cap for the same reason the first went: *at* the cap, it remains a candidate explanation for whatever is observed.

### Why this is safe to move

**The sizing rationale is stale.** `data_tier.py` derives 4 from a 30 s deadline — measured 2026-08-12: n=4 wall 15.54 s, n=6 31.20 s, n=8 51.08 s / p50 33.29 s, hence *"at 4 every admitted write lands inside the deadline; at 8 the median is past it."* That 30 s came from three hardcoded ToolHive constants. **ToolHive was removed in #5448** and the budget is now 120 s (`WITAN_REMOTE_CALL_BUDGET_SECONDS`), against which even the n=8 measurement fits with room.

**Memory is not the risk, and this is the load-bearing point.** In-flight *memory* is bounded by `per_actor_bytes_max`, deliberately left at its default of 256 MiB (sized against the pod's 2 Gi limit). That's a separate, still-enforced per-actor bound, so raising the **count** does not raise how many bytes any actor may have in flight — one actor is capped at 256 MiB whether its count limit is 4 or 50. `data_tier.py` says as much itself: the count was re-sized against the deadline, not against memory.

**The real risk is time, and it is the experiment.** Writes serialise per graph and per-write cost *rose* with writers in the 2026-08-12 numbers (0.31 → 0.16 req/s). If #531 didn't change that, admitting 50 queues work past even the 120 s budget and the caller collects a 502 of indeterminate outcome instead of a clean 429. The probe counts that in its `INDETERMINATE` bucket, which has been 0 in every run so far. On Production that would be a regression — which is why this is QA-only.

### Scope

Verified that neither `Pulumi.Production.yaml` nor `Pulumi.CI.yaml` sets this key; both stay on `DEFAULT_PER_ACTOR_INFLIGHT_MAX = 4`.

⚠️ The data tier is `replicas=1` with `strategy=Recreate` (strict single-version storage — two binaries must never hold the same S3 store), so applying this is a brief **hard gap** in QA, not a rolling update.

### Validation

`pulumi preview` against the QA stack with the image pinned to the digest QA already runs, so the image isn't part of the diff:

```
~ 1 to update      (the omnigraph-server Deployment)
  45 unchanged
  env[2]: "4" => "50"
```

Confirmed against the live pod that `env[2]` is `OMNIGRAPH_PER_ACTOR_INFLIGHT_MAX` and that `env[3]` `OMNIGRAPH_PER_ACTOR_BYTES_MAX=268435456` (256 MiB) is untouched. Value is unquoted because `__main__.py` reads it with `get_int`, and `_bounded_cap` refuses anything outside 0..u32 — out of range, omnigraph silently reverts to its *own* upstream defaults (16 in flight, 4 GiB), looser than ours in both directions. `pre-commit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157RW6GU6WNkfqrJUQG6Ejf
