### PR TITLE
docs(witan,omnigraph): record that the QA cap experiment failed and 50 stays

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -45,10 +45,42 @@ config:
   # Cross-checked against storage_prefix at preview time — see the CI
   # config's comment on this same key for why.
   omnigraph:internal_schema_version: 6
-  # ★ QA ONLY, AND IT IS AN INSTRUMENT SETTING, NOT A TUNING. Raised 4 -> 50 so
-  # the data tier's per-actor admission cap stops bounding a measurement OF the
-  # data tier. Neither Production nor CI sets this key, so both stay on
-  # data_tier.py's DEFAULT_PER_ACTOR_INFLIGHT_MAX of 4. Do not copy this there.
+  # ★★ THE EXPERIMENT THIS WAS RAISED FOR IS OVER, IT FAILED, AND THE VALUE
+  # STAYS ANYWAY. Read this before "fixing" it.
+  #
+  # RESULT: with this cap at 50 AND witan's client-side gate also at 50, a
+  # 16-writer probe against QA returned 0 acked / 16 errored with 8
+  # INDETERMINATE (errored but committed), and every read timed out. The witan
+  # pod log recorded 13 `outcome: ok` for the same 16 writes — thirteen writes
+  # landed and not one caller learned it. Progression:
+  #     gate 4  / actor 4    6 acked, 0 INDETERMINATE  (clean refusals)
+  #     gate 50 / actor 4    9 acked, 0 INDETERMINATE  (clean 429s)
+  #     gate 50 / actor 50   0 acked, 8 INDETERMINATE  (collapse)
+  #
+  # ★ THE MEMORY PREDICTION HELD; THE TIME ONE DID NOT SAVE US. No OOMKill, 0
+  # restarts, pod Ready throughout — per_actor_bytes_max at 256 MiB did its job
+  # exactly as argued below. The failure was purely TIME: writes are still
+  # serialised per graph, the queue ran past the 120s budget, and callers
+  # collected errors for work that had already committed. So #531's parallel
+  # staging did NOT change the per-graph serialisation, and data_tier.py's knee
+  # is real even though its 30s premise went stale.
+  #
+  # ★ MAINTAINER DECISION 2026-08-31: KEEP 50 ON QA REGARDLESS. QA sees no real
+  # use, so the exposure has no victim, and leaving it lifted keeps QA
+  # unblocked for future sizing work without another two deploy cycles. This is
+  # deliberate, not an un-reverted experiment.
+  #
+  # ★ NEVER COPY THIS TO CI OR PRODUCTION. Neither sets this key, so both stay
+  # on data_tier.py's DEFAULT_PER_ACTOR_INFLIGHT_MAX of 4, and the collapse
+  # above is what raising it there would buy.
+  #
+  # DO NOT chase more throughput by raising caps further — that lever is spent.
+  # The next honest one is reducing per-write cost: a single-row insert costs a
+  # full-table FilteredRead upstream, and batching the hot witan write paths.
+  #
+  # The original rationale for trying 50 follows, kept because the reasoning
+  # about WHY each cap had to move is still correct; only its hoped-for outcome
+  # was wrong.
   #
   # WHY, IN SEQUENCE. omnigraph #531 (in the `edge` build agent-kit#305 pinned)
   # stages independent tables at the loader's write concurrency instead of a

--- a/src/ol_infrastructure/applications/witan/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/witan/Pulumi.QA.yaml
@@ -5,11 +5,37 @@ config:
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
   # witan:oidc_audience: witan
-  # ★ QA ONLY, AND IT IS AN INSTRUMENT SETTING, NOT A TUNING. Raised 4 -> 50 to
-  # take this gate OUT OF THE EXPERIMENT entirely. Neither Production nor CI
-  # sets this key at all, so both stay on witan's code default of 4 — which
-  # deployment.py describes as the measured value — and this edit must not be
-  # copied to them while the gate is load-bearing there.
+  # ★★ THE EXPERIMENT THIS WAS RAISED FOR IS OVER, IT FAILED, AND THE VALUE
+  # STAYS ANYWAY. Read this before "fixing" it.
+  #
+  # RESULT: with this gate at 50 AND omnigraph's per-actor cap also at 50, a
+  # 16-writer probe against QA returned 0 acked / 16 errored with 8
+  # INDETERMINATE (errored but committed), and every read timed out. The witan
+  # pod log recorded 13 `outcome: ok` for the same 16 writes — thirteen writes
+  # landed and not one caller learned it. That is precisely the
+  # indeterminate-write failure the gate exists to prevent. Progression:
+  #     gate 4  / actor 4    6 acked, 0 INDETERMINATE  (clean refusals)
+  #     gate 50 / actor 4    9 acked, 0 INDETERMINATE  (clean 429s)
+  #     gate 50 / actor 50   0 acked, 8 INDETERMINATE  (collapse)
+  # So omnigraph #531 bought no capacity that survives removing the caps, and
+  # the caps' value was never throughput — it is turning "your write may or
+  # may not have happened" into "nothing was written, retry".
+  #
+  # ★ MAINTAINER DECISION 2026-08-31: KEEP 50 ON QA REGARDLESS. QA sees no real
+  # use, so the exposure has no victim, and leaving it lifted keeps QA
+  # unblocked for future sizing work without another two deploy cycles. This is
+  # deliberate, not an un-reverted experiment. QA is knowingly a place where
+  # concurrent writes go indeterminate: treat a QA write-concurrency symptom as
+  # expected, not as a new bug.
+  #
+  # ★ NEVER COPY THIS TO CI OR PRODUCTION. Neither sets this key, so both stay
+  # on witan's code default of 4 — which deployment.py describes as the
+  # measured value — and there the gate is load-bearing, with real users on the
+  # other side of it.
+  #
+  # The original rationale for trying 50 follows, kept because the reasoning
+  # about WHY the first cap had to move is still correct; only its hoped-for
+  # outcome was wrong.
   #
   # Why: omnigraph #531 (in the `edge` build pinned by agent-kit#305) stages
   # independent tables at the loader's write concurrency instead of a pinned 1,


### PR DESCRIPTION
Comment-only. Both QA configs currently describe `50` as an instrument setting for a *pending* experiment. The experiment has run, it failed, and the value is staying anyway — so both comments now mislead in the same two ways: they imply a result is still awaited, and they imply the setting is temporary. Someone acting on either would revert a deliberate decision.

### The result, now recorded in both files

With witan's gate at 50 **and** omnigraph's per-actor cap at 50, a 16-writer probe against QA:

| config | acked | INDETERMINATE | reads |
|---|---|---|---|
| gate 4 / actor 4 | 6 | 0 | 8 clean |
| gate 50 / actor 4 | 9 | 0 | 8 clean |
| **gate 50 / actor 50** | **0** | **8** | **0 clean, all TimeoutExpired** |

The witan pod log recorded **13 `outcome: ok`** for those same 16 writes. Thirteen landed and no caller learned it — the indeterminate-write failure the caps exist to prevent, reproduced the moment both came off. Both caps were confirmed out of the path: 0 per-actor 429s, 0 witan-gate refusals.

So omnigraph #531 bought no capacity that survives removing the caps, and their value was never throughput — it's turning *"your write may or may not have happened"* into *"nothing was written, retry"*.

### What the failure was *not*

No OOMKill, 0 restarts, pod Ready throughout. `per_actor_bytes_max` at 256 MiB held exactly as [#5678](https://github.com/mitodl/ol-infrastructure/pull/5678) argued it would — raising the *count* never raised the per-actor byte bound. The failure was purely **time**: writes are still serialised per graph and the queue ran past the 120 s budget. `data_tier.py`'s knee is therefore real even though its 30 s ToolHive premise went stale, and the next lever is per-write cost, not more admission.

### The decision

**Keeping 50 on QA is deliberate**, not an un-reverted experiment: QA sees no real use so the exposure has no victim, and leaving the caps lifted keeps QA unblocked for future sizing work without another two deploy cycles. Both files now say so, say that a QA write-concurrency symptom is **expected rather than a new bug**, and say never to copy the values to CI or Production — neither of which sets these keys, so both remain at 4.

The original rationale for trying 50 is kept in both files: the reasoning about *why* each cap had to move is still correct; only its hoped-for outcome was wrong.

### Validation

`pulumi preview` on both QA stacks, image pinned to the digests each already runs:

```
omnigraph QA:  46 unchanged   (zero changes)
witan QA:      49 unchanged   (zero changes)
```

Zero resource changes on both, confirming the edits are inert. `pre-commit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157RW6GU6WNkfqrJUQG6Ejf
