### PR TITLE
fix(github): re-instate deletion/force-push protection on release branches

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -47,6 +47,7 @@ from ol_infrastructure.lib.github_helper import (
     get_installation_token,
 )
 from ol_infrastructure.saas.github.repositories.rulesets import (
+    RELEASE_BRANCHES_RULESET_NAME,
     REQUIRED_CHECKS_RULESET_NAME,
 )
 from ol_infrastructure.saas.github.tiers import TIER_PROPERTY_NAME
@@ -323,6 +324,42 @@ def _required_checks(
     return sorted(set(ours)), sorted(set(foreign))
 
 
+def _release_branches(
+    client: httpx.Client,
+    name: str,
+    rulesets: list[dict[str, Any]],
+) -> list[str]:
+    """Recover the branch names our release-branch ruleset protects, if any.
+
+    Same reasoning as `_required_checks` above, and the same failure without it:
+    `crawl` rebuilds every repo YAML from scratch, so a hand-added
+    `protected_release_branches` value is not preserved unless the crawl derives it
+    from live state -- it is deleted, the ruleset it described disappears from the
+    fleet data, and Pulumi wants to remove the resource. That already happened once
+    to `required_status_checks` (#5566); this closes the same gap for release-branch
+    protection before it can repeat.
+
+    Identified by ruleset NAME (`RELEASE_BRANCHES_RULESET_NAME`), same as
+    `_required_checks` -- the id is assigned by GitHub at creation and differs per
+    repo. `source_type` filtering excludes inherited org rulesets for the same reason
+    it does there, though no org ruleset targets these branches today.
+    """
+    branches: set[str] = set()
+    for listed in rulesets:
+        if listed.get("source_type") != "Repository":
+            continue
+        if listed.get("name") != RELEASE_BRANCHES_RULESET_NAME:
+            continue
+        detail = _maybe(client, f"/repos/{ORG}/{name}/rulesets/{listed['id']}")
+        if not detail:
+            continue
+        includes = ((detail.get("conditions") or {}).get("ref_name") or {}).get(
+            "includes"
+        ) or []
+        branches.update(ref.removeprefix("refs/heads/") for ref in includes)
+    return sorted(branches)
+
+
 def _push_restrictions(
     protection: dict[str, Any] | None,
 ) -> dict[str, list[str]] | None:
@@ -407,6 +444,7 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
         required_checks, foreign_required_checks = _required_checks(
             client, name, protection, rulesets
         )
+        release_branches = _release_branches(client, name, rulesets)
         push_restrictions = _push_restrictions(protection)
 
         return {
@@ -453,6 +491,7 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
             ),
             "required_status_checks": required_checks,
             "foreign_required_status_checks": foreign_required_checks,
+            "protected_release_branches": release_branches,
             "ruleset_count": len(rulesets),
             "rulesets": [
                 {
@@ -522,6 +561,7 @@ _EXPECTED_REPO_KEYS = frozenset(
         "ruleset_count",
         "required_status_checks",
         "foreign_required_status_checks",
+        "protected_release_branches",
         "secret_scanning",
         "secret_scanning_push_protection",
         "dependabot_security_updates",
@@ -1218,6 +1258,11 @@ def crawl(
         # The one genuinely per-repo rule (§5.4) -- check names differ per repo.
         if repo["required_status_checks"]:
             doc["required_status_checks"] = repo["required_status_checks"]
+        # Same reasoning: without this, `crawl` deletes the declaration on every repo
+        # that has one and Pulumi tries to remove the ruleset it protects. See
+        # `_release_branches`.
+        if repo["protected_release_branches"]:
+            doc["protected_release_branches"] = repo["protected_release_branches"]
         if repo["teams"]:
             doc["teams"] = repo["teams"]
         # "Not enforced" must not become "not recorded". Where the archetype has no

--- a/src/ol_infrastructure/saas/github/repositories/__main__.py
+++ b/src/ol_infrastructure/saas/github/repositories/__main__.py
@@ -41,4 +41,6 @@ if batch:
     pulumi.log.info(f"batch filter active: {len(fleet)} of the fleet")
 
 for repo in fleet:
-    rulesets.build(repo, repository.build(repo))
+    built_repository = repository.build(repo)
+    rulesets.build(repo, built_repository)
+    rulesets.build_release_branches(repo, built_repository)

--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -249,6 +249,38 @@ def _check_required_status_checks(fleet: list[dict[str, Any]]) -> None:
         raise ValueError(message)
 
 
+def _check_protected_release_branches(fleet: list[dict[str, Any]]) -> None:
+    """Fail on `protected_release_branches` data GitHub would reject or that lies.
+
+    Same shape of check as `_check_required_status_checks`: archived repos can't
+    carry rulesets, and a non-string/empty entry would build a ruleset that
+    matches nothing while still claiming (via `_ruleset_count`-style tooling) that
+    the branch is protected.
+    """
+    problems: list[str] = []
+    for repo in fleet:
+        branches = repo.get("protected_release_branches")
+        if not branches:
+            continue
+        name = repo["name"]
+        if repo.get("archived"):
+            problems.append(f"{name}: archived repos cannot carry rulesets")
+            continue
+        if not isinstance(branches, list) or any(
+            not isinstance(b, str) or not b.strip() for b in branches
+        ):
+            problems.append(
+                f"{name}: protected_release_branches must be a list of "
+                "non-empty strings"
+            )
+    if problems:
+        message = (
+            "fleet data carries invalid protected_release_branches:\n  "
+            + "\n  ".join(problems)
+        )
+        raise ValueError(message)
+
+
 def _check_team_references(fleet: list[dict[str, Any]]) -> None:
     """Fail if any repo grants to a team slug absent from teams.yaml.
 
@@ -309,6 +341,7 @@ def load_fleet() -> list[dict[str, Any]]:
     _check_public_repo_teams(fleet)
     _check_dependabot_requires_alerts(fleet)
     _check_required_status_checks(fleet)
+    _check_protected_release_branches(fleet)
 
     # The dotfile trap is silent by construction, so assert rather than trust.
     assignments = yaml.safe_load((DATA_DIR / "archetypes-proposed.yaml").read_text())

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -22,6 +22,9 @@ homepage: https://mm.mit.edu
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: micromasters
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -22,6 +22,9 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mit-learn
+protected_release_branches:
+- release
+- release-candidate
 required_status_checks:
 - ci-gate
 - openapi-diff

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -19,6 +19,9 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mitxonline
+protected_release_branches:
+- release
+- release-candidate
 required_status_checks:
 - ci-gate
 squash_merge_commit_message: BLANK

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -20,6 +20,9 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mitxpro
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -30,6 +30,9 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: ocw-hugo-themes
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -21,6 +21,9 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: ocw-studio
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -17,6 +17,9 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: odl-video-service
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -20,6 +20,9 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: open-discussions
+protected_release_branches:
+- release
+- release-candidate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -197,6 +197,67 @@ def _check(
     )
 
 
+#: The name GitHub shows for the release-branch ruleset this module creates.
+RELEASE_BRANCHES_RULESET_NAME = "protected-release-branches"
+
+
+def _release_branch_conditions(
+    branches: list[str],
+) -> github.RepositoryRulesetConditionsArgs:
+    return github.RepositoryRulesetConditionsArgs(
+        ref_name=github.RepositoryRulesetConditionsRefNameArgs(
+            includes=[f"refs/heads/{branch}" for branch in branches],
+            excludes=[],
+        ),
+    )
+
+
+def build_release_branches(repo: dict[str, Any], repository: github.Repository) -> None:
+    """Protect a repo's release branches from deletion and force-push.
+
+    Targets `release`/`release-candidate`-style branches on repos still driven by
+    the release-script bot ("Doof"): a persistent `release-candidate` branch gets
+    promoted to `release` by merging a PR whose head is `release-candidate`, and the
+    fleet-wide `delete_branch_on_merge` default (converged in #5468) deletes a PR's
+    head branch on merge -- so without an explicit rule here, promoting a release
+    deletes the branch the next release cycle needs to exist.
+
+    This happened to `micromasters`: its `release-candidate` branch was deleted and
+    never recreated, and its `release` branch carried no protection at all (2026-08-31
+    audit). It is exactly the class of "invisible drift" org_rulesets.py warns
+    about -- classic per-branch protection is not visible to this stack and isn't
+    swept along with the rest of the org-ruleset migration, so restoring it here
+    (rather than by hand through the UI) is what keeps a future sweep from silently
+    dropping it again.
+
+    Deliberately narrower than `build()`'s default-branch ruleset: only `deletion`
+    and `non_fast_forward` are required. Nothing here asserts review counts or
+    status checks on these branches -- they receive fast-forward promotions from a
+    bot, not reviewed PRs from contributors, and `baseline-default-branch` /
+    `tier-1-hardening` already don't apply here since both scope to
+    `~DEFAULT_BRANCH` only.
+    """
+    branches = repo.get("protected_release_branches")
+    if not branches:
+        return
+
+    name = repo["name"]
+    github.RepositoryRuleset(
+        f"mitodl-repo-protected-release-branches-{name}",
+        name=RELEASE_BRANCHES_RULESET_NAME,
+        repository=name,
+        target="branch",
+        enforcement="active",
+        bypass_actors=_BYPASS,
+        conditions=_release_branch_conditions(sorted(branches)),
+        rules=github.RepositoryRulesetRulesArgs(
+            non_fast_forward=True,
+            deletion=True,
+        ),
+        opts=ResourceOptions(protect=True, depends_on=[repository]),
+    )
+
+
 def build(repo: dict[str, Any], repository: github.Repository) -> None:
     """Emit the required-status-checks ruleset for one repo, if it declares any.
 

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -1,8 +1,15 @@
-"""Per-repo rulesets: required status checks, and nothing else.
+"""Per-repo rulesets: required status checks, and release-branch protection.
 
 SEC-03 -- every repo in the org runs CI and none of it can block a merge. Closing that
 needs the one rule the §5.4 org-ruleset design deliberately left per-repo, because check
 names are per-repo facts and no org-wide ruleset can name them all.
+
+A second, unrelated ruleset also lives here: `build_release_branches()` blocks deletion
+and force-push on the `release`/`release-candidate` branches of repos still driven by
+the release-script bot ("Doof"). See that function's docstring -- it exists because the
+fleet-wide `delete_branch_on_merge` default silently deletes those branches on the PR
+merge that promotes one to the other, and the classic branch protection that used to
+prevent that is invisible to this stack and was dropped once already.
 
 THERE IS NO DRY RUN. `enforcement: evaluate` does not exist on the Team plan -- the API
 accepts the PUT and then does nothing at all (see organization/org_rulesets.py, which

--- a/tests/ol_infrastructure/saas/github/test_protected_release_branches.py
+++ b/tests/ol_infrastructure/saas/github/test_protected_release_branches.py
@@ -1,0 +1,69 @@
+"""Tests for the `protected_release_branches` fleet-data guard.
+
+Same shape as `test_required_status_checks.py`: `rulesets.py` will build a ruleset
+from any list of strings and GitHub will accept it, so the cases worth writing are
+the ones where the data is well-formed and still wrong.
+"""
+
+from typing import Any
+
+import pytest
+
+from ol_infrastructure.saas.github.repositories import archetypes
+
+
+def _check(*repos: dict[str, Any]) -> None:
+    archetypes._check_protected_release_branches(list(repos))
+
+
+def test_no_declaration_is_fine() -> None:
+    """Most of the fleet declares nothing, and that must stay silent."""
+    _check({"name": "quiet"})
+    _check({"name": "quiet", "protected_release_branches": []})
+
+
+def test_accepts_plain_branch_names() -> None:
+    """A well-formed declaration passes through untouched."""
+    _check(
+        {
+            "name": "mit-learn",
+            "protected_release_branches": ["release", "release-candidate"],
+        }
+    )
+
+
+def test_rejects_declaration_on_an_archived_repo() -> None:
+    """GitHub refuses ruleset writes on an archived repo, so it is unsatisfiable."""
+    with pytest.raises(ValueError, match="archived"):
+        _check(
+            {
+                "name": "old",
+                "archived": True,
+                "protected_release_branches": ["release"],
+            }
+        )
+
+
+@pytest.mark.parametrize("bad", [[""], ["   "], [None], ["release", ""], "release"])
+def test_rejects_empty_or_non_string_branches(bad: Any) -> None:
+    """A bare string rather than a list is in here because YAML makes it easy:
+    writing `protected_release_branches: release` silently yields the string, which
+    would iterate into single-character branch names.
+    """
+    with pytest.raises(ValueError, match="list of non-empty strings"):
+        _check({"name": "repo", "protected_release_branches": bad})
+
+
+def test_error_names_every_offender_at_once() -> None:
+    """Reporting one repo per run makes fixing a fleet a game of whack-a-mole."""
+    with pytest.raises(ValueError, match="protected_release_branches") as caught:
+        _check(
+            {
+                "name": "alpha",
+                "archived": True,
+                "protected_release_branches": ["release"],
+            },
+            {"name": "beta", "protected_release_branches": [""]},
+        )
+    assert "alpha" in str(caught.value)
+    assert "beta" in str(caught.value)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The org GitHub-ruleset migration made `delete_branch_on_merge` a fleet-wide default (#5468). Combined with `release`/`release-candidate` branch protection existing only as classic, Pulumi-invisible branch protection, that protection could be silently dropped by a future sweep — and was, on `micromasters`: its `release-candidate` branch had been deleted outright, and `release` carried no protection at all.

- Adds `rulesets.build_release_branches()` in `src/ol_infrastructure/saas/github/repositories/rulesets.py`: a `RepositoryRuleset` (`protected-release-branches`) blocking deletion and force-push on a repo's declared release branches.
- Driven by a new `protected_release_branches` field in each repo's YAML, validated in `archetypes.py` (archived-repo / non-empty-string checks, same pattern as `required_status_checks`).
- Wired into `__main__.py` alongside the existing `rulesets.build()` call.
- Set `protected_release_branches: [release, release-candidate]` on the 8 repos that still carry this branch pattern: `mit-learn`, `mitxonline`, `mitxpro`, `ocw-hugo-themes`, `ocw-studio`, `odl-video-service`, `open-discussions`, `micromasters`.

This codifies the protection in Pulumi instead of leaving it as invisible drift, so it can't be dropped again by a future org-wide sweep.

Also recreated `micromasters`' missing `release-candidate` branch (from `master`'s tip) via the GitHub API — Pulumi doesn't own branch refs themselves, so this was a one-off manual fix alongside the code change.

### How can this be tested?
- `pulumi preview` against the `ol-saas-github-repositories` stack showed exactly 8 resources to create (one `RepositoryRuleset` per repo) and 1522 unchanged — nothing else in the fleet was touched.
- Applied with `pulumi up`; all 8 rulesets created successfully.
- Verified live on each of the 8 repos with `gh api repos/mitodl/<repo>/rules/branches/release`, confirming both `deletion` and `non_fast_forward` rules now apply.
- Confirmed `micromasters` now has both `release` and `release-candidate` branches present and covered by the new ruleset.

### Additional Context
Found via a live audit this session: `gh api repos/mitodl/<repo>/branches/<branch>/protection` showed classic protection (deletion blocked) still intact on 6 of the 7 repos org_rulesets.py's own docstring names as carrying release-branch protection; `odl-video-service`'s `release` branch had none, and `micromasters` (not in that original 7) had lost the branch entirely. This PR closes that gap going forward for all 8.
