### PR TITLE
fix(edxapp): give FRONTEND_SITE_CONFIG a per-environment baseUrl

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -225,6 +225,20 @@ def _build_interpolated_config_dict(
         "ENABLE_MFE_CONFIG_API": True,
         "FRONTEND_SITE_CONFIG": {
             "basename": "/",
+            # The origin the Site Project itself is served from. It is the LMS
+            # host because Fastly serves the Site Project under /apps there
+            # rather than giving it a host of its own (see the "Handle Site
+            # Project routing" VCL snippets in __main__.py).
+            #
+            # Must be set here rather than left to the value compiled into the
+            # bundle: one build artifact is promoted CI -> QA -> Production, and
+            # the mitx artifact additionally serves mitx-staging, whose LMS
+            # origins differ again. Without this, every environment but the one
+            # the build config names falls back to that environment's origin for
+            # auth redirects. frontend-base awaits the runtime config before
+            # configureAuth, so the value set here is the one the auth service
+            # is built with.
+            "baseUrl": f"https://{domains['lms']}",
             "lmsBaseUrl": f"https://{domains['lms']}",
             "loginUrl": f"https://{domains['lms']}/login",
             "logoutUrl": f"https://{domains['lms']}/logout",


### PR DESCRIPTION
`baseUrl` is the origin the OEP-65 Site Project is served from, and the only origin frontend-base uses that `FRONTEND_SITE_CONFIG` did not supply. That left it to whatever the MFE build compiled in, which does not work for how these artifacts are shipped. From `src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py`:

> the artifact is environment-agnostic: built once in CI using lehrer's Dagger module, then promoted unchanged to QA and Production via rclone cross-bucket copy.

> mitx-staging has no Site Project directory of its own in lehrer — it builds from `frontend/mitx` and publishes to its own bucket/public path, **since per-site values come from the runtime frontend_site_config API rather than the build**.

`baseUrl` was the one per-site value that did not come from that API. So every environment but the one the build config names fell back to *that* environment's origin whenever auth redirects use `baseUrl` — including `mitx-staging`, whose LMS origin is `staging.mitx.mit.edu`, not the `lms.mitx.mit.edu` the shared `mitx` build carries. Caught by Copilot on mitodl/lehrer#209.

This sets it from `domains['lms']` like every sibling key, so each stack gets its own.

## Why the runtime value is sufficient

frontend-base's `initialize()` awaits `runtimeConfig()` (which fetches `runtimeConfigJsonUrl` and deep-merges every non-`apps` key over the compiled config) **before** it calls `configureAuth(..., {config: getSiteConfig()})`. So the auth service is constructed with the value set here, not with the compiled default and a later correction.

## Preview

`pulumi preview -s mitxonline.CI --diff` on `60-interpolated-config-yaml`:

```
              ~ FRONTEND_SITE_CONFIG                      : {
                    ...
                  + baseUrl                     : "https://courses.ci.learn.mit.edu"
                    basename                    : "/"
                    ...
Resources:
    +-1 to replace
    173 unchanged
```

One added key, carrying the CI stack's own LMS domain rather than a production one. The preview then stops on `EDXAPP_DOCKER_IMAGE_DIGEST is not set`, which the deploy pipeline supplies and is unrelated to this change; the configmap diff is fully rendered before that point.

## Relationship to mitodl/lehrer#209

That PR reconciles the *compiled default* with the sub-path topology (it previously named `apps.{mitxonline,mitx,xpro}.mit.edu`, none of which resolve). Ordering does not matter: this PR alone replaces a fallback pointing at a host that has never existed with each environment's real origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hhgaMWi8M5yDQ7gf5QHY9