### PR TITLE
feat(otel): RED dashboard off the app meter, and OVS onto OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -833,15 +833,29 @@ app_env_vars.update(k8s_extra_vars)
 # in the one environment nobody watches.
 #
 # OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES are read straight from the
-# environment; OPENTELEMETRY_ENDPOINT is a Django setting odl_video/settings.py
-# reads, which is why it carries the full /v1/traces path rather than a base URL
-# the SDK would append to.
+# environment, and so is the endpoint: OTEL_EXPORTER_OTLP_ENDPOINT is a *base*
+# URL that the SDK appends the signal path to, which is what lets one variable
+# serve both traces (/v1/traces) and metrics (/v1/metrics).
+#
+# It replaced the OPENTELEMETRY_ENDPOINT Django setting, which carried the full
+# /v1/traces path and therefore could not configure metrics -- POSTing a metrics
+# batch at the traces path delivers nothing, so mitol-django-observability
+# deliberately refuses to reuse it and leaves the MeterProvider off. Setting the
+# base URL here is what turns on http.server.duration, the unsampled RED signal
+# the Service RED dashboard reads.
+#
+# Requires mitol-django-observability >= 2026.8.19, which both added the
+# MeterProvider and stopped passing an environment-sourced endpoint to
+# OTLPSpanExporter(endpoint=...) verbatim. On an older release this base URL
+# would be POSTed to the collector root -- a 404 per batch, surfaced as nothing
+# louder than a BatchSpanProcessor warning. OVS pins >=2026.8.19 and its running
+# 0.95.0 image locks exactly that, checked before this change.
 if stack_info.env_suffix != "ci":
     app_env_vars.update(
         {
-            "OPENTELEMETRY_ENDPOINT": (
+            "OTEL_EXPORTER_OTLP_ENDPOINT": (
                 "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc"
-                ".cluster.local:4318/v1/traces"
+                ".cluster.local:4318"
             ),
             "OTEL_RESOURCE_ATTRIBUTES": (
                 f"service.namespace={ovs_namespace},"

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
@@ -14,6 +14,13 @@ Sub-modules
     the olapps realm.
   keycloak_incident_lookup — Ad-hoc single-incident investigation (event
     timeline, error trends, realm/client/IdP scoping) across all realms.
+  service_red — Rate/errors/duration for the OTel-instrumented Django
+    services, read from each app's own MeterProvider rather than from
+    Tempo-derived spanmetrics.
+
+Dashboards live in per-subject folders (Keycloak, Application Performance)
+so an unrelated dashboard is not filed under a service it has nothing to do
+with; add a new Folder in `create()` rather than widening an existing one.
 """
 
 import json
@@ -27,6 +34,7 @@ from ol_infrastructure.infrastructure.grafana_alerting.dashboards import (
     keycloak_incident_lookup,
     keycloak_olapps_realm,
     keycloak_overview,
+    service_red,
 )
 from ol_infrastructure.infrastructure.grafana_alerting.dashboards.datasources import (
     LOKI_DATASOURCE_REF,
@@ -319,6 +327,86 @@ def _logs_panel(
     }
 
 
+def _table_panel(
+    *,
+    title: str,
+    join_field: str,
+    columns: list[dict[str, Any]],
+    grid_pos: dict[str, Any],
+    datasource_ref: dict[str, str] = MIMIR_DATASOURCE_REF,
+    description: str = "",
+    sort_by: str | None = None,
+) -> dict[str, Any]:
+    """Build a table panel that joins several instant queries into one row set.
+
+    Each entry in `columns` is `{"expr": ..., "title": ..., "unit": ...}`
+    (`unit` optional). Every expression must aggregate down to exactly
+    `join_field` -- e.g. `sum by (http_target) (...)` -- so each returned
+    frame has a single label column for `joinByField` to align on. An
+    expression that leaks a second label produces one row per label
+    combination instead of one row per endpoint, and the join silently
+    yields a mostly-empty table rather than an error.
+
+    Prometheus table frames come back as `Time` + label columns + `Value`,
+    and Grafana disambiguates the value columns across targets as
+    `Value #<refId>`. The `organize` transformation below both drops the
+    per-frame `Time` columns and renames each `Value #<refId>` to its
+    human-readable `title`; the field overrides then attach units by that
+    renamed name, which is what the override matcher sees.
+    """
+    targets = [
+        {
+            "datasource": datasource_ref,
+            "expr": column["expr"],
+            "refId": chr(65 + i),
+            "instant": True,
+            "format": "table",
+        }
+        for i, column in enumerate(columns)
+    ]
+    exclude = {"Time": True} | {f"Time {i + 1}": True for i, _ in enumerate(columns)}
+    rename = {
+        f"Value #{chr(65 + i)}": column["title"] for i, column in enumerate(columns)
+    }
+    overrides = [
+        {
+            "matcher": {"id": "byName", "options": column["title"]},
+            "properties": [{"id": "unit", "value": column["unit"]}],
+        }
+        for column in columns
+        if column.get("unit")
+    ]
+    options: dict[str, Any] = {
+        "showHeader": True,
+        "footer": {"show": False, "reducer": ["sum"], "countRows": False},
+    }
+    if sort_by is not None:
+        options["sortBy"] = [{"displayName": sort_by, "desc": True}]
+    return {
+        "title": title,
+        "description": description,
+        "type": "table",
+        "datasource": datasource_ref,
+        "gridPos": grid_pos,
+        "fieldConfig": {
+            "defaults": {
+                "custom": {"align": "auto", "filterable": True},
+                "decimals": 2,
+            },
+            "overrides": overrides,
+        },
+        "options": options,
+        "transformations": [
+            {"id": "joinByField", "options": {"byField": join_field, "mode": "outer"}},
+            {
+                "id": "organize",
+                "options": {"excludeByName": exclude, "renameByName": rename},
+            },
+        ],
+        "targets": targets,
+    }
+
+
 def _row_panel(*, title: str, y: int) -> dict[str, Any]:
     """Build a row divider panel to visually group the panels beneath it."""
     return {
@@ -381,6 +469,23 @@ def create(resource_opts: ResourceOptions) -> None:
         _timeseries_panel,
         _bar_gauge_panel,
         _logs_panel,
+        _row_panel,
+        _create_dashboard,
+        resource_opts,
+    )
+
+    apm_folder = Folder(
+        "application-performance-dashboards-folder",
+        title="Application Performance",
+        uid="application-performance-dashboards",
+        opts=resource_opts,
+    )
+
+    service_red.create(
+        apm_folder.uid,
+        _timeseries_panel,
+        _stat_panel,
+        _table_panel,
         _row_panel,
         _create_dashboard,
         resource_opts,

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/service_red.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/service_red.py
@@ -19,15 +19,24 @@ Even a spanmetrics dashboard with the right metric name would be misleading.
 Tempo generates spanmetrics from what it *ingests*, i.e. after tail sampling,
 so RED computed that way describes the sample rather than the traffic.
 Measured 2026-09-01 against mitxonline-webapp, which had been emitting for 25h
-(learn-webapp was mid-rollout and not yet a fair comparison):
+(learn-webapp was mid-rollout and not yet a fair comparison), 1h rate windows:
 
-  request rate   414/s from `http_server_duration_milliseconds_count`
-                 1.06/s from `traces_spanmetrics_latency_count` -- ~0.26%
-  p95 latency    381 ms native, 620 ms trace-derived -- 63% pessimistic
+  request rate   431/s from `http_server_duration_milliseconds_count`
+                 1.05/s from `traces_spanmetrics_latency_count` -- 0.24%
 
-The direction of the latency error is not even stable: on learn-webapp the
-trace-derived p95 read *lower* than native. There is no correction factor to
-apply, which is why these panels read the meter directly.
+The latency error is not a bias you could correct for, it is noise. Over the
+same three hours, p95 on mitxonline-webapp:
+
+  native, 1h window        357 - 401 ms
+  native, 5m window        328 - 408 ms
+  trace-derived, 1h        320 - 545 ms
+  trace-derived, 5m        231 - 1246 ms
+
+A 5.4x swing on the trace-derived estimate across a window where the native
+measurement moved 11%, because at ~1 sampled span/s a 5m bucket holds a few
+hundred spans and the tail sampler picked them for being slow or errored.
+Reading it at one instant can show it 60% high or 40% low. That is why these
+panels read the meter directly rather than applying a fudge factor.
 
 `http_server_duration_milliseconds_*` bypasses the tail sampler entirely. In
 the `grafana-k8s-monitoring-alloy-receiver` pipeline only `traces` route into

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/service_red.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/service_red.py
@@ -1,0 +1,319 @@
+"""RED metrics for the OTel-instrumented Django services, from the app's own meter.
+
+Replaces two Grafana-Cloud-UI dashboards that both read trace-derived data and
+neither of which works:
+
+  `opentelemetry-apm` queried `duration_milliseconds_*`, the metric name a
+  self-hosted otel-collector `spanmetrics` connector produces. Grafana Cloud's
+  Tempo metrics-generator names its output `traces_spanmetrics_latency_*`
+  instead, so every panel on that dashboard has always been empty here.
+
+  `febljk0a32qyoa` ("Lightweight APM for OpenTelemetry") queries the *stable*
+  semconv names -- `http_server_request_duration_seconds_*`,
+  `http_client_request_duration_seconds_*`. Our SDK emits the old ones:
+  `OTEL_SEMCONV_STABILITY_OPT_IN` is set nowhere in `src/`, and
+  opentelemetry-instrumentation-wsgi/-asgi gate the stable metric behind it.
+  So that dashboard is empty for our services too.
+
+Even a spanmetrics dashboard with the right metric name would be misleading.
+Tempo generates spanmetrics from what it *ingests*, i.e. after tail sampling,
+so RED computed that way describes the sample rather than the traffic.
+Measured 2026-09-01 against mitxonline-webapp, which had been emitting for 25h
+(learn-webapp was mid-rollout and not yet a fair comparison):
+
+  request rate   414/s from `http_server_duration_milliseconds_count`
+                 1.06/s from `traces_spanmetrics_latency_count` -- ~0.26%
+  p95 latency    381 ms native, 620 ms trace-derived -- 63% pessimistic
+
+The direction of the latency error is not even stable: on learn-webapp the
+trace-derived p95 read *lower* than native. There is no correction factor to
+apply, which is why these panels read the meter directly.
+
+`http_server_duration_milliseconds_*` bypasses the tail sampler entirely. In
+the `grafana-k8s-monitoring-alloy-receiver` pipeline only `traces` route into
+`otelcol.exporter.loadbalancing.gc_otlp_endpoint_sampler`; `metrics` go
+straight to the OTLP exporter.
+
+WHY `http_target` AND NOT `http_route`: the wsgi/asgi instrumentation carries
+the Django URL *pattern* (`^api/v1/learning_resources/(?P<id>[^/.]+)/$`) on the
+`http.target` metric attribute, and emits no `http.route` attribute at all.
+So `http_target` is the endpoint dimension here, and it is a route pattern
+rather than a raw path -- cardinality is 124 values for mitxonline-webapp and
+65 for learn-webapp, not one per request.
+
+WHAT IS ABSENT AND WHY: every edxapp workload sets `OTEL_METRICS_EXPORTER=none`
+(applications/edxapp/k8s_resources.py), so LMS/CMS/celery emit traces but no
+`http.server.duration` and will never appear in the `$service` list. That is by
+design, not a gap in this dashboard.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from pulumi import Input, ResourceOptions
+
+from ol_infrastructure.infrastructure.grafana_alerting.dashboards.datasources import (
+    MIMIR_DATASOURCE_REF,
+)
+
+_DURATION = "http_server_duration_milliseconds"
+_SELECTOR = 'service_name=~"$service", http_target=~"$route"'
+_5XX = f'{_SELECTOR}, http_status_code=~"5.."'
+_4XX = f'{_SELECTOR}, http_status_code=~"4.."'
+
+# `sum(...) or vector(0)` keeps an error-ratio panel reading 0 rather than "No
+# data" during the (common, desirable) windows with no 5xx at all -- without it
+# the numerator is an empty vector and the whole division returns nothing.
+_ZERO = "or vector(0)"
+
+
+def _rate(
+    selector: str, suffix: str = "count", window: str = "$__rate_interval"
+) -> str:
+    return f"rate({_DURATION}_{suffix}{{{selector}}}[{window}])"
+
+
+def _quantile(quantile: float, by: str = "") -> str:
+    grouping = f"le, {by}" if by else "le"
+    return (
+        f"histogram_quantile({quantile}, "
+        f"sum by ({grouping}) ({_rate(_SELECTOR, 'bucket')}))"
+    )
+
+
+def _dashboard_json(
+    timeseries_panel: Callable[..., dict[str, Any]],
+    stat_panel: Callable[..., dict[str, Any]],
+    table_panel: Callable[..., dict[str, Any]],
+    row_panel: Callable[..., dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "uid": "otel-service-red",
+        "title": "Service RED - OpenTelemetry",
+        "description": (
+            "Rate, errors and duration for the OTel-instrumented Django "
+            "services, read from each app's own MeterProvider "
+            "(http.server.duration) rather than from Tempo-derived "
+            "spanmetrics. Metrics bypass the tail sampler, so these numbers "
+            "describe all traffic instead of the sampled fraction."
+        ),
+        "tags": ["opentelemetry", "apm", "red"],
+        "timezone": "browser",
+        "schemaVersion": 39,
+        "version": 1,
+        "editable": True,
+        "time": {"from": "now-6h", "to": "now"},
+        "refresh": "1m",
+        "templating": {
+            "list": [
+                {
+                    "name": "service",
+                    "label": "Service",
+                    "type": "query",
+                    "datasource": MIMIR_DATASOURCE_REF,
+                    "query": f"label_values({_DURATION}_count, service_name)",
+                    "multi": True,
+                    "includeAll": True,
+                    "current": {"text": "All", "value": "$__all"},
+                    "refresh": 2,
+                },
+                {
+                    "name": "route",
+                    "label": "Endpoint pattern",
+                    "type": "textbox",
+                    "query": ".*",
+                    "current": {"text": ".*", "value": ".*"},
+                },
+            ]
+        },
+        "panels": [
+            row_panel(title="Overview", y=0),
+            stat_panel(
+                title="Request rate",
+                expr=f"sum({_rate(_SELECTOR)})",
+                grid_pos={"h": 4, "w": 6, "x": 0, "y": 1},
+                unit="reqps",
+                decimals=1,
+            ),
+            stat_panel(
+                title="5xx rate",
+                expr=f"(sum({_rate(_5XX)}) {_ZERO}) / sum({_rate(_SELECTOR)})",
+                grid_pos={"h": 4, "w": 6, "x": 6, "y": 1},
+                unit="percentunit",
+                decimals=2,
+            ),
+            stat_panel(
+                title="p95 latency",
+                expr=_quantile(0.95),
+                grid_pos={"h": 4, "w": 6, "x": 12, "y": 1},
+                unit="ms",
+                decimals=0,
+            ),
+            stat_panel(
+                title="In-flight requests",
+                expr='sum(http_server_active_requests{service_name=~"$service"})',
+                grid_pos={"h": 4, "w": 6, "x": 18, "y": 1},
+                unit="short",
+                decimals=0,
+            ),
+            row_panel(title="Rate", y=5),
+            timeseries_panel(
+                title="Requests per second by service",
+                expr=f"sum by (service_name) ({_rate(_SELECTOR)})",
+                legend_format="{{service_name}}",
+                grid_pos={"h": 8, "w": 12, "x": 0, "y": 6},
+                unit="reqps",
+                legend_calc="mean",
+            ),
+            timeseries_panel(
+                title="Requests per second by status code",
+                expr=f"sum by (http_status_code) ({_rate(_SELECTOR)})",
+                legend_format="{{http_status_code}}",
+                grid_pos={"h": 8, "w": 12, "x": 12, "y": 6},
+                unit="reqps",
+                legend_calc="mean",
+            ),
+            row_panel(title="Errors", y=14),
+            timeseries_panel(
+                title="Error ratio",
+                queries=[
+                    {
+                        "expr": (
+                            f"(sum({_rate(_5XX)}) {_ZERO}) / sum({_rate(_SELECTOR)})"
+                        ),
+                        "legend_format": "5xx",
+                    },
+                    {
+                        "expr": (
+                            f"(sum({_rate(_4XX)}) {_ZERO}) / sum({_rate(_SELECTOR)})"
+                        ),
+                        "legend_format": "4xx",
+                    },
+                ],
+                grid_pos={"h": 8, "w": 12, "x": 0, "y": 15},
+                unit="percentunit",
+                description=(
+                    "4xx is graphed alongside 5xx because a large share of "
+                    "these services' 4xx are 401/403 from unauthenticated "
+                    "API polling, which is normal traffic rather than a "
+                    "fault -- a 4xx spike is worth reading, a steady 4xx "
+                    "floor is not."
+                ),
+            ),
+            timeseries_panel(
+                title="Top endpoints by 5xx rate",
+                expr=f"topk(10, sum by (http_target) ({_rate(_5XX)}))",
+                legend_format="{{http_target}}",
+                grid_pos={"h": 8, "w": 12, "x": 12, "y": 15},
+                unit="reqps",
+                legend_calc="max",
+            ),
+            row_panel(title="Duration", y=23),
+            timeseries_panel(
+                title="Latency percentiles",
+                queries=[
+                    {"expr": _quantile(0.50), "legend_format": "p50"},
+                    {"expr": _quantile(0.95), "legend_format": "p95"},
+                    {"expr": _quantile(0.99), "legend_format": "p99"},
+                ],
+                grid_pos={"h": 8, "w": 12, "x": 0, "y": 24},
+                unit="ms",
+                legend_calc="max",
+                description=(
+                    "Interpolated from the SDK's default 15 explicit bucket "
+                    "boundaries (0,5,10,25,50,75,100,250,500,750,1000,2500,"
+                    "5000,7500,10000 ms). A p99 sitting inside the 2500-5000 "
+                    "bucket is precise to that bucket and no further."
+                ),
+            ),
+            timeseries_panel(
+                title="Top endpoints by p95 latency",
+                expr=f"topk(10, {_quantile(0.95, by='http_target')})",
+                legend_format="{{http_target}}",
+                grid_pos={"h": 8, "w": 12, "x": 12, "y": 24},
+                unit="ms",
+                legend_calc="max",
+                description=(
+                    "Ranks on latency alone, so a once-an-hour endpoint can "
+                    "outrank a hot one. Read it next to the Endpoints table "
+                    "below, which carries the request rate."
+                ),
+            ),
+            row_panel(title="Endpoints", y=32),
+            table_panel(
+                title="Per-endpoint RED",
+                join_field="http_target",
+                sort_by="Requests/sec",
+                columns=[
+                    {
+                        "expr": f"sum by (http_target) ({_rate(_SELECTOR)})",
+                        "title": "Requests/sec",
+                        "unit": "reqps",
+                    },
+                    {
+                        "expr": _quantile(0.95, by="http_target"),
+                        "title": "p95 (ms)",
+                        "unit": "ms",
+                    },
+                    {
+                        # No `or vector(0)` here, unlike the panels above:
+                        # `vector(0)` carries no labels, so it can never match
+                        # a `by (http_target)` denominator. An endpoint with no
+                        # 5xx correctly leaves this cell empty instead.
+                        "expr": (
+                            f"sum by (http_target) ({_rate(_5XX)}) / "
+                            f"sum by (http_target) ({_rate(_SELECTOR)})"
+                        ),
+                        "title": "5xx ratio",
+                        "unit": "percentunit",
+                    },
+                ],
+                grid_pos={"h": 12, "w": 24, "x": 0, "y": 33},
+                description=(
+                    "One row per Django URL pattern. `http_target` holds the "
+                    "route regex, not the requested path, so this stays at "
+                    "roughly 100 rows per service rather than growing with "
+                    "traffic."
+                ),
+            ),
+            row_panel(title="Saturation", y=45),
+            timeseries_panel(
+                title="In-flight requests by pod",
+                expr=(
+                    "sum by (k8s_pod_name) "
+                    '(http_server_active_requests{service_name=~"$service"})'
+                ),
+                legend_format="{{k8s_pod_name}}",
+                grid_pos={"h": 8, "w": 24, "x": 0, "y": 46},
+                unit="short",
+                legend_calc="max",
+                description=(
+                    "The $route filter does not apply here: "
+                    "http_server_active_requests carries no http_target "
+                    "attribute, only method/scheme/host. Compare the peak "
+                    "against the pod's worker+thread budget to see whether "
+                    "requests are queueing."
+                ),
+            ),
+        ],
+    }
+
+
+def create(
+    folder_uid: Input[str],
+    timeseries_panel: Callable[..., dict[str, Any]],
+    stat_panel: Callable[..., dict[str, Any]],
+    table_panel: Callable[..., dict[str, Any]],
+    row_panel: Callable[..., dict[str, Any]],
+    create_dashboard: Callable[
+        [str, Input[str], dict[str, Any], ResourceOptions], None
+    ],
+    resource_opts: ResourceOptions,
+) -> None:
+    """Create the OpenTelemetry service RED dashboard."""
+    create_dashboard(
+        "otel-service-red-dashboard",
+        folder_uid,
+        _dashboard_json(timeseries_panel, stat_panel, table_panel, row_panel),
+        resource_opts,
+    )


### PR DESCRIPTION
## What are the relevant tickets?

Part of the OpenTelemetry APM coverage work. Closes the "move RED dashboards off trace-derived spanmetrics" task and the odl-video-service half of "move ocw_studio and odl_video_service off OPENTELEMETRY_ENDPOINT". Follows #5645.

## Description

Two things, both downstream of #5645 turning on the MeterProvider.

### 1. A RED dashboard that reads the app's own meter

Both APM dashboards in Grafana Cloud are empty, and neither is fixable by tweaking a query:

- `opentelemetry-apm` queries `duration_milliseconds_*`, the name a self-hosted otel-collector `spanmetrics` connector emits. Grafana Cloud's Tempo metrics-generator calls its output `traces_spanmetrics_latency_*`. Listing every `.*duration_milliseconds.*` metric in `grafanacloud-prom` returns only `http_client_*`, `http_server_*` and `witan_tool_*` — the metric that dashboard queries does not exist here.
- `febljk0a32qyoa` ("Lightweight APM for OpenTelemetry") queries the *stable* semconv names (`http_server_request_duration_seconds_*`). Our SDK emits the old ones: `OTEL_SEMCONV_STABILITY_OPT_IN` appears nowhere in `src/`, and the wsgi/asgi instrumentation gates the stable metric behind it.

Repointing either at `traces_spanmetrics_*` would trade empty for wrong. Tempo derives spanmetrics from what it *ingests*, i.e. after tail sampling. Measured 2026-09-01 against mitxonline-webapp, which had been emitting for 25h (learn-webapp was mid-rollout and not a fair comparison), 1h rate windows:

| | native `http_server_duration_milliseconds` | trace-derived `traces_spanmetrics_latency` |
|---|---|---|
| request rate | 431/s | 1.05/s — **0.24% of traffic** |

The rate undercount is the stable, decisive finding. The latency error is not a bias you could correct for, it is noise. p95 on mitxonline-webapp over the same three hours:

| | range over 3h |
|---|---|
| native, 1h window | 357 – 401 ms |
| native, 5m window | 328 – 408 ms |
| trace-derived, 1h window | 320 – 545 ms |
| trace-derived, 5m window | 231 – **1246** ms |

A 5.4x swing on the trace-derived estimate across a window where the native measurement moved 11% — at ~1 sampled span/s a 5m bucket holds a few hundred spans, all picked by the tail sampler for being slow or errored. Read at one instant it can show 60% high or 40% low. So the new dashboard reads `http.server.duration` directly. That metric bypasses the sampler: in the `grafana-k8s-monitoring-alloy-receiver` pipeline only `traces` route into the loadbalancing sampler exporter.

`Service RED - OpenTelemetry` (uid `otel-service-red`) lands in a new **Application Performance** folder, so it is not filed under Keycloak. Panels: overview stats, rate by service and by status code, 4xx/5xx ratio, top endpoints by 5xx and by p95, latency percentiles, a per-endpoint RED table, and in-flight requests by pod.

The endpoint dimension is `http_target`, not `http_route` — the wsgi/asgi instrumentation puts the Django URL *pattern* on `http.target` and emits no `http.route` attribute at all. Cardinality is ~100 route patterns per service (124 mitxonline, 65 learn), not one value per path.

Adds a `_table_panel` helper to `dashboards/base.py` (joins several instant queries with `joinByField`) for the per-endpoint table.

### 2. odl-video-service moves to `OTEL_EXPORTER_OTLP_ENDPOINT`

Same swap #5645 made for mit_learn, learn_ai, mitxonline and ol_analytics_api, which turns the MeterProvider on. OVS's OTel block lives in `__main__.py` rather than a stack file because OVS has no `vars:` block in its stack configs.

**ocw-studio is deliberately not included here.** Its running `0.196.0` image locks `mitol-django-observability==2026.3.11` (read from `uv.lock` at tag `v0.196.0`, resolved from the image tag live in production rather than from HEAD). That release has neither the endpoint fix — before 2026.8.19 an environment-sourced endpoint was passed to `OTLPSpanExporter(endpoint=...)`, which uses it verbatim, so a base URL 404s per batch at the collector root — nor the MeterProvider. The same swap there would break its working tracing and still produce no metrics. Tracked separately; it needs a dependency bump and a release first.

### Nothing to move on alerts

The task also covered moving *alerts* off spanmetrics. There are none: all 127 Grafana-managed rules were dumped and checked, and not one references `traces_spanmetrics_*`, `traces_service_graph_*`, or `duration_milliseconds_*`. Existing HTTP error alerting is Loki nginx-log parsing (`log_rules/mit_learn.py`) plus `apisix_http_status` at the edge; the only latency rules are Synthetic Monitoring probes (`folder_uid: grafana-synthetic-monitoring-app`).

Worth flagging the gap that leaves: there is still no app-side latency alert anywhere. Now that `http.server.duration` is trustworthy, thresholds can be picked from evidence — but that is new alerting rather than a move, so it is not in this PR.

## How can this be tested?

Every panel query was run against `grafanacloud-prom` before commit, with `$service` expanded to `(learn-webapp|mitxonline-webapp)` and `$__rate_interval` to `5m`. All return data. Notable: `^checkout/result/` shows a p95 of ~9.7s, which was invisible before.

`pulumi preview`:

- `grafana_alerting` Production: `+ 2 to create` (the folder and the dashboard), 37 unchanged.
- `odl_video_service` Production: `~ 3 to update`, 137 unchanged — env var rename only, on the deployment plus its init containers.

`pre-commit run` passes (ruff format, ruff check, mypy).

After apply, `Service RED - OpenTelemetry` should list learn-webapp and mitxonline-webapp in `$service`; ovs-webapp joins once the OVS deploy rolls. edxapp workloads will never appear — `applications/edxapp/k8s_resources.py` sets `OTEL_METRICS_EXPORTER=none`, so they emit traces and no metrics by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBxrkpbnKGKKfqtZNtN3dP
