### PR TITLE
fix(mitxonline): redirect bare `/courses/` and `/programs/` index pages to MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1102,10 +1102,13 @@ course_program_redirect_vcl = "\n".join(
 
 # Catalog pages redirect to MIT Learn's unit catalog view - no per-page mapping,
 # every /catalog/* path (and any sub-filter/department) goes to the same fixed
-# destination. Uses a distinct error code (604) from the course/program
-# redirects (603) and UAI B2C redirects (602) so this is fully additive.
+# destination. Bare /courses/ and /programs/ (no ID) are included here too,
+# since they're the index/listing views for those sections - the per-ID
+# redirect below requires a non-empty path segment, so it never matches these.
+# Uses a distinct error code (604) from the course/program redirects (603) and
+# UAI B2C redirects (602) so this is fully additive.
 catalog_redirect_vcl = (
-    f'if (req.url.path ~ "^/catalog(/.*)?$") {{\n'
+    f'if (req.url.path ~ "^/catalog(/.*)?$" || req.url.path ~ "^/(courses|programs)/?$") {{\n'
     f'  set req.http.x-redir-location = "https://{learn_frontend_domain}/c/unit/mitx";\n'
     f"  error 604;\n"
     f"}}"

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1104,7 +1104,7 @@ course_program_redirect_vcl = "\n".join(
 # every /catalog/* path (and any sub-filter/department) goes to the same fixed
 # destination. Bare /courses/ and /programs/ (no ID) are included here too,
 # since they're the index/listing views for those sections - the per-ID
-# redirect below requires a non-empty path segment, so it never matches these.
+# redirect above requires a non-empty path segment, so it never matches these.
 # Uses a distinct error code (604) from the course/program redirects (603) and
 # UAI B2C redirects (602) so this is fully additive.
 catalog_redirect_vcl = (


### PR DESCRIPTION
## What are the relevant tickets?

Fixes mitodl/hq#13100
Subissue of mitodl/hq#12027

## Description (What does it do?)

Bare `https://mitxonline.mit.edu/courses/` and `https://mitxonline.mit.edu/programs/` (the index/listing paths, no ID) were returning 404. Neither the per-ID product-page redirect (mitodl/hq#12449) nor the `/catalog/*` redirect (mitodl/hq#12504) covered these two paths — the per-ID rule requires a non-empty path segment after the prefix, so it never matched, and the catalog rule only matched `/catalog/*`.

This extends the existing catalog redirect (`catalog_redirect_vcl`) to also match bare `/courses` and `/programs`, since they're conceptually the same "list everything, no ID given" case as `/catalog` — same destination, same error code (604), fully additive. The per-ID redirect logic (`course_program_redirect_vcl`) is untouched.

Found via the mitodl/hq#12505 404 audit.

## Screenshots

N/A — infra-level redirect, no UI change.

## How can this be tested?

- `uv run pre-commit run --files src/ol_infrastructure/applications/mitxonline/__main__.py` — ruff format/check, mypy, secret detection all pass.
- `uv run pytest tests/ol_infrastructure/lib/test_fastly.py` — 17/17 pass, including the repo-wide scan that every VCL snippet is built through the validating helper.
- Manually verified the new regex (`^/(courses|programs)/?$`) against realistic and edge-case paths in Python's `re` (matches bare `/courses`, `/courses/`, `/programs`, `/programs/`; does not match per-ID pages, the UAI program page, or lookalikes like `/coursesfoo`).
- After deploy, confirm with `curl -I https://mitxonline.mit.edu/courses/` and `curl -I https://mitxonline.mit.edu/programs/` — expect `301` with `Location: https://learn.mit.edu/c/unit/mitx`.
- `pulumi preview` not run against live state — blocked by an unrelated ephemeral-agent S3 backend auth issue in this session; will need to be run before merge/deploy.

## Additional Context

Same pattern as the existing `/catalog/*` redirect (mitodl/hq#12504) and course/program redirect (mitodl/hq#12449) — this repo's Fastly VCL snippet approach in `src/ol_infrastructure/applications/mitxonline/__main__.py`.
