### PR TITLE
docs(omnigraph): runbook the full-text index rebuild, a third kind of maintenance

### DIFF
--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -79,6 +79,16 @@ kubectl -n omnigraph run omnigraph-version-probe --rm -it --restart=Never \
 Same number as the deployed stores → ordinary deploy, stop reading. Different
 number → continue.
 
+> **"Ordinary deploy" is not always ordinary.** An upgrade can leave
+> `internal-schema` untouched and still require an offline, per-branch
+> maintenance pass — omnigraph 0.10.0 kept schema 6 while changing the
+> full-text analyzer (Lance 11), which makes every existing full-text index
+> unproven and search fail closed with HTTP 409 until it is rebuilt. This gate
+> is correct to pass it; it is not the only gate. See
+> [`rebuild-full-text-indexes`](omnigraph-store-maintenance-runbook.md#omnigraph-rebuild-full-text-indexes--an-analyzer-generation-cutover)
+> in the maintenance runbook, and read the upstream release notes for anything
+> describing an index or analyzer change.
+
 ## Before you start
 
 - **Pause the `pulumi-omnigraph` Concourse pipeline.** The chain is

--- a/docs/omnigraph-store-maintenance-runbook.md
+++ b/docs/omnigraph-store-maintenance-runbook.md
@@ -297,10 +297,11 @@ the memory side.
 
 ### Cost, measured
 
-Production, 16 graphs / 18 branches / 3.97 GB: **~24 minutes of write outage**
-end to end, of which the rebuild itself was ~2 minutes. The backup and the two
-image rolls dominate, and the witan roll waits on its pre-deploy migration Job
-(~8 minutes).
+Production, 16 graphs / 18 branches / 3.97 GB (90,634 objects): **~24 minutes of
+write outage** end to end (01:43–02:07 UTC), of which the rebuild itself was
+only ~2 minutes. The backup and the two image rolls dominate, and the witan roll
+in particular waits on its pre-deploy migration Job — measured at 8m on QA and
+11m on production, so budget the larger figure.
 
 ### Which principal, and why not break-glass
 

--- a/docs/omnigraph-store-maintenance-runbook.md
+++ b/docs/omnigraph-store-maintenance-runbook.md
@@ -141,6 +141,175 @@ maintenance CLI at a different version than the server writing the store is the
 mixed-fleet case upstream documents as unsupported. This is also why the
 CronJobs pin the same digest the Deployment does.
 
+## `omnigraph rebuild-full-text-indexes` — an analyzer-generation cutover
+
+A third category, and the one that reads most like the other two while behaving
+least like them. `optimize` and `cleanup` are safe to run against a serving
+fleet; this is not. Run it when an upgrade changes the **full-text analyzer** —
+as omnigraph 0.10.0 did, upgrading Lance to 11 (upstream #581).
+
+First run in production on 2026-09-01; the notes below are measured from it,
+against omnigraph 0.10.0.
+
+### Why nothing warns you
+
+The format version does not move: `omnigraph version` still reports
+`internal-schema 6` on both sides of the upgrade, so agent-kit's pin gate
+(`bin/check_omnigraph_format.py`, against `_OMNIGRAPH_INTERNAL_SCHEMA`) stays
+**green — correctly**, because the on-disk format really is unchanged. Analyzer
+generation sits outside what that gate covers, and outside what the
+storage-format runbook's "is this actually a format bump?" check answers. There
+is no automated signal; the trigger is reading the upstream release notes.
+
+0.10.0 fails **closed**, which is the one mercy here: an index whose analyzer
+generation cannot be proven compatible raises `FullTextIndexRebuildRequired`
+(HTTP 409, detail key `full_text_index_rebuild_required`). Ordinary reads keep
+working and no partial indexed result is returned, so the blast radius is
+"search is refused", not "search quietly lies". Raw Lance under-returns silently
+on a generation mismatch; the guard exists to turn that into an error.
+
+### It is not just `council`, and not just `main`
+
+`@index` on a String property produces a **full-text** index, so grepping
+`read.gq` for `search()`/`bm25()` call sites under-counts the work. Measured
+index counts per branch:
+
+| Graph | Indexes | Node types |
+|---|---|---|
+| `council` | 34 | Memory, Task, Topic, WorkflowProject, WorkflowSession, WorkflowTrace, CodeBranch |
+| `code-bridge` | 16 | InterfaceBinding, RepoSymbol, PackageMap |
+| each `code-<repo>` | 9 | CodeFile, Symbol |
+
+The rebuild is **per branch** (`--branch`, default `main`); other branches and
+historical snapshots are untouched. So enumerate rather than assuming main-only
+— witan-code's per-actor WIP views (agent-kit ADR-0006) count, and the view
+reaper means the set changes week to week. Production in 2026-09 was 16 graphs
+but **18** (graph, branch) pairs:
+
+```sh
+for g in $(omnigraph graphs list --server http://127.0.0.1:8080 | cut -f1); do
+  for b in $(omnigraph branch list --server http://127.0.0.1:8080 --graph "$g"); do
+    printf '%s\t%s\n' "$g" "$b"
+  done
+done
+```
+
+That needs a bearer token; read `svc-witan-admin` out of the server's own
+`/etc/omnigraph/actor-tokens/tokens.json` and export it as
+`OMNIGRAPH_BEARER_TOKEN` (no subcommand takes a token flag). Run it before
+scaling the server down, since it asks the server.
+
+The per-repo `code-<repo>` graphs are re-derivable, so a full reindex is an
+alternative remedy for those. `council` is **not** — it must be rebuilt in place.
+
+### The ordering trap
+
+**Rebuild with the NEW binary, while the old fleet is stopped, BEFORE rolling
+the image.** The rebuild writes an index using whichever binary runs it, so
+rebuilding with the currently-deployed (old) binary produces an index the new
+server then refuses — the maintenance window is spent and the outage still
+arrives.
+
+Check what is actually deployed rather than trusting the version string. Both
+the pre-#581 `edge` pin and the released v0.10.0 report `omnigraph 0.10.0`, and
+only the latter is Lance 11. The cheap discriminator is the subcommand itself,
+which does not exist on the older build:
+
+```sh
+kubectl -n omnigraph exec deployment/omnigraph-server -- \
+  omnigraph rebuild-full-text-indexes --help   # `unrecognized subcommand` = pre-#581
+```
+
+### Procedure
+
+1. **Stop everything that writes the graph.** That is four CronJobs across two
+   namespaces, not just the two in this runbook's table:
+
+   ```sh
+   kubectl -n omnigraph patch cronjob omnigraph-optimize omnigraph-cleanup \
+     --type=merge -p '{"spec":{"suspend":true}}'
+   kubectl -n witan patch cronjob witan-ci-indexer witan-view-reaper \
+     --type=merge -p '{"spec":{"suspend":true}}'
+   ```
+
+   Scaling the Deployments to zero does **not** stop the two omnigraph sweeps —
+   they write S3 directly, behind the server's back. That is the same property
+   the storage-format runbook suspends them for.
+
+2. **Scale both tiers down** and wait for the pods to actually go:
+
+   ```sh
+   kubectl -n witan scale deployment/witan-server --replicas=0
+   kubectl -n omnigraph scale deployment/omnigraph-server --replicas=0
+   kubectl -n witan wait --for=delete pod \
+     -l app.kubernetes.io/name=witan-server --timeout=240s
+   kubectl -n omnigraph wait --for=delete pod \
+     -l app.kubernetes.io/name=omnigraph-server --timeout=240s
+   ```
+
+3. **Back up the graph roots and `__cluster` first.** Parallelise one
+   `aws s3 sync` per graph and write a completion marker; a serial sync of ~90k
+   objects is needlessly slow. Bucket versioning is enabled with no
+   `NoncurrentVersionExpiration` rule, so the pre-rebuild Lance versions are
+   *also* independently recoverable — but do not rely on that alone as the
+   rollback plan.
+
+4. **Rebuild, per graph and per branch, on the new image:**
+
+   ```sh
+   kubectl -n omnigraph run omnigraph-fts-rebuild --rm -it --restart=Never \
+     --image=<the NEW image, the one about to be deployed> \
+     --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+     --command -- omnigraph rebuild-full-text-indexes \
+       --cluster s3://ol-data-witan-<env>/<storage-prefix> \
+       --graph <graph-id> --branch <branch> \
+       --as svc-witan-admin --json
+   ```
+
+   Note the **storage prefix**: the cluster root is the stack's `storage_uri`
+   output (`s3://ol-data-witan-production/fmt6` today), which is what the
+   CronJobs get as `OMNIGRAPH_STORAGE_ROOT`. That is the form verified here.
+
+   Unlike `optimize`/`cleanup`, this command **accepts `--as`** — it is
+   actor-bound, and the actor attributes the write. `--json` gives you a
+   `graph_commit_id` and a `rebuilt_indexes` list per target, which is the
+   evidence worth keeping. Prefer one pod running a loop over all targets to 18
+   pod startups.
+
+5. **Then roll the images** (`pulumi-omnigraph` before `pulumi-witan`). The
+   Pulumi deploys reconcile the suspend flags and replica counts back to
+   declared state, so steps 1–2 need no manual undo — but verify rather than
+   assume: `witan-break-glass` must be `true`, every other CronJob `false`.
+
+### Verifying it worked
+
+The thing Lance 11 changes is English **stemming**, so test that specifically:
+query a stem and its morphological variant and assert the returned **slugs** are
+identical (`cluster`/`clusters`, `write`/`writes`, `migration`/`migrations`).
+
+**Do not compare hit counts.** They saturate at the CLI's 20-row display limit
+and pass even on a broken index — the check has to compare identity, not volume.
+
+Also confirm zero `requires rebuild` / `full_text_index_rebuild_required` lines
+in `omnigraph-server` logs after restart, and exercise the code side
+(`code_search_symbol`, and `witan-code deps` for `code-bridge`) rather than only
+the memory side.
+
+### Cost, measured
+
+Production, 16 graphs / 18 branches / 3.97 GB: **~24 minutes of write outage**
+end to end, of which the rebuild itself was ~2 minutes. The backup and the two
+image rolls dominate, and the witan roll waits on its pre-deploy migration Job
+(~8 minutes).
+
+### Which principal, and why not break-glass
+
+This is a **direct-storage** command gated by **AWS IAM** on the bucket, like
+`optimize`/`cleanup`/`repair` — run it on the `omnigraph-server` ServiceAccount,
+which carries the bucket's IRSA grant. Cedar is not what authorizes it, so the
+witan break-glass pod (agent-kit ADR-0005 path b) is the wrong path despite
+`svc-witan-admin` appearing in the command line.
+
 ## What this does not cover
 
 - **A storage-format bump.** That cannot be done by restart or by any command

--- a/docs/witan-admin-break-glass-runbook.md
+++ b/docs/witan-admin-break-glass-runbook.md
@@ -67,9 +67,17 @@ is deliberately asymmetric:
   fix for a bad index is a reindex), no `branch_merge` (promotion into `main` is
   CI's, with a git merge behind it), no `branch_delete` (Cedar cannot tell whose
   WIP view a delete targets).
-- **`omnigraph repair` / `optimize` / `cleanup`** — not this principal, not this
+- **`omnigraph repair` / `optimize` / `cleanup` /
+  `rebuild-full-text-indexes`** — not this principal, not this
   namespace. Those are direct-storage commands gated by AWS IAM on the bucket and
-  scheduled by the omnigraph stack. See `omnigraph-store-maintenance-runbook.md`.
+  scheduled by (or run beside) the omnigraph stack. See
+  `omnigraph-store-maintenance-runbook.md`.
+
+  `rebuild-full-text-indexes` is the one that misleads, because it *does* take
+  `--as svc-witan-admin` — it is actor-bound, so the actor attributes the write.
+  That does not make it a Cedar-authorized operation or a break-glass one: it
+  still needs the bucket IRSA grant and so runs on the `omnigraph-server`
+  ServiceAccount in the `omnigraph` namespace, not in a pod here.
 
 ### Which identity is an environment actually on?
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A — no GitHub issue. Tracked in the witan task graph as `tk-rebuild-full-text-indexes-on-the-deployed-witan--076eb6` (closed), spun out of [mitodl/agent-kit#311](https://github.com/mitodl/agent-kit/pull/311).

### Description (What does it do?)
Documents `omnigraph rebuild-full-text-indexes`, which I ran against production on 2026-09-01 for the omnigraph 0.10.0 / Lance 11 upgrade and found documented nowhere. It is a third maintenance category alongside the scheduled sweeps and `repair`, and it is the one most likely to be got wrong, because every existing signal says "ordinary deploy".

- **`docs/omnigraph-store-maintenance-runbook.md`** — new section: why no gate catches an analyzer-generation change, the real scope, the ordering trap, the procedure, verification, measured cost, and which principal runs it.
- **`docs/omnigraph-storage-format-upgrade-runbook.md`** — a caveat at the "same number → ordinary deploy, *stop reading*" decision point. 0.10.0 keeps `internal-schema 6` while changing the full-text analyzer, so that check passes — correctly — on an upgrade that still needs an offline, per-branch pass.
- **`docs/witan-admin-break-glass-runbook.md`** — adds the command to the "not this principal" list. It is a trap there, because unlike `optimize`/`cleanup` it *does* accept `--as svc-witan-admin`, which makes it look Cedar-authorized when it is still IAM-gated direct storage needing the `omnigraph-server` IRSA grant.

Three findings worth a reviewer's attention, since they contradict what I'd have guessed going in:

- **Scope is not `council`.** `@index` on a String property yields a *full-text* index, so `code-bridge` and every `code-<repo>` graph carry them too. Grepping `read.gq` for `search()`/`bm25()` call sites under-counts the work.
- **It is per branch, and the branch set is not `main`-only.** witan-code's per-actor WIP views count. Production was 16 graphs but **18** `(graph, branch)` pairs.
- **Order matters and is counter-intuitive.** The rebuild writes an index with whichever binary runs it, so it must run on the *new* image while the old fleet is stopped, *before* the roll. Running it after — or with the deployed binary — spends the window and still leaves an index the new server refuses with HTTP 409.

### How can this be tested?
Docs only; nothing to execute. The procedure it describes was executed end to end, QA first as a rehearsal and then production:

- **QA:** council rebuilt, both tiers rolled onto the new images, stemming verified. Backup taken first.
- **Production:** writers stopped (4 CronJobs across 2 namespaces + both Deployments), 90,634 objects / 3.97 GB backed up, all 18 `(graph, branch)` targets rebuilt (council 34 indexes, code-bridge 16, each code graph 9), images rolled via `pulumi-omnigraph` #54 then `pulumi-witan` #54. Write outage 01:43–02:07 UTC.
- **Verified after, not inferred:** both tiers 1/1 ready on the new digests; zero `full_text_index_rebuild_required` lines in `omnigraph-server` logs since restart; `memory_search` / `task_search` / `recall` returning ranked hits through the production endpoint as a real per-user actor; `code_search_symbol` and `witan-code deps` exercising the rebuilt code graphs and `code-bridge`.
- **The stemming check the runbook prescribes:** `cluster`/`clusters`, `write`/`writes` and `migration`/`migrations` each return an identical top-5 slug list. It insists on comparing *slugs* rather than hit counts because counts saturate at the CLI's 20-row display limit and pass even on a broken index.

To review the doc itself, the useful check is whether the procedure is followable by someone who wasn't there — particularly step 4's addressing (the cluster root includes the `fmt6` storage prefix) and the pre-flight branch enumeration.

### Additional Context
- Every number in the new section is measured from the production run, not estimated. I corrected one in the second commit: the pre-deploy migration Job budget was quoting the QA figure (8m) when production took 10m38s.
- The cross-runbook anchor link was verified to resolve by computing GitHub's slug. Worth noting my first check reported a mismatch and was wrong — GitHub's slugger replaces each space individually, so `" — "` yields a *double* hyphen.
- The pre-#581 build being Lance 10 comes from upstream's commit range as recorded in agent-kit#311, corroborated by the subcommand not existing on that build at all (`unrecognized subcommand`). Both builds self-report `omnigraph 0.10.0`, which is why the runbook gives the subcommand as the discriminator rather than the version string.
- Not addressed here: nothing automatically detects that an analyzer rebuild is needed. The storage-format gate correctly stays green through one, so the trigger remains "read the upstream release notes". Worth a follow-up if we want a real signal.
