### PR TITLE
fix(xpro): raise Granian backpressure so idle keepalives stop starving readiness

### DIFF
--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -588,7 +588,28 @@ if k8s_deploy:
                 application_module="mitxpro.wsgi:application",
                 # Stage 2 of docs/plans/granian-configuration-overhaul.md: holding
                 # pins removed, so this app now runs on the component defaults (1
-                # worker, 8 blocking threads, 16 backpressure, runtime defaults).
+                # worker, 8 blocking threads, runtime defaults).
+                #
+                # backpressure is pinned above the component default of
+                # 2 * blocking_threads because that default assumes a connection
+                # is a request. Since the nginx sidecar was removed the 26 APISix
+                # pods hold their upstream keepalive connections directly against
+                # Granian, and an idle keepalive connection spends backpressure
+                # budget without doing any work. At 16 the budget was consumed by
+                # idle connections alone -- granian_connections_active sat pinned
+                # at exactly 16 per pod while blocking threads were 1-2% busy --
+                # which starved the readiness probe (it shares this pool, see the
+                # probe notes in components/services/k8s.py) and flapped both pods
+                # out of the EndpointSlice, leaving APISix with "no valid upstream
+                # node" and ~26% of xpro requests answered with an instant 503.
+                #
+                # Request concurrency does not need this headroom: ~3 req/s at
+                # ~0.2s of in-Python time per request is well under 1 in flight,
+                # so blocking_threads stays at 8 and remains the real limit on
+                # concurrent work. 128 just stops the connection count from being
+                # the binding constraint, and matches the per-worker connection
+                # counts mitlearn already sustains.
+                backpressure=128,
                 blocking_threads_idle_timeout=120,
                 enable_metrics=True,
                 # Serve /static/* from Granian's Rust layer instead of the sidecar


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Pins `backpressure=128` on xpro's `GranianConfig` instead of taking the component default of `2 * blocking_threads` (16).

That default assumes a connection is a request. It stopped holding for xpro when the nginx sidecar was removed in #5541 and APISix began talking to Granian directly.

What is measured, from the 2026-08-31 14:42 UTC rollout onward:

- `granian_connections_active` sat pinned at exactly 16 per pod — the backpressure ceiling — for hours at a time. On the previous ReplicaSet, with the sidecar still in front, the same metric read 0-1.
- Meanwhile `granian_blocking_busy_cumulative / (busy + idle)` never exceeded ~4% and was typically 1-2%, pod CPU sat at ~0.02 cores, and `granian_blocking_queue` was 0. Request concurrency by Little's law is under 1 in flight (~3 req/s at ~0.2s of in-Python time per request, from `granian_blocking_busy_cumulative / granian_requests_handled`).

So the 16 connections were overwhelmingly not carrying requests. The likely mechanism is APISix upstream keepalive: there are 26 `apache-apisix` pods in `operations`, the repo sets no explicit `keepalive_pool`, so APISix defaults apply and idle keepalive connections spend backpressure budget without doing work. I have not counted keepalive connections from the APISix side, so treat the attribution as inference and the connection-vs-request gap above as the measurement.

The consequence is measured end to end:

- The readiness probe is an HTTP GET to the same port Granian serves (`/health/readiness/` on 8073), so it competes for the same budget. It timed out on ~80% of attempts — `Readiness probe failed: Get "http://10.13.129.13:8073/health/readiness/": context deadline exceeded`, ~3.1 failures/min against a 15s probe period.
- `kube_deployment_status_replicas_available` for `xpro-app` flapped 2 → 1 → 0 all day with **zero** container restarts, i.e. readiness, not crashes.
- With the EndpointSlice empty, APISix logged `[lua] init.lua:646: handle_upstream(): failed to set upstream: no valid upstream node` and returned an instant 503 (`request_time=0.000`, `upstream_addr=-`).

APISix over one 30-minute window for `xpro-web.odl.mit.edu`, complete status breakdown: 2007x 200, 933x 503, 593x 499, 81x 404, 61x 302. In a comparable Fastly window: 386 "Service Temporarily Unavailable" plus 405 "first byte timeout" 503s, with p95 origin latency of 30-49s against ~440-520ms in the buckets before the rollout.

`blocking_threads` stays at 8 deliberately — it was never the constraint. 128 only removes the connection count as the binding limit, and is within the per-worker range mitlearn already sustains (34-130 observed).

### How can this be tested?
What I ran:

- `uv run pre-commit run --files src/ol_infrastructure/applications/xpro/__main__.py` — passed, including `ruff check`, `ruff format`, and `mypy`.
- `XPRO_DOCKER_TAG=0.198.0 uv run pulumi preview --stack Production` (0.198.0 is the tag currently running in production, per `kube_pod_container_info`). Exactly one resource changes and nothing else:

```
~ kubernetes:apps/v1:Deployment  xpro/xpro-app
  ~ spec.template.spec.containers[0].args:
      ~ [14]: "16" => "128"

Resources:
    ~ 1 to update
    158 unchanged
```

The production figures above come from Grafana Cloud (`grafanacloud-prom`, `grafanacloud-logs`) over the 24h window ending 2026-09-01 14:00 UTC.

Not done, and the reviewer's call: **nothing has been deployed or validated post-rollout.** To validate after applying, watch for `granian_connections_active` on the `xpro` namespace rising above 16 per pod, `Readiness probe failed` events for `xpro-app` stopping, `kube_deployment_status_replicas_available{deployment="xpro-app"}` holding steady at 2, and APISix `no valid upstream node` errors for `xpro-web.odl.mit.edu` going to zero.

Applying this stack triggers a rolling restart of the two `xpro-app` pods.

### Additional Context
Two things intentionally left out of scope:

1. **The component default is the underlying bug.** [`DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER = 2`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/k8s.py#L457-L462) is derived from `blocking_threads`, which only makes sense if a connection implies a request in flight. That assumption breaks for any app fronted by APISix without a sidecar absorbing the connection fan-in, which is every app the sidecar-removal rollout touches. This PR only unblocks xpro. Worth deciding separately whether the default should change, or whether readiness should stop sharing the request connection pool — the [probe notes](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/k8s.py#L119-L129) already moved liveness to a TCP connect for this exact hazard, but readiness stayed on HTTP, so saturation now pulls the pod out of the load balancer instead of restarting it.

2. **micromasters is the next candidate, not a current outage.** It went through the same sidecar removal in #5549 and its `granian_connections_active` also peaked at exactly 16 per worker over 24h, at its cap. It produced 1 readiness-probe event record in 6h against xpro's 145, so it has headroom at current traffic rather than an active problem.
