### PR TITLE
fix(edxapp): drop vestigial xqueue DB-creds grants from edxapp Vault policies

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/edxapp_mitx-staging_policy.hcl
+++ b/src/ol_infrastructure/applications/edxapp/edxapp_mitx-staging_policy.hcl
@@ -6,10 +6,6 @@ path "mariadb-mitx-staging/creds/edxapp-csmh" {
   capabilities = ["read"]
 }
 
-path "mariadb-mitx-staging/creds/xqueue" {
-  capabilities = ["read"]
-}
-
 path "sys/leases/renew" {
   capabilities = [ "update" ]
 }

--- a/src/ol_infrastructure/applications/edxapp/edxapp_mitx_policy.hcl
+++ b/src/ol_infrastructure/applications/edxapp/edxapp_mitx_policy.hcl
@@ -6,10 +6,6 @@ path "mariadb-mitx/creds/edxapp-csmh" {
   capabilities = ["read"]
 }
 
-path "mariadb-mitx/creds/xqueue" {
-  capabilities = ["read"]
-}
-
 path "sys/leases/renew" {
   capabilities = [ "update" ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/10826 (item 3, which flagged the mitxonline policy as missing this grant — investigation showed the grant is vestigial in the mitx/mitx-staging policies instead).

### Description (What does it do?)
- Removes the `mariadb-mitx/creds/xqueue` and `mariadb-mitx-staging/creds/xqueue` read grants from the per-deployment edxapp Vault policies.
- edxapp never reads xqueue's dynamic DB credentials: it talks to xqueue over HTTP using `django_auth` credentials rendered from the static `secret-{deployment}/edx-xqueue` secret (https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/edxapp/k8s_secrets.py#L292-L309), which remains granted.
- The only consumer of `mariadb-{deployment}/creds/xqueue` is the standalone xqueue app, which mounts it under its own Vault role and policy (https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/xqueue/xqueue_policy.hcl and https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/xqueue/__main__.py#L183). All three deployments (mitx, mitx-staging, mitxonline) get that grant through the xqueue stacks.
- Net effect: shrinks the edxapp role's Vault surface; no behavior change. mitxonline's policy needs no addition — it never had the grant and nothing misses it.

### How can this be tested?
- `pulumi preview` run locally against `applications.edxapp` `mitx-staging.QA` and `mitx.QA`: each shows exactly one change from this PR — an in-place update of the `edxapp-{deployment}` `vault:index/policy:Policy` removing the xqueue stanza. (mitx.QA also shows a pre-existing unrelated drift on the `secret-mitx` mount's `options.version`.)
- Repo-wide grep confirms no template, configmap, or secret in the edxapp deployment references `creds/xqueue`.
- Post-deploy validation: xqueue pods continue to obtain DB creds via their own role (`vault read mariadb-mitx/creds/xqueue` with the xqueue token still works; edxapp pods never request it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)