### PR TITLE
fix(eks): send APISIX http->https redirects to port 443 instead of 9443

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -13,7 +13,10 @@ import pulumi_kubernetes as kubernetes
 from pulumi import Config, InvokeOptions, Output, ResourceOptions
 
 from bridge.lib.constants import mit_learn_session_cookie_name
-from bridge.lib.magic_numbers import AWS_LOAD_BALANCER_NAME_MAX_LENGTH
+from bridge.lib.magic_numbers import (
+    AWS_LOAD_BALANCER_NAME_MAX_LENGTH,
+    DEFAULT_HTTPS_PORT,
+)
 from ol_infrastructure.lib.aws.eks_helper import (
     cached_image_uri,
 )
@@ -545,7 +548,7 @@ def setup_apisix(
                     "pluginAttrs": {
                         # Redirect http requests to port 443, not APISIX's
                         # internal TLS port 9443 (hq#10999)
-                        "redirect": {"https_port": 443},
+                        "redirect": {"https_port": DEFAULT_HTTPS_PORT},
                         **(
                             {"opentelemetry": otel_plugin_metadata}
                             if otel_tracing_enabled

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -542,11 +542,16 @@ def setup_apisix(
                     # (4318); the plugin appends ``/v1/traces`` itself.  From the
                     # receiver, traces flow through the existing tail-sampling
                     # pipeline to Grafana Cloud (see grafana.py gc-otlp-endpoint).
-                    **(
-                        {"pluginAttrs": {"opentelemetry": otel_plugin_metadata}}
-                        if otel_tracing_enabled
-                        else {}
-                    ),
+                    "pluginAttrs": {
+                        # Redirect http requests to port 443, not APISIX's
+                        # internal TLS port 9443 (hq#10999)
+                        "redirect": {"https_port": 443},
+                        **(
+                            {"opentelemetry": otel_plugin_metadata}
+                            if otel_tracing_enabled
+                            else {}
+                        ),
+                    },
                     "trustedAddresses": fastly_ips,
                     # Enable comprehensive per-phase request lifecycle tracing
                     # (SSL/SNI, rewrite, access, header_filter, body_filter, log).


### PR DESCRIPTION
### What are the relevant tickets?
Addresses the redirect half of https://github.com/mitodl/hq/issues/10999 (the http-URLs half is mitodl/mit-learn#3876).

### Description (What does it do?)
Sets `plugin_attr.redirect.https_port: 443` on the shared APISIX gateway. Without it the `http_to_https` redirect falls back to APISIX's internal SSL listen port, so plain-http requests get `Location: https://host:9443/...`. With it set to 443 the plugin omits the port entirely. Note this applies to every app behind the gateway, not just mit-learn.

### How can this be tested?
Reproduced locally against the exact prod version (`apache/apisix:3.18.0-debian` — the version prod reports in its `Server:` header). One container, no etcd or backend needed: the redirect plugin answers the request itself, so the route's upstream is never contacted.

1. In an empty directory, create `config.yaml` — routes come from a file instead of etcd, and the SSL listener on 9443 is what the plugin falls back to when `https_port` is unset (needed to reproduce the bug):

```yaml
deployment:
  role: traditional
  role_traditional:
    config_provider: yaml
  admin:
    admin_key:
      # any non-empty key; an empty one makes APISIX autogenerate a key and
      # rewrite config.yaml, which fails on a bind-mounted file
      - name: admin
        key: localtestonly
        role: admin
apisix:
  node_listen: 9080
  enable_admin: false
  ssl:
    enable: true
    listen:
      - port: 9443
```

2. Create `apisix.yaml` — one catch-all route with the redirect plugin, mirroring what `OLApisixSharedPlugins` applies. The upstream is a dummy; nothing listens there. The `#END` line is required:

```yaml
routes:
  - uri: /*
    plugins:
      redirect:
        http_to_https: true
    upstream:
      nodes:
        "127.0.0.1:1980": 1
      type: roundrobin
#END
```

3. Run APISIX with both files mounted:

```sh
docker run --rm -d --name apisix-test -p 19080:9080 \
  -v $PWD/config.yaml:/usr/local/apisix/conf/config.yaml:ro \
  -v $PWD/apisix.yaml:/usr/local/apisix/conf/apisix.yaml:ro \
  apache/apisix:3.18.0-debian
```

4. Curl it — this is the current prod behavior:

```sh
➜ curl -sI http://localhost:19080/api/v1/test -H "Host: api.learn.mit.edu" | grep Location
Location: https://api.learn.mit.edu:9443/api/v1/test
```

5. Append to `config.yaml` the block this PR causes the helm chart to render:

```yaml
plugin_attr:
  redirect:
    https_port: 443
```

6. `docker stop apisix-test`, rerun step 3, curl again — the port is gone:

```sh
➜ curl -sI http://localhost:19080/api/v1/test -H "Host: api.learn.mit.edu" | grep Location
Location: https://api.learn.mit.edu/api/v1/test
```

7. `docker stop apisix-test` cleans up.

After deploy, the same check against the live gateway should show no port in the Location header:

```sh
curl -sI http://api.rc.learn.mit.edu/api/v1/learning_resources/ | grep Location
```

### Additional Context
I verified the plugin-side behavior above, but not the chart rendering step (`pluginAttrs` → `plugin_attr` in config.yaml) — read from the existing code/comments only, since the otel attrs already ride through the same key. Worth a `pulumi preview` glance on QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
