### PR TITLE
feat(ol-python-base): rebase onto Docker Hardened Images Python dev variant (Tier 1)

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -9,7 +9,8 @@ This directory contains Dockerfiles for MIT Open Learning services.
 Published as `mitodl/ol-python-base:{3.11,3.12,3.13}` via the Concourse pipeline at
 [`pipelines/infrastructure/ol_python_base_docker.yaml`](../pipelines/infrastructure/ol_python_base_docker.yaml).
 
-Bakes the substrate every app Dockerfile previously duplicated: Python slim, common-core
+Bakes the substrate every app Dockerfile previously duplicated: hardened Python
+(Docker Hardened Images `-dev` variant, Debian 13; pulls require `docker login dhi.io`), common-core
 apt packages, the `uv` binary, non-root `mitodl` user, `/opt/venv` + `UV_CACHE_DIR`
 env vars. App Dockerfiles do `FROM mitodl/ol-python-base:<python-version>` and add only
 app-specific layers.

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -2,12 +2,21 @@
 # Shared Python base image for MIT Open Learning services.
 #
 # Bakes the substrate that every Python app Dockerfile previously duplicated:
-# slim Python, the common-core apt packages, the uv binary, a non-root `mitodl`
-# user, and the /opt/venv environment configuration. App images do
+# hardened Python, the common-core apt packages, the uv binary, a non-root
+# `mitodl` user, and the /opt/venv environment configuration. App images do
 # `FROM mitodl/ol-python-base:<python-version>` and add only their app-specific
 # layers (extra apt, node build stages, project source, run command).
 #
+# The base is Docker Hardened Images' Python `-dev` variant (Debian 13/trixie):
+# near-zero-CVE, continuously rebuilt, signed provenance. The `-dev` variant is
+# deliberate — it keeps the shell and apt that this build (and downstream app
+# builds and dev stages) depend on; the shell-less runtime variant is only for
+# per-app production stages (see the hardened-images RFC). Note that dhi.io
+# denies anonymous pulls, so building this image requires `docker login dhi.io`
+# first (any Docker account works; CI uses the dockerhub service credentials).
+#
 # Build:
+#   docker login dhi.io
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 # Multi-arch build (published for both amd64 and arm64/Apple Silicon; --push
 # is required since a multi-platform result can't be loaded into the local
@@ -15,7 +24,7 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 --push \
 #     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
-FROM python:${PYTHON_VERSION}-slim
+FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev
 
 LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
@@ -38,6 +47,13 @@ RUN apt-get update && \
       zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# DHI's Python is Debian-packaged (`python3` in /usr/bin) rather than the
+# python.org /usr/local layout that python:X-slim used, and Debian packaging
+# ships no bare `python` binary. Provide one for downstream Dockerfiles and
+# scripts that expect it. Guarded so this stays a no-op if a future base adds
+# its own.
+RUN command -v python >/dev/null 2>&1 || ln -s "$(command -v python3)" /usr/local/bin/python
 
 # Install uv (pinned via the upstream tag; bump deliberately).
 COPY --from=ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 /uv /uvx /usr/local/bin/

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -33,6 +33,10 @@ LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 # own Dockerfile / apt.txt.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+      # adduser is absent from the DHI dev image's curated package set
+      # (python:X-slim shipped it implicitly); required by the mitodl user
+      # creation below.
+      adduser \
       build-essential \
       ca-certificates \
       curl \

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -1,17 +1,24 @@
 import sys
 
+from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
     GetStep,
     Identifier,
     Input,
     Job,
+    Output,
     Pipeline,
+    Platform,
     PutStep,
+    TaskConfig,
+    TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
-from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 PYTHON_VERSIONS = ("3.11", "3.12", "3.13", "3.14")
@@ -22,6 +29,68 @@ ol_infrastructure_repo = git_repo(
     branch="main",
     paths=["dockerfiles/ol-python-base/Dockerfile"],
 )
+
+# Upstream Docker Hardened Images bases (see the hardened-images RFC). These
+# resources exist to trigger rebuilds whenever Docker ships a CVE-patched
+# rebuild of the base — without them the hardening silently decays between
+# Dockerfile edits. The build itself pulls the base straight from dhi.io
+# (authenticated via the docker config written by dhi_docker_config_task;
+# dhi.io denies anonymous pulls, and feeding the fetched image in via
+# IMAGE_ARG would collapse the multi-arch build to a single platform).
+dhi_python_base_resources = {
+    version: registry_image(
+        name=Identifier(f"dhi-python-{version.replace('.', '')}-image"),
+        image_repository="dhi.io/python",
+        image_tag=f"{version}-debian13-dev",
+        username="((dockerhub.username))",
+        password="((dockerhub.password))",  # noqa: S106
+    )
+    for version in PYTHON_VERSIONS
+}
+
+
+def dhi_docker_config_task() -> TaskStep:
+    """Write a docker config authorizing pulls from dhi.io.
+
+    oci-build-task resolves FROM-image credentials through the standard
+    docker config machinery, honoring the DOCKER_CONFIG env var, so the
+    build task consumes this task's output directory via
+    DOCKER_CONFIG=docker-config.
+    """
+    docker_config = Output(name=Identifier("docker-config"))
+    return TaskStep(
+        task=Identifier("write-dhi-docker-config"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type=REGISTRY_IMAGE,
+                source={
+                    "repository": dockerhub_ecr_image_uri("alpine"),
+                    "tag": "latest",
+                    "aws_region": ECR_REGION,
+                },
+            ),
+            outputs=[docker_config],
+            params={
+                "DHI_USERNAME": "((dockerhub.username))",
+                "DHI_PASSWORD": "((dockerhub.password))",
+            },
+            run=Command(
+                path="sh",
+                # -e only: -x would echo the credentials into the build log.
+                args=[
+                    "-ec",
+                    (
+                        'auth="$(printf \'%s:%s\' "$DHI_USERNAME"'
+                        ' "$DHI_PASSWORD" | base64 | tr -d \'\\n\')"\n'
+                        'printf \'{"auths": {"dhi.io": {"auth": "%s"}}}\''
+                        f' "$auth" > {docker_config.name}/config.json\n'
+                    ),
+                ],
+            ),
+        ),
+    )
+
 
 image_resources = {
     version: registry_image(
@@ -52,11 +121,22 @@ def build_job(python_version: str) -> Job:
         public=True,
         plan=[
             GetStep(get=ol_infrastructure_repo.name, trigger=True),
+            GetStep(
+                get=dhi_python_base_resources[python_version].name,
+                trigger=True,
+            ),
+            dhi_docker_config_task(),
             container_build_task(
-                inputs=[Input(name=ol_infrastructure_repo.name)],
+                inputs=[
+                    Input(name=ol_infrastructure_repo.name),
+                    Input(name=Identifier("docker-config")),
+                ],
                 build_parameters={
                     "CONTEXT": context,
                     "BUILD_ARG_PYTHON_VERSION": python_version,
+                    # Auth for the dhi.io FROM pull; written by
+                    # dhi_docker_config_task above.
+                    "DOCKER_CONFIG": "docker-config",
                     # Cross-build linux/arm64 via QEMU emulation (workers have
                     # qemu-user-static/binfmt-support installed) so Apple
                     # Silicon can pull a native image. Multiple platforms
@@ -84,6 +164,7 @@ def build_job(python_version: str) -> Job:
 ol_python_base_pipeline = Pipeline(
     resources=[
         ol_infrastructure_repo,
+        *dhi_python_base_resources.values(),
         *image_resources.values(),
         *ecr_image_resources.values(),
     ],


### PR DESCRIPTION
### What are the relevant tickets?
Implements Tier 1 of the hardened container base images plan — RFC: https://github.com/mitodl/hq/discussions/13121

### Description (What does it do?)
Rebases `mitodl/ol-python-base` — the shared base image behind mit-learn, mitxonline, learn-ai, micromasters, ocw-studio, odl-video-service, and mitxpro — from `python:X-slim` onto Docker Hardened Images' Python **dev** variant (`dhi.io/python:X-debian13-dev`): near-zero-CVE, continuously rebuilt, SLSA Build L3 signed provenance, free Community tier.

The dev variant keeps the shell and apt, so **downstream app Dockerfiles, dev/CI stages, and `kubectl exec` are unaffected**. App repos need no changes; they pick up the new base on their next scheduled rebuild.

Changes:
- `dockerfiles/ol-python-base/Dockerfile` — `FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev`; adds a guarded `python` → `python3` symlink (DHI's Python is Debian-packaged in `/usr/bin` with no bare `python` binary, unlike `python:X-slim`'s `/usr/local` layout); header docs updated with the `docker login dhi.io` requirement for local builds.
- `src/ol_concourse/pipelines/container_images/ol_python_base.py` —
  - New per-version `registry_image` resources on the DHI bases with `trigger=True`, so Docker's CVE-patch rebuilds of the base automatically propagate into fresh `ol-python-base` builds (mirrors the upstream-image trigger pattern in the [Keycloak pipeline](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py)).
  - New `write-dhi-docker-config` task: `dhi.io` denies anonymous pulls, so the task writes a docker `config.json` from the dockerhub service credentials and the build task consumes it via `DOCKER_CONFIG` for the `FROM` pull. (`IMAGE_ARG` was considered and rejected — it would collapse the multi-arch amd64+arm64 build to a single platform.)
- `dockerfiles/README.md` — base-image description updated.

Verified against the [published DHI catalog definitions](https://github.com/docker-hardened-images/catalog/tree/main/image/python/debian-13): Python 3.11–3.14 all exist on debian-13 with dev variants, linux/amd64 + linux/arm64, version-pinned tags; dev variants build as root with bash/apt/ca-certificates present, and ship standard Debian apt sources alongside Docker's hardened repo, so the existing `apt-get install` layer works unchanged.

### How can this be tested?
1. **Credential check (before merge):** confirm the dockerhub service credentials authenticate against `dhi.io` (`docker login dhi.io`) — this PR assumes they do.
2. **Local build:** `docker login dhi.io && docker build --build-arg PYTHON_VERSION=3.12 -t ol-python-base:test dockerfiles/ol-python-base/`. Sanity: `docker run --rm ol-python-base:test sh -c "python --version && uv --version && pg_config --version"`.
3. **Pipeline definition renders:** `uv run python src/ol_concourse/pipelines/container_images/ol_python_base.py` — verified locally; each job gains the DHI trigger get + config task, and the build task gets `DOCKER_CONFIG=docker-config`.
4. **After merge + `fly set-pipeline`:** the four base tags rebuild; then canary by triggering learn-ai's CI build and letting it **deploy in CI** (boot, migrations, health checks) before the rest of the fleet rebuilds — a runtime-only failure (shared library `python:slim` shipped implicitly) would not show up at build time.
5. **Rollback:** revert the `FROM` line; every app rebuilds back onto the old base on its next build.

### Additional Context
- Draft until: (a) the RFC is posted and agreed, (b) the `dhi.io` credential assumption is verified, and (c) a local test build against the DHI base has been run.
- Pre-commit (ruff, mypy, hadolint, detect-secrets) passes on all changed files.
- Expectation-setting: packages we `apt-get install` on top (build-essential, libpq-dev, …) come from stock Debian — the hardening win is in the base OS + interpreter layers. Vuln-scanner before/after numbers will be attached to the RFC.

### Checklist:
- [ ] Verify dockerhub service creds authenticate against `dhi.io` (or provision a dedicated credential in Vault and update the `((dockerhub.*))` references here). **Note from local testing: `dhi.io` login requires a Docker Hub access token — a raw account password is rejected. If the Vault secret holds a password rather than a PAT, it needs a token provisioned.**
- [x] Local test build + smoke test (step 2 above) — done 2026-09-01, results in PR comment below
- [x] Post the RFC and link it here — https://github.com/mitodl/hq/discussions/13121
- [ ] `fly set-pipeline -p ol-python-base-docker` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


