### PR TITLE
fix(jupyterhub-data): stop injecting a Galaxy token that Galaxy rejects

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.CI.yaml
@@ -6,6 +6,7 @@ config:
   jupyterhub_data:keycloak_base_url: https://sso-ci.ol.mit.edu
   jupyterhub_data:keycloak_realm: ol-data-platform
   jupyterhub_data:trino_host: mitol-ol-data-lake-production.trino.galaxy.starburst.io
+  jupyterhub_data:trino_catalog: ol_data_lake_production
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.Production.yaml
@@ -6,6 +6,7 @@ config:
   jupyterhub_data:keycloak_base_url: https://sso.ol.mit.edu
   jupyterhub_data:keycloak_realm: ol-data-platform
   jupyterhub_data:trino_host: mitol-ol-data-lake-production.trino.galaxy.starburst.io
+  jupyterhub_data:trino_catalog: ol_data_lake_production
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub_data/Pulumi.QA.yaml
@@ -6,6 +6,7 @@ config:
   jupyterhub_data:keycloak_base_url: https://sso-qa.ol.mit.edu
   jupyterhub_data:keycloak_realm: ol-data-platform
   jupyterhub_data:trino_host: mitol-ol-data-lake-production.trino.galaxy.starburst.io
+  jupyterhub_data:trino_catalog: ol_data_lake_production
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/jupyterhub_data/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/__main__.py
@@ -1,11 +1,14 @@
 """JupyterHub Data application deployment for MIT Open Learning Data Platform.
 
 This project deploys a JupyterHub instance to the data EKS cluster. It uses
-GenericOAuthenticator against the ol-data-platform Keycloak realm so that
-JupyterHub itself holds each user's OIDC access token. KubeSpawner then injects
-the token as TRINO_TOKEN into the single-user server environment, enabling
-per-user JWT auth against Starburst Galaxy without any credential management
-in the notebook itself.
+GenericOAuthenticator against the ol-data-platform Keycloak realm to
+authenticate access to the notebook environment itself.
+
+Warehouse access is a separate handshake: notebooks authenticate to Starburst
+Galaxy through Galaxy's own OAuth2 flow, which federates the login to the same
+Keycloak SSO. Only the endpoint (TRINO_HOST / TRINO_PORT / TRINO_CATALOG) is
+injected into the single-user environment — Galaxy does not accept a
+Keycloak-issued JWT, so there is no token for the hub to pass along.
 """
 
 import json

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -3,8 +3,13 @@
 Key differences from the existing jupyterhub/deployment.py:
 - No OLApisixOIDCResources — JupyterHub owns auth via GenericOAuthenticator
 - APISIX route provides TLS termination and WebSocket proxying only
-- Injects TRINO_TOKEN from the user's OIDC access token via KubeSpawner pre_spawn_hook
-- JUPYTERHUB_CRYPT_KEY is required for auth state (access/refresh token) encryption
+- JUPYTERHUB_CRYPT_KEY is required because GenericOAuthenticator runs with
+  enable_auth_state, which encrypts stored access/refresh tokens
+- Notebooks authenticate to Starburst Galaxy themselves via Galaxy's OAuth2
+  flow; the hub does not hand them a token (see the comment on singleuser
+  extraEnv below)
+- The singleuser postStart hook seeds every notebook template baked into the
+  image into each user's persistent home directory, without clobbering edits
 - Uses EFS dynamic storage (efs-sc) for per-user home directories
 - No course image pre-puller
 """
@@ -45,19 +50,6 @@ from ol_infrastructure.components.services.vault import (
 from ol_infrastructure.lib.jupyterhub_config import get_authenticator_config
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 from ol_infrastructure.lib.vault import postgres_role_statements
-
-# JupyterHub KubeSpawner pre_spawn_hook: injects the user's Keycloak OIDC access token
-# as TRINO_TOKEN so notebooks can authenticate against Starburst Galaxy per-user
-# without any manual credential management. Token refresh is handled by JupyterHub
-# automatically (Keycloak sessions are 2 hours idle per ol-data-platform realm config).
-_PRE_SPAWN_HOOK = """
-async def pre_spawn_hook(spawner):
-    auth_state = await spawner.user.get_auth_state()
-    if auth_state and auth_state.get("access_token"):
-        spawner.environment["TRINO_TOKEN"] = auth_state["access_token"]
-
-c.KubeSpawner.pre_spawn_hook = pre_spawn_hook
-"""
 
 # KubeSpawner profile list: currently defines Standard and Large CPU/memory tiers.
 _PROFILE_LIST = f"""
@@ -127,6 +119,9 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
     )
     keycloak_base_url = jupyterhub_data_config.get("keycloak_base_url") or ""
     keycloak_realm = jupyterhub_data_config.get("keycloak_realm") or "ol-data-platform"
+    trino_catalog = (
+        jupyterhub_data_config.get("trino_catalog") or "ol_data_lake_production"
+    )
 
     # Vault Policy
     vault_policy = vault.Policy(
@@ -483,9 +478,7 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                         },
                     ],
                     "extraConfig": {
-                        "hubDataConfig.py": (
-                            _COMMON_HUB_CONFIG + _PRE_SPAWN_HOOK + _PROFILE_LIST
-                        ),
+                        "hubDataConfig.py": (_COMMON_HUB_CONFIG + _PROFILE_LIST),
                     },
                     "config": auth_config,
                     "resources": {
@@ -511,9 +504,20 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                     "cmd": ["jupyterhub-singleuser"],
                     "startTimeout": 300,
                     "networkPolicy": {"enabled": False},
-                    # Seed a getting-started notebook into the user's home on
-                    # first login. cp -n is a no-op if the file already exists,
-                    # so user edits are never overwritten by a pod restart.
+                    # Seed the notebook templates into the user's home on first
+                    # login: getting_started.py (minimal starting point), demo.py
+                    # (full tour) and README.md. Copying the whole directory means
+                    # a new template ships with the image rather than needing a
+                    # matching change here.
+                    #
+                    # cp -n is load-bearing: home is a persistent EFS volume, so
+                    # it must never overwrite a copy the user has edited. The
+                    # corollary is that template FIXES do not reach users who
+                    # already have a copy.
+                    #
+                    # `|| true` guards the container: a postStart hook that exits
+                    # non-zero kills it, and the glob fails if the templates
+                    # directory is ever empty.
                     "lifecycleHooks": {
                         "postStart": {
                             "exec": {
@@ -521,10 +525,8 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                                     "sh",
                                     "-c",
                                     "mkdir -p /home/jovyan/notebooks && "
-                                    "cp -n "
-                                    "/usr/local/share/marimo/templates/"
-                                    "getting_started.py "
-                                    "/home/jovyan/notebooks/getting_started.py",
+                                    "cp -n /usr/local/share/marimo/templates/* "
+                                    "/home/jovyan/notebooks/ || true",
                                 ]
                             }
                         }
@@ -547,9 +549,26 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                             ),
                         }
                     },
+                    # Endpoint only, no credential. Starburst Galaxy authenticates
+                    # query clients itself: the notebook uses Galaxy's OAuth2
+                    # flow (trino.auth.OAuth2Authentication), Galaxy federates
+                    # the login to Keycloak SSO, and Galaxy issues its own
+                    # token. Galaxy has no issuer trust for a third-party IdP,
+                    # so a Keycloak access token passed as a bearer JWT is
+                    # rejected with "401 Authentication required". Injecting one
+                    # here would also go stale within minutes, since a pod's
+                    # environment is fixed for the pod's lifetime.
+                    #
+                    # TRINO_USER is deliberately absent. marimo's environment
+                    # scanner offers a "Quick add" Trino connection only when
+                    # TRINO_HOST, TRINO_USER and TRINO_CATALOG are all set, and
+                    # the snippet it generates uses BasicAuthentication or no
+                    # auth at all — neither of which Galaxy accepts here. Adding
+                    # TRINO_USER would surface a one-click connection that 401s.
                     "extraEnv": {
                         "TRINO_HOST": trino_host,
                         "TRINO_PORT": "443",
+                        "TRINO_CATALOG": trino_catalog,
                         "JUPYTERHUB_SINGLEUSER_APP": (
                             "jupyter_server.serverapp.ServerApp"
                         ),

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -108,7 +108,12 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
     service_account_name: str,
     jupyterhub_data_config: Config,
 ) -> kubernetes.helm.v3.Release:
-    """Provision JupyterHub data Helm release with GenericOAuthenticator and Trino token injection."""  # noqa: E501
+    """Provision the JupyterHub data Helm release.
+
+    Authentication is GenericOAuthenticator against Keycloak for the hub itself.
+    Query clients authenticate to Starburst Galaxy separately, via Galaxy's own
+    OAuth2 flow from inside the notebook — the hub injects no Trino credentials.
+    """
     base_name = "jupyterhub-data"
     env_name = stack_info.name
     vault_policy_hcl = (


### PR DESCRIPTION
## What are the relevant tickets?

mitodl/ol-data-platform#2624 · paired with mitodl/ol-data-platform#2630

## Description (What does it do?)

The KubeSpawner `pre_spawn_hook` injected each user's Keycloak OIDC access token as `TRINO_TOKEN` so notebooks could authenticate to Starburst Galaxy. That could never have worked, for two independent reasons.

**Galaxy does not accept externally-issued JWTs.** Customer-JWKS JWT auth is a Starburst *Enterprise* feature. Galaxy authenticates query clients only by Galaxy username/password over HTTP Basic, or by its own OAuth2 flow in which Galaxy is the authorization server and merely federates the login to the customer IdP. The injected bearer token was unrecognised and every notebook query returned 401.

**Separately, a pod's environment is fixed for the pod's lifetime** while a Keycloak access token lives minutes, so the value was stale almost immediately regardless. The removed comment claimed *"Token refresh is handled by JupyterHub automatically (Keycloak sessions are 2 hours idle)"*, which conflates SSO session lifetime with access-token lifetime. Pods are culled at 4 hours idle, so a notebook would have been broken for most of its life even if Galaxy had accepted the token.

Notebooks now complete Galaxy's own OAuth2 flow themselves, federating to the same Keycloak SSO. Queries run as the individual user against their own Galaxy role — which is what the JWT design was reaching for in the first place. Verified working end to end in the live notebook.

### `TRINO_CATALOG`

Added to `singleuser.extraEnv` from a new `jupyterhub_data:trino_catalog` config key, because marimo's data-sources panel reads the catalog from the SQLAlchemy engine URL and cannot discover it. All three stacks are set to `ol_data_lake_production` because all three already point `trino_host` at the production Galaxy cluster.

`TRINO_USER` is **deliberately not set**. marimo's environment scanner offers a one-click "Quick add" Trino connection when `TRINO_HOST`, `TRINO_USER` and `TRINO_CATALOG` are all present, and the snippet it generates uses `BasicAuthentication` or no auth at all — neither of which Galaxy accepts here. Setting it would surface a one-click connection that 401s. There is a comment on the `extraEnv` block saying so.

### postStart hook

Extended from the single named `getting_started.py` to the whole templates directory, so `demo.py` and `README.md` arrive too and a future template ships with the image rather than needing a matching change here. `cp -n` is retained — home is a persistent EFS volume and the hook must never overwrite a copy a user has edited — and `|| true` is added because a postStart hook that exits non-zero kills the container and the glob fails if the templates directory is ever empty.

## How can this be tested?

- `ruff format` / `ruff check` / `mypy` / `yamllint` / full `pre-commit` — green
- The complete Helm `values` dict was extracted by AST and validated against the **pinned chart's** `values.schema.yaml` (`JUPYTERHUB_CHART_VERSION = 4.4.1`): **0 unknown key paths**. `singleuser.lifecycleHooks` is confirmed as a real passthrough to `KubeSpawner.lifecycle_hooks`, with `postStart` accepting arbitrary properties.
- The postStart command was executed in a sandbox rather than assumed: a fresh copy populates all three files; a simulated user edit **survives** a second run; a missing source directory still exits 0 so the container lives.
- `grep` confirms zero remaining `TRINO_TOKEN` / `pre_spawn_hook` references in `src/`.

Note: `ruff` cannot parse this repo's `pyproject.toml` (`exclude-newer = "7d"` fails its date parser) and silently falls back to default settings. Pre-existing and unrelated to this change, but worth knowing — it means local ruff runs here are not using project config.

## Merge and deploy order

**Merge and deploy this PR *after* mitodl/ol-data-platform#2630 has merged and its image has published.**

1. **mitodl/ol-data-platform#2630** — merging publishes `ghcr.io/mitodl/marimo-jupyterlab:latest` containing the new `demo.py` and `README.md`.
2. **This PR** — the extended postStart hook copies the whole templates directory. Applied *before* that image exists, the hook copies only `getting_started.py`: harmless, but `demo.py` and `README.md` silently never arrive, and because `cp -n` will not overwrite later, users who spawn in that window keep an incomplete `~/notebooks/`.
3. **mitodl/platform-engineering-site#71** — docs only, independent.

Applying this stack requires a Pulumi apply per environment plus a pod respawn for users to pick up the new env vars. `singleuser.image.pullPolicy` is already `Always`, so no image-tag change is needed.

**Rollout caveat:** `cp -n` never overwrites, so users who already have `~/notebooks/getting_started.py` keep their old copy and will not receive the auth fix. They need to delete it (or be told to). The rollout is not self-completing.

## Additional Context

### Question for reviewers: should `enable_auth_state` come out?

`get_authenticator_config()` in `lib/jupyterhub_config.py` sets `GenericOAuthenticator.enable_auth_state = True`, which makes JupyterHub persist every user's OIDC **access and refresh tokens**, encrypted with `JUPYTERHUB_CRYPT_KEY`, into the `jupyterhub_data` Postgres database.

The `pre_spawn_hook` removed in this PR was its only consumer. So after this merges, the deployment stores per-user credentials that nothing reads — refresh tokens in particular are long-lived and their blast radius on a database compromise is larger than an access token's.

I left it in place rather than decide unilaterally, because it is a real fork and not a one-line change:

- `enable_auth_state` and `JUPYTERHUB_CRYPT_KEY` are coupled — auth state enabled without the key stops the hub from starting, so they must go together.
- `lib/jupyterhub_config.py` is shared with the other `jupyterhub` stack, so that caller needs checking too.
- Removing it touches the crypt-key `VaultStaticSecret`, the `hub.extraEnv` entry, the two `secret-operations/jupyterhub-data/crypt-key` paths in `jupyterhub_data_policy.hcl`, and the Vault secret itself.
- Flipping the flag does not clean up existing `auth_state` rows; those need an explicit purge.

**If per-user auth state is wanted for something upcoming** (a published-app or MCP path that needs to act as the user), keep it and this question is answered. **If not**, it should come out as its own PR. Tracked as `tk-jupyterhub-stores-every-user-s-keycloak-refresh--d0ad95` either way.

### Other follow-ups found, not fixed here

- **Published (run-mode) marimo apps will hit the same 401.** `applications/marimo_data/__main__.py` documents that they use the `ol-marimo-app-client` service account for Trino, which yields another Keycloak JWT. Those apps have no user session, so the OAuth2 flow is unavailable to them too — they need a Galaxy service account. Nothing consumes `secret-operations/sso/marimo-app` yet, so nothing is broken in production today, but it breaks the moment someone publishes a notebook.
- **All three stacks point `trino_host` at the production Galaxy cluster** while the IRSA trust role grants S3/Glue only on `ol-data-lake-*-{env_suffix}`. So notebooks on `nb-ci`/`nb-qa` query production through Trino but hold QA-scoped AWS credentials, and a direct `pyiceberg`/S3 read can only work in production. Either QA should point at the QA cluster (and `trino_catalog` move to `ol_data_lake_qa` with it), or the choice should be documented and the IRSA policy widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
