### PR TITLE
Bump the API client generator image to v7.25.0

### DIFF
--- a/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py
+++ b/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py
@@ -56,7 +56,7 @@ def generate_api_client_pipeline(  # noqa: PLR0913
     # Define parameterized image tags
     python_image_tag = "3.12-slim"
     node_image_tag = "24-slim"
-    openapi_generator_tag = "v7.2.0"
+    openapi_generator_tag = "v7.25.0"
 
     # Define script names
     generate_script: str = "generate-inner.sh"


### PR DESCRIPTION
### What are the relevant tickets?

N/A — companion to https://github.com/mitodl/mit-learn/pull/3870, which bumps the same generator for mit-learn's in-tree client.

### Description (What does it do?)

Bumps `openapi_generator_tag` in the API-clients pipeline from `v7.2.0` (Dec 2023) to `v7.25.0` — 23 minor releases.

**This tag is what governs the published clients.** The pipeline runs the client repo's `scripts/generate-inner.sh` inside this image (`api_clients_pipeline.py:122`), and that script reads no version of its own. `mit-learn-api-clients` also carries an `OPENAPI-GENERATOR-VERSION` file, but it's read only by that repo's local `scripts/generate.sh` and has no effect here — so bumping that file alone would have changed nothing about what gets published.

One pin serves both `mit-learn-api-clients` and `mitxonline-api-clients` via `PIPELINE_CONFIGS`, so **this changes both clients.**

### How can this be tested?

Not exercised in Concourse. Locally, each client was generated with its own config at both versions:

| Client (v1 config) | v7.2.0 | v7.25.0 |
| --- | --- | --- |
| mit-learn | 5 `.ts`, 0 `.md` | 5 `.ts`, **218 `.md`** |
| mitxonline | 5 `.ts`, 0 `.md` | 5 `.ts`, **246 `.md`** |

v7.25.0 added `api_doc`/`model_doc` templates. Those markdown files land inside the published packages, per API version, unless the generator configs suppress them — which is what the two prerequisite PRs below do. Both are no-ops at v7.2.0 (verified: exit 0, 0 `.md`, no warnings), so they can land first safely.

Beyond docs, the bump changes the generated clients' public types: item-level `nullable` on arrays is now honored (v7.2.0 silently dropped it), and JSDoc is dropped throughout. mit-learn's in-tree client shows the full shape of that churn in mitodl/mit-learn#3870.

### Additional Context

Nothing tracks this pin — no `customManagers` in `renovate.json` covering it — which is how it drifted 23 releases. Same gap exists for mit-learn's own three pins; noted there.

### Checklist:
- [x] Merge mitodl/mit-learn-api-clients#64 first (adds docs suppression)
- [x] Merge mitodl/mitxonline-api-clients#76 first (adds docs suppression)
