### PR TITLE
chore(edxapp): drop the instructor legacy MFE builds, already served by the Site Project

### DIFF
--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -532,12 +532,6 @@ ReleaseMap: dict[
                 release="master",
             ),
             OpenEdxApplicationVersion(
-                application="instructor",
-                application_type="MFE",
-                release="master",
-                branch_override="main",
-            ),
-            OpenEdxApplicationVersion(
                 application="learning",
                 application_type="MFE",
                 release="master",
@@ -604,12 +598,6 @@ ReleaseMap: dict[
                 application="gradebook",
                 application_type="MFE",
                 release="master",
-            ),
-            OpenEdxApplicationVersion(
-                application="instructor",
-                application_type="MFE",
-                release="master",
-                branch_override="main",
             ),
             OpenEdxApplicationVersion(
                 application="learner-dashboard",
@@ -684,12 +672,6 @@ ReleaseMap: dict[
                 application="gradebook",
                 application_type="MFE",
                 release="master",
-            ),
-            OpenEdxApplicationVersion(
-                application="instructor",
-                application_type="MFE",
-                release="master",
-                branch_override="main",
             ),
             OpenEdxApplicationVersion(
                 application="learning",


### PR DESCRIPTION
## What

Removes the three `instructor` legacy MFE rows from `version_matrix.py` (mitxonline, mitx, mitx-staging), and deletes the stale artifacts they had been syncing to S3.

## Why

`openedx/frontend-app-instructor-dashboard` converted to a frontend-base module library on its default branch, so these rows have been building a webpack MFE out of a tree that no longer contains one.

**They did not fail.** `build_legacy` ends at `container.directory("/app/mfe/dist")`; the converted build (`make build` → `tsc` plus an SCSS copy) writes `dist/index.js` there, so `dist/` is non-empty, the export succeeds, and nothing downstream inspects the artifact's shape. Concourse went green while syncing an unservable tree to S3 as recently as **2026-08-31**, including mitxonline production.

The S3 trees confirmed it directly: they mirror the repo's `src/` directories (`ccxCoach/`, `certificates/`, `cohorts/`, …) with `index.js` and **no `index.html`**.

## Nothing consumed it

All nine mitxonline/mitx/mitx-staging stacks (CI/QA/Production) set:

```yaml
edxapp:site_project:
  mfe_apps:
  - instructor-dashboard
```

so `k8s_configmaps.py:194` resolves `INSTRUCTOR_MICROFRONTEND_URL` to `https://<lms>/apps/instructor-dashboard`, not the legacy `/instructor` path.

Verified live: `https://courses.learn.mit.edu/apps/instructor-dashboard/` returns 200, and the served bytes are identical to `mitxonline-site/index.html` in S3 (825 bytes, `diff` clean). The `"INSTRUCTOR_MICROFRONTEND_URL": "/instructor"` at `config_builder.py:209` sits in the upstream sandbox default block (`"ROOT_PATH": "sandbox"`, `"LOGGING_ENV": "sandbox"`), not a deployment value.

`OpenEdxMicroFrontend.instructor` has no remaining references in the tree.

## S3 cleanup (already applied)

Deleted `<env>-edxapp-mfe/instructor/`, 552 objects each:

| bucket | objects | newest object |
| --- | --- | --- |
| `mitx-ci` | 552 | 2026-08-31 |
| `mitx-staging-ci` | 552 | 2026-08-31 |
| `mitxonline-ci` | 552 | 2026-08-28 |
| `mitxonline-qa` | 552 | 2026-08-28 |
| `mitxonline-production` | 552 | 2026-08-31 |

`mitx`/`mitx-staging` QA and Production and all three xpro buckets held no objects under the prefix. Sibling prefixes are untouched (production still has `admin-console/`, `authoring/`, `communications/`, `course-authoring/`, `discuss/`, `gradebook/`, `learn/`, `library-authoring/`, `mitxonline-site/`, `ora-grading/`), and `/apps/instructor-dashboard/` still returns 200 after the deletion.

Versioning on these buckets is `Suspended`, so object manifests were captured before deletion.

## Related

mitodl/lehrer#211 makes this class of failure loud: `build_legacy` now asserts `dist/index.html` before returning, and `lehrer upstream frontend-base-status` detects a landing from the upstream default branch's `package.json`. **Merge order matters** — once that lands these three jobs would turn red, so this should go in first or alongside.

## Testing

`ReleaseMap` still loads and no deployment lists `instructor` any more. mitxonline keeps admin-console, authoring, communications, discussions, gradebook, learning, ora-grading; mitx/mitx-staging keep those plus learner-dashboard. pre-commit (ruff, mypy, detect-secrets) clean.
