### PR TITLE
feat(dagster): rename the learning_resources code location to delivery

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
@@ -39,7 +39,7 @@ def build_dagster_docker_pipeline() -> Pipeline:
         {"name": "data_platform", "module": "data_platform.definitions"},
         {"name": "edxorg", "module": "edxorg.definitions"},
         {"name": "lakehouse", "module": "lakehouse.definitions"},
-        {"name": "learning_resources", "module": "learning_resources.definitions"},
+        {"name": "delivery", "module": "delivery.definitions"},
         {"name": "legacy_openedx", "module": "legacy_openedx.definitions"},
         {"name": "openedx", "module": "openedx.definitions"},
         {"name": "b2b_organization", "module": "b2b_organization.definitions"},

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2136,11 +2136,7 @@ code_locations: list[dict[str, str | int]] = [
     {"name": "data_platform", "module": "data_platform.definitions", "port": 4001},
     {"name": "edxorg", "module": "edxorg.definitions", "port": 4002},
     {"name": "lakehouse", "module": "lakehouse.definitions", "port": 4003},
-    {
-        "name": "learning_resources",
-        "module": "learning_resources.definitions",
-        "port": 4004,
-    },
+    {"name": "delivery", "module": "delivery.definitions", "port": 4004},
     {"name": "legacy_openedx", "module": "legacy_openedx.definitions", "port": 4005},
     {"name": "openedx", "module": "openedx.definitions", "port": 4006},
     {


### PR DESCRIPTION
### What are the relevant tickets?
Deployment half of mitodl/ol-data-platform#2628, the first location of the 10 → 6 Dagster code-location consolidation (mitodl/ol-data-platform#2260).

**Merge order: #2628 first, this second.** The Concourse build watches `dg_projects/<name>/` and the Pulumi deployment runs `-m <module>.definitions`, so the renamed directory has to exist on `ol-data-platform` `main` before either side of this can produce a working image. #2628 itself is gated behind mitodl/ol-data-platform#2581 and #2579.

### Description (What does it do?)

Renames the `learning_resources` Dagster code location to `delivery` in the two places that name it:

- `src/ol_infrastructure/applications/dagster/__main__.py` — the `code_locations` entry. Port stays 4004; the image becomes `mitodl/dagster-delivery`, the deployment `delivery`, the module `delivery.definitions`, and the Concourse-supplied tag env var `DAGSTER_DELIVERY_IMAGE_TAG`. Collapsed to one line now that the shorter name fits the formatter's width.
- `src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py` — the matching `code_locations` entry, which drives the git resource path filter (`dg_projects/delivery/`), the image resource, the build job, and the tag env var passed to the Pulumi job.

`delivery` needs no `extra_watched_paths` entry. Its Dockerfile COPYs only `packages/ol-orchestrate-lib` and its own `dg_projects/<name>/` tree, both of which the default path filter already watches.

### How can this be tested?

- `pre-commit run` on both changed files — passed, including ruff and mypy.

Not verified here: no `pulumi preview` was run. This changes a dict entry that the deployment loop reads, and a preview against the live Dagster stack would show the `learning-resources` Kubernetes deployment being replaced by `delivery` — which is exactly the intent, but is worth seeing before apply rather than after.

`mitodl/dagster-delivery` does not exist in ECR and does not need to be created by hand. The pipeline's `registry-image` put creates it: `aws ecr describe-repositories` shows `mitodl/dagster-ml` created 2026-08-24, the day the `ml` location was added, and the ECR stack declares no dagster repositories.

**After apply, confirm in this order:**
1. The `delivery` deployment is Running and the `learning-resources` one is gone (not both — a stale deployment would keep serving a location the workspace no longer lists).
2. `delivery` loads in the Dagster UI with its assets and instigators. #2628 declares `default_status=RUNNING` on the five instigators that are live today, since instigator state is keyed on location name and does not follow a rename.
3. `SENTRY_RELEASE` on the pod is the new git short-ref.

### Additional Context

`stack_root="learning_resources/"` in `src/ol_infrastructure/infrastructure/sentry/__main__.py:2629` is deliberately untouched. That is a source-code mapping for the MIT Learn Django app's `learning_resources` package in the `open_discussions` repo, not the Dagster location, and the name collision between the two is part of why the location is being renamed.
