### PR TITLE
fix(granian): size backpressure from connections, not blocking threads

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -214,6 +214,36 @@ the nginx sidecar already absorbs part of the risk (the probe hits nginx, not gr
 **Tracked as a separate task**, sequenced after the pilot in stage 2 so probe behavior and
 concurrency behavior aren't changed in the same rollout window.
 
+  > **Correction (2026-09-01, after the xpro outage).** Two claims above are wrong.
+  >
+  > First, `backpressure` caps *connections*, not in-flight requests, so lowering it to 16
+  > made the probe hazard worse rather than less urgent. With the nginx sidecar removed
+  > (#5541, #5549) APISIX holds its upstream keepalive connections directly against
+  > Granian, and idle keepalives spend the budget while doing no work: xpro sat pinned at
+  > exactly `2 * blocking_threads` = 16 active connections per pod with its blocking
+  > threads 1-2% busy. Readiness is an HTTP GET on the same port and so competes for the
+  > same budget; it timed out on ~80% of attempts, both replicas left the EndpointSlice
+  > with zero container restarts, and APISIX answered ~26% of xpro requests with an
+  > instant "no valid upstream node" 503 for ~18 hours.
+  >
+  > Second, "the sidecar absorbs part of the risk" no longer describes any deployment.
+  > Every Granian app now talks to APISIX directly.
+  >
+  > The 2026-08-26 mitxonline CMS rollback was the same failure, misread at the time as a
+  > thread-concurrency shortfall: "saturated at 16 active connections, HTTP readiness fell
+  > to 1/3, APISIX p95/p99 60s while Django spans stayed 0.2-1.1s". Restoring 2 workers x
+  > 32 threads fixed it because it also raised backpressure to 64, not because CMS needed
+  > 64 threads.
+  >
+  > Component fix: `backpressure` now defaults to a flat `DEFAULT_WSGI_BACKPRESSURE = 128`
+  > connection budget, independent of `blocking_threads`, and the readiness failure budget
+  > widens to 6 failures x 15s / 5s timeout because this failure mode is correlated across
+  > replicas -- fast eviction empties the endpoints instead of shedding load, and
+  > Kubernetes has no minimum-available floor for readiness. Readiness stays HTTP on the
+  > app port: Granian serves one application listener, and its metrics listener answers
+  > from the Rust runtime and knows nothing about Django's dependencies. Lesson
+  > `les-granian-backpressure-budgets-connections-not-req-6064fb`.
+
 ## Capacity math
 
 Per-pod nominal request concurrency:
@@ -550,6 +580,13 @@ entirely in container args, so there is no data or schema migration to unwind.
 
 1. Runtime cgroup-based `--workers-max-rss` (entrypoint wrapper) — evaluate post-rollout.
 2. TCP liveness / HTTP readiness probe split — eligible after stage 2.
-3. Per-app `blocking_threads` and `backpressure` tuning from measured latency and burst
-   saturation before removing any remaining holding pins; the 2026-08-26 CMS rollback
-   disproved a uniform target of 8 threads / 16 backpressure.
+3. Per-app `blocking_threads` tuning from measured latency and burst saturation before
+   removing any remaining holding pins. `backpressure` is no longer part of that
+   per-app exercise: it is a connection budget with one fleet-wide default (see the
+   correction under item 5 above), and the 2026-08-26 CMS rollback that appeared to disprove
+   a uniform 8-thread target was a connection-ceiling failure, not a thread shortfall.
+4. The remaining explicit `backpressure` pins -- mitxonline app (64), edxapp CMS (64)
+   and the edxapp LMS holding pins (64) -- still cap below the component default.
+   `mitxonline-openedx` is currently pinned at its 64 ceiling with blocking threads
+   ~4.6% busy, the same signature. Removing those pins needs the mitxonline edxapp
+   deploy path unblocked first (`tk-mitxonline-edxapp-production-deploys-have-been-b-d87ca6`).

--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -235,7 +235,7 @@ concurrency behavior aren't changed in the same rollout window.
   > 32 threads fixed it because it also raised backpressure to 64, not because CMS needed
   > 64 threads.
   >
-  > Component fix: `backpressure` now defaults to a flat `DEFAULT_WSGI_BACKPRESSURE = 128`
+  > Component fix: `backpressure` now defaults to a flat `DEFAULT_WSGI_BACKPRESSURE = 256`
   > connection budget, independent of `blocking_threads`, and the readiness failure budget
   > widens to 6 failures x 15s / 5s timeout because this failure mode is correlated across
   > replicas -- fast eviction empties the endpoints instead of shedding load, and
@@ -243,6 +243,20 @@ concurrency behavior aren't changed in the same rollout window.
   > app port: Granian serves one application listener, and its metrics listener answers
   > from the Rust runtime and knows nothing about Django's dependencies. Lesson
   > `les-granian-backpressure-budgets-connections-not-req-6064fb`.
+  >
+  > **Two corrections to the correction, from PR review.** `granian_connections_active`
+  > carries a `worker` label -- it is per worker, not per pod. Every capped app's number
+  > is therefore an upper bound imposed by its own pin, not a measurement of demand, and
+  > the only app running uncapped (mitlearn: `asginl`, `backlog=None`) reaches 154 on a
+  > single worker. 256 is sized above that rather than above the capped apps, since
+  > choosing from capped apps is exactly how the 16 that took xpro down was arrived at.
+  >
+  > And the CMS case is not purely a connection ceiling. Measured per container over 7
+  > days, mitxonline CMS reaches 21.6 concurrently-busy blocking threads per pod (p99
+  > 17.2) with `granian_blocking_queue` up to 32 deep on individual workers -- real work
+  > waiting on threads. So CMS's `backpressure=64` pin is removed while its thread pins
+  > (2 workers x 32) stay: the rollback conflated two limits and only one of them was the
+  > cause, but the other is not absent. mitxonline LMS, for contrast, peaks at 5.4.
 
 ## Capacity math
 
@@ -585,8 +599,13 @@ entirely in container args, so there is no data or schema migration to unwind.
    per-app exercise: it is a connection budget with one fleet-wide default (see the
    correction under item 5 above), and the 2026-08-26 CMS rollback that appeared to disprove
    a uniform 8-thread target was a connection-ceiling failure, not a thread shortfall.
-4. The remaining explicit `backpressure` pins -- mitxonline app (64), edxapp CMS (64)
-   and the edxapp LMS holding pins (64) -- still cap below the component default.
-   `mitxonline-openedx` is currently pinned at its 64 ceiling with blocking threads
-   ~4.6% busy, the same signature. Removing those pins needs the mitxonline edxapp
-   deploy path unblocked first (`tk-mitxonline-edxapp-production-deploys-have-been-b-d87ca6`).
+4. The remaining explicit `backpressure` pins -- mitxonline app (64) and the edxapp LMS
+   holding pins (64) -- still cap below the component default. Neither is binding
+   (mitxonline app peaks at 23 connections per worker, mitxonline LMS at 26-28), so they
+   are left to their own rollout stages rather than swept along here. edxapp CMS, which
+   *was* binding at 64 on both workers continuously, is unpinned in the same change that
+   raised the default.
+5. CMS thread sizing (2 workers x 32 blocking threads) is still unmeasured against a
+   target rather than merely against demand. Demand is now known -- 21.6 busy threads per
+   pod at peak -- so a one-worker shape needs at least ~24 threads, not the component's 8.
+   Tracked as `tk-mitxonline-cms-needs-a-saturation-aware-scaling--cf08a8`.

--- a/src/bridge/lib/magic_numbers.py
+++ b/src/bridge/lib/magic_numbers.py
@@ -39,9 +39,15 @@ DEFAULT_WSGI_PORT = 8073  # Arbitrary
 # for the GIL, so this tracks the container's CPU allocation (100m-500m requested for
 # our webapps), not the request rate.
 DEFAULT_WSGI_BLOCKING_THREADS = 8
-# Multiplier applied to blocking_threads to derive Granian's --backpressure for WSGI
-# apps: enough in-flight requests to keep every thread busy plus one queued each.
-DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER = 2
+# Granian's --backpressure for WSGI apps. This caps accepted *connections* per
+# worker, not in-flight requests, so it is deliberately not derived from
+# DEFAULT_WSGI_BLOCKING_THREADS: with the nginx sidecar gone the 26 APISix pods hold
+# their upstream keepalive connections directly against Granian, and an idle keepalive
+# spends budget while doing no work. 128 sits above every connection population
+# measured in production (xpro 37 max, mitxonline 23, mitlearn 154 across two workers)
+# and coincides with what Granian itself would derive from backlog=128 at workers=1.
+# blocking_threads remains the real limit on concurrent Python work.
+DEFAULT_WSGI_BACKPRESSURE = 128
 EIGHT_HOURS_SECONDS = 28800
 FIVE_MINUTES = 60 * 5
 FORUM_SERVICE_PORT = 4567

--- a/src/bridge/lib/magic_numbers.py
+++ b/src/bridge/lib/magic_numbers.py
@@ -43,11 +43,19 @@ DEFAULT_WSGI_BLOCKING_THREADS = 8
 # worker, not in-flight requests, so it is deliberately not derived from
 # DEFAULT_WSGI_BLOCKING_THREADS: with the nginx sidecar gone the 26 APISix pods hold
 # their upstream keepalive connections directly against Granian, and an idle keepalive
-# spends budget while doing no work. 128 sits above every connection population
-# measured in production (xpro 37 max, mitxonline 23, mitlearn 154 across two workers)
-# and coincides with what Granian itself would derive from backlog=128 at workers=1.
+# spends budget while doing no work.
+#
+# granian_connections_active is a per-*worker* series (it carries a `worker` label), so
+# these are per-worker populations. Sized above the largest observed anywhere, which is
+# mitlearn at 154: mitlearn is the busiest app and the only one running uncapped
+# (interface asginl, backlog=None), so it is the only measurement that reveals real
+# demand rather than the ceiling it was given. Every WSGI app measured below it was
+# capped, so their numbers (xpro 37 against a 128 cap, mitxonline 23 against 64) are
+# upper-bounded by their own pins and cannot be read as demand. Picking a number from
+# capped apps is how the 16 that took xpro down got chosen.
+#
 # blocking_threads remains the real limit on concurrent Python work.
-DEFAULT_WSGI_BACKPRESSURE = 128
+DEFAULT_WSGI_BACKPRESSURE = 256
 EIGHT_HOURS_SECONDS = 28800
 FIVE_MINUTES = 60 * 5
 FORUM_SERVICE_PORT = 4567

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -93,7 +93,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -94,7 +94,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -94,7 +94,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -104,7 +104,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
@@ -109,7 +109,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -105,7 +105,6 @@ config:
       workers: 1
       runtime_threads: 1
       blocking_threads: 8
-      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -851,8 +851,13 @@ def create_k8s_resources(  # noqa: C901
                     ),
                     initial_delay_seconds=15,
                     period_seconds=15,
-                    failure_threshold=3,
-                    timeout_seconds=3,
+                    # Wider than the default 3x/3s: readiness shares the Granian
+                    # connection budget with user traffic and its failure is
+                    # correlated across replicas, so a fast eviction empties the
+                    # EndpointSlice instead of shedding load. See
+                    # default_probe_configs in components/services/k8s.py.
+                    failure_threshold=6,
+                    timeout_seconds=5,
                 ),
                 "startup_probe": kubernetes.core.v1.ProbeArgs(
                     http_get=kubernetes.core.v1.HTTPGetActionArgs(
@@ -1197,8 +1202,13 @@ def create_k8s_resources(  # noqa: C901
                     ),
                     initial_delay_seconds=15,
                     period_seconds=15,
-                    failure_threshold=3,
-                    timeout_seconds=3,
+                    # Wider than the default 3x/3s: readiness shares the Granian
+                    # connection budget with user traffic and its failure is
+                    # correlated across replicas, so a fast eviction empties the
+                    # EndpointSlice instead of shedding load. See
+                    # default_probe_configs in components/services/k8s.py.
+                    failure_threshold=6,
+                    timeout_seconds=5,
                 ),
                 "startup_probe": kubernetes.core.v1.ProbeArgs(
                     http_get=kubernetes.core.v1.HTTPGetActionArgs(

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -851,11 +851,11 @@ def create_k8s_resources(  # noqa: C901
                     ),
                     initial_delay_seconds=15,
                     period_seconds=15,
-                    # Wider than the default 3x/3s: readiness shares the Granian
+                    # Matches default_probe_configs: readiness shares the Granian
                     # connection budget with user traffic and its failure is
                     # correlated across replicas, so a fast eviction empties the
-                    # EndpointSlice instead of shedding load. See
-                    # default_probe_configs in components/services/k8s.py.
+                    # EndpointSlice instead of shedding load. Kept in step with
+                    # the component default -- see components/services/k8s.py.
                     failure_threshold=6,
                     timeout_seconds=5,
                 ),
@@ -1153,22 +1153,30 @@ def create_k8s_resources(  # noqa: C901
                 application_module="cms.wsgi:application",
                 port=8000,
                 no_ws=True,
-                # Restore the pre-overhaul holding pins after the 2026-08-26
-                # mitxonline production rollout showed that the component defaults
-                # cannot absorb Studio's bursty authoring traffic. With 1 worker,
-                # 8 blocking threads, and backpressure 16, every CMS pod repeatedly
-                # saturated at 16 active connections, HTTP readiness fell to 1/3,
-                # and APISIX p95/p99 latency reached 60s while Django spans remained
-                # around 0.2-1.1s. CPU- and request-rate-based autoscaling stayed at
-                # the three-replica floor because it cannot see this connection
-                # backlog. Keep these known-good values until CMS concurrency is
-                # retuned with a saturation-aware scaling signal.
-                # See docs/plans/granian-configuration-overhaul.md stage 3.
+                # Thread pins restored after the 2026-08-26 mitxonline production
+                # rollout, when the component defaults (1 worker, 8 blocking threads,
+                # backpressure 16) left every CMS pod saturated at 16 active
+                # connections with HTTP readiness at 1/3 and APISIX p95/p99 latency at
+                # 60s while Django spans stayed around 0.2-1.1s.
+                #
+                # That rollback conflated two limits, and only one of them was the
+                # cause. Saturating at exactly 2 * blocking_threads is the connection
+                # ceiling, not the thread pool -- backpressure caps connections, and
+                # idle APISIX keepalives spend it doing no work. So backpressure is
+                # unpinned here and takes DEFAULT_WSGI_BACKPRESSURE.
+                #
+                # The thread pins stay, because unlike every other app CMS does have
+                # real thread demand: measured over 7 days its concurrently-busy
+                # blocking threads reach 21.6 per pod (p99 17.2), and
+                # granian_blocking_queue reaches 32 deep on individual workers. 8
+                # threads would queue on every busy pod. Retuning these is a separate
+                # exercise from the connection fix and needs its own rollout window --
+                # see tk-mitxonline-cms-needs-a-saturation-aware-scaling and
+                # docs/plans/granian-configuration-overhaul.md stage 3.
                 workers=2,
                 runtime_mode="mt",
                 runtime_threads=2,
                 blocking_threads=32,
-                backpressure=64,
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],
@@ -1202,11 +1210,11 @@ def create_k8s_resources(  # noqa: C901
                     ),
                     initial_delay_seconds=15,
                     period_seconds=15,
-                    # Wider than the default 3x/3s: readiness shares the Granian
+                    # Matches default_probe_configs: readiness shares the Granian
                     # connection budget with user traffic and its failure is
                     # correlated across replicas, so a fast eviction empties the
-                    # EndpointSlice instead of shedding load. See
-                    # default_probe_configs in components/services/k8s.py.
+                    # EndpointSlice instead of shedding load. Kept in step with
+                    # the component default -- see components/services/k8s.py.
                     failure_threshold=6,
                     timeout_seconds=5,
                 ),

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -906,7 +906,8 @@ micromasters_k8s_app = OLApplicationK8s(
             application_module="micromasters.wsgi:application",
             # Stage 2 of docs/plans/granian-configuration-overhaul.md: holding pins
             # removed, so this app now runs on the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure, runtime defaults).
+            # blocking threads, DEFAULT_WSGI_BACKPRESSURE connections, runtime
+            # defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             # Serve /static/* from Granian's Rust layer instead of the sidecar
@@ -1014,11 +1015,11 @@ micromasters_k8s_app = OLApplicationK8s(
                 ),
                 initial_delay_seconds=15,
                 period_seconds=15,
-                # Wider than the default 3x/3s: readiness shares the Granian
+                # Matches default_probe_configs: readiness shares the Granian
                 # connection budget with user traffic and its failure is
                 # correlated across replicas, so a fast eviction empties the
-                # EndpointSlice instead of shedding load. See
-                # default_probe_configs in components/services/k8s.py.
+                # EndpointSlice instead of shedding load. Kept in step with the
+                # component default -- see components/services/k8s.py.
                 failure_threshold=6,
                 timeout_seconds=5,
             ),

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -1014,8 +1014,13 @@ micromasters_k8s_app = OLApplicationK8s(
                 ),
                 initial_delay_seconds=15,
                 period_seconds=15,
-                failure_threshold=3,
-                timeout_seconds=3,
+                # Wider than the default 3x/3s: readiness shares the Granian
+                # connection budget with user traffic and its failure is
+                # correlated across replicas, so a fast eviction empties the
+                # EndpointSlice instead of shedding load. See
+                # default_probe_configs in components/services/k8s.py.
+                failure_threshold=6,
+                timeout_seconds=5,
             ),
             "startup_probe": kubernetes.core.v1.ProbeArgs(
                 http_get=kubernetes.core.v1.HTTPGetActionArgs(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -637,7 +637,11 @@ mitxonline_k8s_app = OLApplicationK8s(
             # this app's stage of the rollout. Granian derived backpressure=64
             # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
             # Delete all four (and revert workers to the default) to adopt the
-            # component defaults (1 worker, 8 blocking threads, 16 backpressure).
+            # component defaults (1 worker, 8 blocking threads, and
+            # DEFAULT_WSGI_BACKPRESSURE connections). Note backpressure is no
+            # longer derived from blocking_threads: it caps connections, and the
+            # component default is well above this 64 (which is not binding here --
+            # this app peaks at 23 connections per worker).
             # See docs/plans/granian-configuration-overhaul.md
             workers=MITXONLINE_GRANIAN_WORKERS,
             runtime_mode="mt",

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -621,7 +621,8 @@ ocw_studio_k8s_app = OLApplicationK8s(
             application_module="main.wsgi:application",
             # Stage 1 of docs/plans/granian-configuration-overhaul.md: holding pins
             # removed, so this app now runs on the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure, runtime defaults).
+            # blocking threads, DEFAULT_WSGI_BACKPRESSURE connections, runtime
+            # defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             # Serve /static/* from Granian's Rust layer instead of the sidecar.

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -898,7 +898,8 @@ ovs_k8s_app = OLApplicationK8s(
             application_module="odl_video.wsgi:application",
             # Stage 1 of docs/plans/granian-configuration-overhaul.md: holding pins
             # removed, so this app now runs on the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure, runtime defaults).
+            # blocking threads, DEFAULT_WSGI_BACKPRESSURE connections, runtime
+            # defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             log_level=(ovs_config.get("log_level") or "info").lower(),
@@ -947,11 +948,11 @@ ovs_k8s_app = OLApplicationK8s(
                 ),
                 initial_delay_seconds=15,
                 period_seconds=15,
-                # Wider than the default 3x/3s: readiness shares the Granian
+                # Matches default_probe_configs: readiness shares the Granian
                 # connection budget with user traffic and its failure is
                 # correlated across replicas, so a fast eviction empties the
-                # EndpointSlice instead of shedding load. See
-                # default_probe_configs in components/services/k8s.py.
+                # EndpointSlice instead of shedding load. Kept in step with the
+                # component default -- see components/services/k8s.py.
                 failure_threshold=6,
                 timeout_seconds=5,
             ),

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -947,7 +947,12 @@ ovs_k8s_app = OLApplicationK8s(
                 ),
                 initial_delay_seconds=15,
                 period_seconds=15,
-                failure_threshold=3,
+                # Wider than the default 3x/3s: readiness shares the Granian
+                # connection budget with user traffic and its failure is
+                # correlated across replicas, so a fast eviction empties the
+                # EndpointSlice instead of shedding load. See
+                # default_probe_configs in components/services/k8s.py.
+                failure_threshold=6,
                 timeout_seconds=5,
             ),
             "startup_probe": kubernetes.core.v1.ProbeArgs(

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -438,10 +438,11 @@ _probe_configs = {
         ),
         initial_delay_seconds=15,
         period_seconds=15,
-        # Wider than the default 3x/3s: readiness shares the Granian connection
+        # Matches default_probe_configs: readiness shares the Granian connection
         # budget with user traffic and its failure is correlated across replicas,
         # so a fast eviction empties the EndpointSlice instead of shedding load.
-        # See default_probe_configs in components/services/k8s.py.
+        # Kept in step with the component default -- see
+        # components/services/k8s.py.
         failure_threshold=6,
         timeout_seconds=5,
     ),

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -438,8 +438,12 @@ _probe_configs = {
         ),
         initial_delay_seconds=15,
         period_seconds=15,
-        failure_threshold=3,
-        timeout_seconds=3,
+        # Wider than the default 3x/3s: readiness shares the Granian connection
+        # budget with user traffic and its failure is correlated across replicas,
+        # so a fast eviction empties the EndpointSlice instead of shedding load.
+        # See default_probe_configs in components/services/k8s.py.
+        failure_threshold=6,
+        timeout_seconds=5,
     ),
     # TCP rather than HTTP so a saturated Granian worker pool cannot fail
     # liveness and trigger a restart that removes capacity from an already

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -590,26 +590,16 @@ if k8s_deploy:
                 # pins removed, so this app now runs on the component defaults (1
                 # worker, 8 blocking threads, runtime defaults).
                 #
-                # backpressure is pinned above the component default of
-                # 2 * blocking_threads because that default assumes a connection
-                # is a request. Since the nginx sidecar was removed the 26 APISix
-                # pods hold their upstream keepalive connections directly against
-                # Granian, and an idle keepalive connection spends backpressure
-                # budget without doing any work. At 16 the budget was consumed by
-                # idle connections alone -- granian_connections_active sat pinned
-                # at exactly 16 per pod while blocking threads were 1-2% busy --
-                # which starved the readiness probe (it shares this pool, see the
-                # probe notes in components/services/k8s.py) and flapped both pods
-                # out of the EndpointSlice, leaving APISix with "no valid upstream
-                # node" and ~26% of xpro requests answered with an instant 503.
-                #
-                # Request concurrency does not need this headroom: ~3 req/s at
-                # ~0.2s of in-Python time per request is well under 1 in flight,
-                # so blocking_threads stays at 8 and remains the real limit on
-                # concurrent work. 128 just stops the connection count from being
-                # the binding constraint, and matches the per-worker connection
-                # counts mitlearn already sustains.
-                backpressure=128,
+                # The backpressure=128 pin added by #5692 to end the 2026-08-31
+                # outage is gone: the component default is no longer derived from
+                # blocking_threads, so this app inherits a connection budget sized
+                # for the gateway's keepalive population rather than for its thread
+                # pool. That is what the pin existed to work around. Rationale and
+                # the outage evidence now live on GranianConfig.backpressure in
+                # components/services/k8s.py, so they are not restated per app.
+                # Request concurrency is unaffected: ~3 req/s at ~0.2s of in-Python
+                # time per request is well under 1 in flight, and blocking_threads
+                # stays at 8 as the real limit on concurrent work.
                 blocking_threads_idle_timeout=120,
                 enable_metrics=True,
                 # Serve /static/* from Granian's Rust layer instead of the sidecar

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -24,7 +24,7 @@ from pydantic import (
 from bridge.lib.magic_numbers import (
     DEFAULT_NGINX_PORT,
     DEFAULT_REDIS_PORT,
-    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER,
+    DEFAULT_WSGI_BACKPRESSURE,
     DEFAULT_WSGI_BLOCKING_THREADS,
     DEFAULT_WSGI_PORT,
     MAXIMUM_K8S_NAME_LENGTH,
@@ -126,10 +126,39 @@ def default_probe_configs(port: int) -> dict[str, kubernetes.core.v1.ProbeArgs]:
     worker thread, so it distinguishes "the process is gone" from "the process
     is busy".
 
-    The trade-off is deliberate: liveness no longer restarts a pod whose Granian
-    workers are wedged but whose listener still accepts. Readiness does still
-    fail in that case, so the pod is pulled from the Service endpoints and stops
-    receiving traffic -- it just is not killed automatically.
+    Readiness is the harder half, because there is nowhere else to put it.
+    Granian serves one application listener; its metrics listener answers from
+    the Rust runtime and knows nothing about whether Django can reach its
+    dependencies, so it cannot stand in for a readiness check. Readiness
+    therefore shares the port -- and the ``--backpressure`` connection budget --
+    with user traffic, and a probe that competes for the resource it is meant to
+    report on will report on it wrongly under exactly the conditions that matter.
+
+    Two things follow, and both are load-bearing:
+
+    1. ``backpressure`` must be sized from the connection population, not from
+       ``blocking_threads`` (see ``GranianConfig.backpressure``). When the budget
+       was ``2 * blocking_threads``, idle APISix keepalives consumed all of it and
+       readiness timed out on ~80% of attempts against pods whose worker threads
+       were 1-2% busy.
+    2. The failure budget here is deliberately wide -- 6 failures at a 15s period,
+       ~90s of sustained failure before eviction, against a 5s timeout. Readiness
+       failure from connection-level contention is correlated across replicas
+       because every replica shares the cause, so eviction does not shed load onto
+       healthy pods, it empties the EndpointSlice. Kubernetes has no
+       minimum-available floor for readiness the way PodDisruptionBudgets bound
+       voluntary disruption, so an empty EndpointSlice is a reachable state, and
+       APISix answers it with an instant "no valid upstream node" 503 rather than
+       a slow 200. Serving slowly from a saturated pod beats serving nothing.
+
+    An earlier version of this docstring called the liveness trade-off benign --
+    "the pod is pulled from the Service endpoints and stops receiving traffic, it
+    just is not killed automatically". The xpro outage of 2026-08-31 falsified
+    that: with liveness on TCP there is no restart to break the loop, readiness
+    never recovers on its own because the keepalive connections do not go away,
+    and the condition persisted from the rollout until it was diagnosed by hand
+    the next morning. TCP liveness is still right; what was wrong was treating
+    endpoint removal as the safe failure mode.
     """
     return {
         # Liveness probe to check that the process is still there at all. See the
@@ -149,8 +178,11 @@ def default_probe_configs(port: int) -> dict[str, kubernetes.core.v1.ProbeArgs]:
             ),
             initial_delay_seconds=15,  # Wait 15 seconds before first probe
             period_seconds=15,
-            failure_threshold=3,  # Consider failed after 3 attempts
-            timeout_seconds=3,
+            # ~90s of sustained failure before the pod leaves the EndpointSlice.
+            # See the docstring: this failure is correlated across replicas, so
+            # evicting fast empties the endpoints rather than shedding load.
+            failure_threshold=6,
+            timeout_seconds=5,
         ),
         # Startup probe to ensure the application is fully initialized before other probes start
         "startup_probe": kubernetes.core.v1.ProbeArgs(
@@ -309,6 +341,10 @@ class GranianConfig(BaseModel):
     explicitly for WSGI apps instead of being left to Granian's
     ``backpressure = backlog // workers`` / ``blocking_threads = backpressure // 2``
     derivation, which yielded 32 GIL-competing threads per worker at the old defaults.
+    The two are resolved independently: ``blocking_threads`` bounds concurrent Python
+    work, ``backpressure`` bounds accepted connections, and connections here are mostly
+    idle gateway keepalives rather than requests. See the ``backpressure`` field for
+    what deriving one from the other cost in production.
 
     **Port/nginx coupling:** when ``import_nginx_config=True`` on
     ``OLApplicationK8sConfig``, the nginx config proxies to a fixed upstream address
@@ -333,12 +369,22 @@ class GranianConfig(BaseModel):
     ``DEFAULT_WSGI_BLOCKING_THREADS`` rather than letting Granian derive it from
     ``backpressure // 2``."""
     backpressure: PositiveInt | None = None
-    """Maximum in-flight requests a single worker will accept before it stops draining the
-    accept queue (granian ``--backpressure``). Excess connections wait in the kernel
-    backlog (and behind the nginx sidecar), which is where they belong -- an oversized
-    backpressure just moves the queue inside the worker where it inflates tail latency
-    invisibly. When ``None`` on a WSGI app, resolves to 2x the resolved
-    ``blocking_threads``."""
+    """Maximum *connections* a single worker will accept before it stops draining the
+    accept queue (granian ``--backpressure``). Not requests: a connection consumes this
+    budget for as long as it is open, whether or not it is carrying a request. Excess
+    connections wait in the kernel backlog. When ``None`` on a WSGI app, resolves to
+    ``DEFAULT_WSGI_BACKPRESSURE``.
+
+    This used to resolve to ``2 * blocking_threads``, which assumed one connection
+    implies one request in flight. That assumption held only while an nginx sidecar
+    absorbed the connection fan-in. With the sidecar gone, APISix keeps upstream
+    keepalive connections open directly against Granian, and idle keepalives alone
+    exhausted the budget: xpro sat pinned at exactly 16 active connections per pod with
+    its blocking threads 1-2% busy, which starved the readiness probe (same port, same
+    budget) and emptied the EndpointSlice, and ~26% of xpro requests were answered with
+    an instant APISix 503 on 2026-08-31. Size this from the plausible connection
+    population, never from ``blocking_threads``; ``blocking_threads`` is what limits
+    concurrent Python work."""
     no_ws: bool = True
     limit_workers_max_rss: bool = True
     """When ``True`` (default), automatically cap each worker's RSS at 90 % of the
@@ -354,9 +400,10 @@ class GranianConfig(BaseModel):
     """Seconds before an idle blocking thread is retired (granian ``--blocking-threads-idle-timeout``). Omitted when ``None``."""
     respawn_failed_workers: bool = True
     backlog: PositiveInt | None = 128
-    """Kernel listen backlog (granian ``--backlog``). Now that ``backpressure`` is
-    resolved explicitly this no longer feeds Granian's thread-pool derivation, so it means
-    only what it says: how many connections queue outside the workers."""
+    """Kernel listen backlog (granian ``--backlog``). Now that ``backpressure`` and
+    ``blocking_threads`` are resolved explicitly this no longer feeds Granian's own
+    derivations, so it means only what it says: how many connections queue outside the
+    workers."""
     log_level: str = "warning"
     application_module: str = "main.wsgi:application"
     enable_metrics: bool = True
@@ -457,9 +504,7 @@ class GranianConfig(BaseModel):
             if self.blocking_threads is None:
                 self.blocking_threads = DEFAULT_WSGI_BLOCKING_THREADS
             if self.backpressure is None:
-                self.backpressure = (
-                    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * self.blocking_threads
-                )
+                self.backpressure = DEFAULT_WSGI_BACKPRESSURE
         elif self.blocking_threads is not None and self.blocking_threads > 1:
             msg = (
                 f"granian_config.blocking_threads={self.blocking_threads} was set with "

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -804,6 +804,20 @@ def test_liveness_is_tcp_while_readiness_stays_http():
     assert probes["readiness_probe"].tcp_socket is None
 
 
+def test_readiness_failure_budget_tolerates_connection_contention():
+    """Readiness shares Granian's connection budget with user traffic.
+
+    A tight budget turns transient contact with the ``--backpressure`` ceiling
+    into an empty EndpointSlice, because the cause is correlated across every
+    replica. 6 failures at a 15s period is ~90s of sustained failure before a
+    pod is evicted. See default_probe_configs and the xpro outage of 2026-08-31.
+    """
+    readiness = default_probe_configs(DEFAULT_WSGI_PORT)["readiness_probe"]
+    assert readiness.period_seconds == 15
+    assert readiness.failure_threshold == 6
+    assert readiness.timeout_seconds == 5
+
+
 @pulumi.runtime.test
 def test_ports_align_without_nginx_sidecar():
     """No sidecar: container, probes and Service all land on DEFAULT_WSGI_PORT."""

--- a/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
@@ -12,7 +12,7 @@ from kubernetes.utils.quantity import parse_quantity
 from pydantic import ValidationError
 
 from bridge.lib.magic_numbers import (
-    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER,
+    DEFAULT_WSGI_BACKPRESSURE,
     DEFAULT_WSGI_BLOCKING_THREADS,
 )
 from ol_infrastructure.components.services.k8s import GranianConfig
@@ -47,23 +47,24 @@ def test_runtime_mode_omitted_when_none():
 def test_wsgi_defaults_resolve_at_config_time():
     gc = GranianConfig()
     assert gc.blocking_threads == DEFAULT_WSGI_BLOCKING_THREADS
-    assert gc.backpressure == (
-        DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * DEFAULT_WSGI_BLOCKING_THREADS
-    )
+    assert gc.backpressure == DEFAULT_WSGI_BACKPRESSURE
 
 
 def test_wsgi_defaults_emitted():
     args = GranianConfig().build_args()
     assert arg_value(args, "--blocking-threads") == str(DEFAULT_WSGI_BLOCKING_THREADS)
-    assert arg_value(args, "--backpressure") == str(
-        DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * DEFAULT_WSGI_BLOCKING_THREADS
-    )
+    assert arg_value(args, "--backpressure") == str(DEFAULT_WSGI_BACKPRESSURE)
 
 
-def test_wsgi_explicit_blocking_threads_drives_backpressure():
+def test_wsgi_blocking_threads_does_not_drive_backpressure():
+    """The connection budget is independent of the Python thread pool.
+
+    Deriving one from the other is what let idle APISix keepalives exhaust the
+    budget and take xpro down on 2026-08-31; see GranianConfig.backpressure.
+    """
     gc = GranianConfig(blocking_threads=4)
     assert gc.blocking_threads == 4
-    assert gc.backpressure == 8
+    assert gc.backpressure == DEFAULT_WSGI_BACKPRESSURE
 
 
 def test_wsgi_explicit_backpressure_preserved():


### PR DESCRIPTION
## What are the relevant tickets?

`tk-backpressure-default-must-not-be-derived-from-bl-dc237c` and the probe half of
`tk-split-webapp-liveness-probe-to-tcp-keep-readines-4f58d9`, part of the Granian
configuration overhaul. Follows #5692 (the xpro-only pin) and the lesson
`les-granian-backpressure-budgets-connections-not-req-6064fb`.

## Description

Granian's `--backpressure` caps **accepted connections** per worker, not in-flight
requests. The component derived it as `2 * blocking_threads`, which assumes one
connection implies one request. That held only while an nginx sidecar absorbed the
connection fan-in. With the sidecar removed (#5541, #5549), the 26 APISIX pods hold their
upstream keepalive connections directly against Granian and spend the whole budget doing
no work.

xpro proved it in production on 2026-08-31: `granian_connections_active` pinned at exactly
16/worker while blocking threads were 1-2% busy; readiness (an HTTP GET on the same port,
so the same budget) timed out on ~80% of attempts; both replicas left the EndpointSlice
with zero container restarts; APISIX answered ~26% of requests with an instant
`no valid upstream node` 503 from the 14:42 UTC rollout until it was diagnosed by hand the
next morning.

**It is not confined to xpro.** `max_over_time(granian_connections_active[7d])` with the
blocking-thread busy ratio alongside it, queried 2026-09-01. Note the metric carries a
`worker` label, so these are per-worker figures:

| namespace | max conns/worker | ceiling | blocking-thread busy |
|---|---|---|---|
| micromasters | 16 | 16 | 0.08% |
| ocw-studio | 16 | 16 | 0.08% |
| odl-video-service | 16 | 16 | 0.30% |
| mitx-openedx | 16 | 16 | 0.85% |
| mitx-staging-openedx | 16 | 16 | 0.38% |
| mitxonline-openedx CMS | 64 | 64 | — see below |
| xpro (post-#5692) | 37 | 128 | 2.8% |
| mitlearn (**uncapped**) | 154 | — | 1.2% |

Six namespaces pinned at their ceiling with idle worker pools.

### Sizing the default

Every capped app's number is an upper bound imposed by its own pin, not a measurement of
demand. The only app running uncapped is mitlearn (`asginl`, `backlog=None`), and it
reaches **154 on a single worker**. `DEFAULT_WSGI_BACKPRESSURE = 256` is sized above that
— choosing from the capped apps instead is exactly how the 16 that took xpro down was
arrived at. `blocking_threads` is untouched everywhere and remains the limit on concurrent
Python work.

### edxapp CMS: two limits, only one of them the cause

The 2026-08-26 mitxonline CMS rollback ("saturated at 16 active connections, HTTP
readiness fell to 1/3, APISIX p95/p99 60s while Django spans stayed 0.2-1.1s") read the
failure as a thread-concurrency shortfall and restored 2 workers × 32 threads. Saturating
at exactly `2 * blocking_threads` is the connection ceiling, and CMS has been pinned at
its new 64 ceiling on **both workers continuously** for the last 7 days — so
`backpressure=64` is removed here.

But CMS is not *only* connection-capped. Measured per container over the same window it
reaches **21.6 concurrently-busy blocking threads per pod** (p99 17.2), with
`granian_blocking_queue` up to **32 deep** on individual workers. That is real work
waiting on threads, so the `2 workers × 32` pins stay — 8 threads would queue on every
busy pod, which is the latency symptom the rollback was reacting to. mitxonline LMS peaks
at 5.4 for contrast.

Retuning CMS's threads is a separate exercise with its own rollout window
(`tk-mitxonline-cms-needs-a-saturation-aware-scaling--cf08a8`).

### Changes

- `DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER = 2` becomes `DEFAULT_WSGI_BACKPRESSURE = 256`, a
  flat connection budget independent of `blocking_threads`.
- Readiness failure budget widens from 3 × 15s / 3s timeout to 6 × 15s / 5s (~90s of
  sustained failure before eviction), in `default_probe_configs` and in the app-level
  override sites (micromasters, odl_video_service, ol_analytics_api, edxapp LMS and CMS).
  Readiness failure from connection contention is correlated across replicas, so evicting
  fast empties the EndpointSlice instead of shedding load, and Kubernetes has no
  minimum-available floor for readiness the way PDBs bound voluntary disruption.
- Pins removed so their apps take the component default: the `backpressure: 16` in six
  edxapp `mitx` / `mitx-staging` stack configs, edxapp CMS's `backpressure=64`, and xpro's
  `backpressure=128` from #5692 (the derivation that pin worked around is gone).
- `default_probe_configs`' docstring is rewritten: it previously called endpoint removal
  the benign failure mode ("it just is not killed automatically"), which the xpro outage
  falsified. TCP liveness is still right; treating an empty EndpointSlice as safe was not.
- Plan doc records the correction to item 5, the per-worker finding, and what remains
  pinned.

### Deliberately not changed

Readiness stays an HTTP GET on the application port. Granian serves one application
listener, and its metrics listener answers from the Rust runtime, so it knows nothing
about whether Django can reach its dependencies and cannot stand in for a readiness check.
A TCP readiness would succeed under exactly the saturation it must report — the kernel
completes the handshake while the worker stops draining the accept queue, which is why
liveness never fired during the outage. The fix is to stop the probe competing for the
budget, not to move the probe.

The remaining pins below the new default are non-binding and left to their own rollout
stages: mitxonline app (64, peaks at 23/worker) and the edxapp LMS holding pins (64,
mitxonline LMS peaks at 26-28/worker).

## How can this be tested?

`pulumi preview` against CI for each code shape:

- **micromasters** (probe override, default backpressure): 1 Deployment update,
  backpressure `"16" => "256"`, `readinessProbe.failureThreshold 3 => 6`,
  `timeoutSeconds 3 => 5`. No replacements.
- **ocw_studio** (component-default probes): same single Deployment update.
- **xpro** (pin removed): `"16" => "256"` plus the readiness widening.
- **edxapp mitx.CI** (stack-config pin + probe override): LMS webapp gets the backpressure
  and readiness changes; CMS webapp gets readiness only.
- **edxapp mitxonline.CI** (CMS de-pin): CMS webapp `"64" => "256"` plus readiness; LMS
  webapp readiness only, keeping its non-binding 64. No replacements.

1024 tests pass; `pre-commit` (ruff format, ruff check, mypy, yamllint, detect-secrets)
clean. Guard tests: `test_wsgi_blocking_threads_does_not_drive_backpressure` and
`test_readiness_failure_budget_tolerates_connection_contention`.

After deploy, watch `granian_connections_active` (should stop sitting at a flat ceiling),
`kube_deployment_status_replicas_available` (should stop flapping), and APISIX 5xx rate
for the affected apps. For CMS specifically, watch `granian_blocking_queue` — the
connection fix should not change it, and if it does the thread sizing needs revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiCXrutzhKgX5Dw1C6ENwM
