### PR TITLE
feat: enable CANONICAL_HOSTNAME_REDIRECT_ENABLED for xPro CI & Prod

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
@@ -6,6 +6,7 @@ config:
     secure: v1:d1JeftBc68QcCrCH:tQV5P2EU4H/eF7jMjUied4fIcj2Q6d9ujnhvfn5oxJiPbh41oVff6sWQDs9SUl65gQOTWg==
   heroku:user: "mitx-devops"
   xpro:vars:
+    CANONICAL_HOSTNAME_REDIRECT_ENABLED: "True"
     CSRF_TRUSTED_ORIGINS: "https://ci.xpro.mit.edu,https://xpro-ci.odl.mit.edu"
     # CyberSource retired SOAP UsernameToken auth in their test
     # environment, so the export-compliance check errors out and blocks

--- a/src/ol_infrastructure/applications/xpro/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.Production.yaml
@@ -6,6 +6,7 @@ config:
     secure: v1:sflDJ1/1qixNMWt8:zni8/Aoc3kXrp6nBAU2oTyCcCcHrQl/yLYswzg49KlQlrg07oB4FoV/4Fr6PsCcTZ39ttw==
   heroku:user: "mitx-devops"
   xpro:vars:
+    CANONICAL_HOSTNAME_REDIRECT_ENABLED: "True"
     CSRF_TRUSTED_ORIGINS: "https://xpro.mit.edu,https://xpro-web.odl.mit.edu"
     CYBERSOURCE_REST_ENVIRONMENT: "api.cybersource.com"
     CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://secureacceptance.cybersource.com/pay"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10930

### Description (What does it do?)
<!--- Describe your changes in detail -->

Enables CANONICAL_HOSTNAME_REDIRECT_ENABLED on CI and Prod as a followup to https://github.com/mitodl/ol-infrastructure/pull/5595. See related PR for more details.