### PR TITLE
fix: reset MITxOnline's gateway session on hand-off, and make logout framing explicit

### DIFF
--- a/local-dev/apps/mit-learn/apisix-routes.yaml
+++ b/local-dev/apps/mit-learn/apisix-routes.yaml
@@ -86,6 +86,16 @@ spec:
         unauth_action: pass
         session:
           secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          # Flat keys, matching OLApisixOIDCConfig -- lua-resty-session 4.x on
+          # APISIX 3.17+ ignores the nested `cookie:` form.  Named as in
+          # production so this session is distinguishable in devtools from
+          # MITx Online's, which is the whole subject of hq#12763.  MITx Online's
+          # /mitxonline/* routes read this same cookie and must match it exactly.
+          cookie_domain: ".learn.mit.dev"
+          cookie_name: "mitlearn_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         ssl_verify: false
 
   - name: logout-redirect
@@ -135,6 +145,16 @@ spec:
         unauth_action: auth
         session:
           secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          # Flat keys, matching OLApisixOIDCConfig -- lua-resty-session 4.x on
+          # APISIX 3.17+ ignores the nested `cookie:` form.  Named as in
+          # production so this session is distinguishable in devtools from
+          # MITx Online's, which is the whole subject of hq#12763.  MITx Online's
+          # /mitxonline/* routes read this same cookie and must match it exactly.
+          cookie_domain: ".learn.mit.dev"
+          cookie_name: "mitlearn_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         ssl_verify: false
 ---
 # ApisixRoute — /learn/ prefix (strips prefix before forwarding to backend).
@@ -185,6 +205,16 @@ spec:
         unauth_action: pass
         session:
           secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          # Flat keys, matching OLApisixOIDCConfig -- lua-resty-session 4.x on
+          # APISIX 3.17+ ignores the nested `cookie:` form.  Named as in
+          # production so this session is distinguishable in devtools from
+          # MITx Online's, which is the whole subject of hq#12763.  MITx Online's
+          # /mitxonline/* routes read this same cookie and must match it exactly.
+          cookie_domain: ".learn.mit.dev"
+          cookie_name: "mitlearn_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         ssl_verify: false
 
   - name: logout-redirect
@@ -240,4 +270,14 @@ spec:
         unauth_action: auth
         session:
           secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          # Flat keys, matching OLApisixOIDCConfig -- lua-resty-session 4.x on
+          # APISIX 3.17+ ignores the nested `cookie:` form.  Named as in
+          # production so this session is distinguishable in devtools from
+          # MITx Online's, which is the whole subject of hq#12763.  MITx Online's
+          # /mitxonline/* routes read this same cookie and must match it exactly.
+          cookie_domain: ".learn.mit.dev"
+          cookie_name: "mitlearn_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         ssl_verify: false

--- a/local-dev/apps/mit-learn/configmaps/app-env.yaml
+++ b/local-dev/apps/mit-learn/configmaps/app-env.yaml
@@ -30,6 +30,10 @@ data:
   MITOL_API_BASE_URL: "https://api.learn.mit.dev"
   # Redirect target for first-time OIDC logins; defaults to a legacy open.odl.local host.
   MITOL_NEW_USER_LOGIN_URL: "https://learn.mit.dev/onboarding"
+  # Open edX's logout page, which Learn's logout interstitial frames so the
+  # logout fans out to MITx Online and studio without leaving learn.mit.dev
+  # (hq#12763).  Must match the openedx app's lms_base_url.
+  OPENEDX_LOGOUT_URL: "https://lms.mit.dev/logout"
 
   # mkcert root CA — trusts the local wildcard TLS cert for inter-pod HTTPS
   # (e.g. Django OIDC token exchange with Keycloak at sso.ol.mit.dev)

--- a/local-dev/apps/mitxonline/apisix-routes.yaml
+++ b/local-dev/apps/mitxonline/apisix-routes.yaml
@@ -25,6 +25,17 @@ spec:
       headers:
         set:
           Referrer-Policy: "origin"
+          # Mirrors response_rewrite_plugin_config in
+          # src/ol_infrastructure/applications/mitxonline/__main__.py.  Without
+          # it local-dev silently permits framing that production refuses, so a
+          # logout fan-out would pass here and fail in production.
+          #
+          # lms.mit.dev frames our /logout?no_redirect=1 during its own logout
+          # fan-out; api.learn.mit.dev is above it in the chain once Learn's
+          # logout interstitial frames lms (hq#12763), and frame-ancestors is
+          # checked against every ancestor, not just the immediate parent.
+          Content-Security-Policy: >-
+            frame-ancestors 'self' https://lms.mit.dev https://api.learn.mit.dev
   - name: prometheus
     enable: true
 ---
@@ -89,9 +100,17 @@ spec:
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
           secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
-          cookie:
-            domain: ".mitxonline.mit.dev"
-            lifetime: 1209600
+          # Flat keys, matching OLApisixOIDCConfig.  lua-resty-session 4.x on
+          # APISIX 3.17+ reads only these; the nested `cookie:` form this used to
+          # use is silently ignored, which left the cookie host-only and gave
+          # mitxonline.mit.dev and api.mitxonline.mit.dev separate sessions.
+          cookie_domain: ".mitxonline.mit.dev"
+          # Named as in production so the two gateway sessions are telling apart
+          # in devtools rather than both showing as "session".
+          cookie_name: "mitxonline_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         session_contents:
           access_token: true
           enc_id_token: true
@@ -148,15 +167,71 @@ spec:
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
           secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
-          cookie:
-            domain: ".mitxonline.mit.dev"
-            lifetime: 1209600
+          # Flat keys, matching OLApisixOIDCConfig.  lua-resty-session 4.x on
+          # APISIX 3.17+ reads only these; the nested `cookie:` form this used to
+          # use is silently ignored, which left the cookie host-only and gave
+          # mitxonline.mit.dev and api.mitxonline.mit.dev separate sessions.
+          cookie_domain: ".mitxonline.mit.dev"
+          # Named as in production so the two gateway sessions are telling apart
+          # in devtools rather than both showing as "session".
+          cookie_name: "mitxonline_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         session_contents:
           access_token: true
           enc_id_token: true
           id_token: true
           user: true
         unauth_action: auth
+
+  # Session reset for hand-offs from MIT Learn (hq#12763).  Mirrors the
+  # "switch-session" route in
+  # src/ol_infrastructure/applications/mitxonline/__main__.py.
+  #
+  # No openid-connect plugin on purpose: it would validate, and possibly
+  # refresh, the very session this route exists to discard.  The
+  # serverless-post-function expires the gateway session cookie on the way out,
+  # so the redirect Django issues lands on "cart" below with no session, runs a
+  # fresh authorization-code flow, and comes back as whoever currently holds the
+  # Keycloak SSO session.
+  - name: switch-session
+    priority: 20
+    match:
+      hosts:
+      - "mitxonline.mit.dev"
+      - "api.mitxonline.mit.dev"
+      paths:
+      - "/switch-session"
+      - "/switch-session/"
+    backends:
+    - serviceName: mitxonline-webapp
+      servicePort: 8010
+    plugin_config_name: mitxonline-shared-plugins
+    plugins:
+    - name: serverless-post-function
+      enable: true
+      config:
+        # header_filter, not the default log phase: response headers are still
+        # mutable there.
+        phase: header_filter
+        functions:
+        - |
+          return function(conf, ctx)
+              local cookie = ngx.var.http_cookie
+              if not cookie then
+                  return
+              end
+              local core = require("apisix.core")
+              for pair in cookie:gmatch("[^;]+") do
+                  local name = pair:match("^%s*([^=%s]+)=")
+                  if name and (name == "mitxonline_apisix_session"
+                               or name:match("^mitxonline_apisix_session_%d+$")) then
+                      core.response.add_header("Set-Cookie", name .. "=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax")
+                      core.response.add_header("Set-Cookie", name .. "=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax; Domain=.mitxonline.mit.dev")
+                  end
+              end
+          end
 
   - name: cart
     priority: 20
@@ -188,9 +263,17 @@ spec:
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
           secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
-          cookie:
-            domain: ".mitxonline.mit.dev"
-            lifetime: 1209600
+          # Flat keys, matching OLApisixOIDCConfig.  lua-resty-session 4.x on
+          # APISIX 3.17+ reads only these; the nested `cookie:` form this used to
+          # use is silently ignored, which left the cookie host-only and gave
+          # mitxonline.mit.dev and api.mitxonline.mit.dev separate sessions.
+          cookie_domain: ".mitxonline.mit.dev"
+          # Named as in production so the two gateway sessions are telling apart
+          # in devtools rather than both showing as "session".
+          cookie_name: "mitxonline_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         session_contents:
           access_token: true
           enc_id_token: true
@@ -244,8 +327,12 @@ spec:
         scope: "openid profile email ol-profile"
         ssl_verify: false
         renew_access_token_on_expiry: true
-        # No cookie name/domain override → default name "session" on host
-        # api.learn.mit.dev, matching the learn route that issued the cookie.
+        # Must match the learn route that issued the cookie, exactly -- a
+        # mismatch turns this unauth_action=pass route anonymous.
         session:
           secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
+          cookie_name: "mitlearn_apisix_session"
+          absolute_timeout: 1209600
+          idling_timeout: 0
+          rolling_timeout: 0
         unauth_action: pass

--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -14,11 +14,14 @@ data:
   # mitxonline.odl.local:8013 host, which doesn't resolve in this stack.
   MITXONLINE_NEW_USER_LOGIN_URL: "https://mitxonline.mit.dev/create-profile"
 
-  # The trailing "&" is deliberate: the view appends "?redirect_url=..." to this
-  # value, and it keeps no_redirect parsing as exactly "1".
-  # If the openedx app is ever enabled here, change this to
-  # https://lms.mit.dev/logout to match how the deployed envs do it.
-  LOGOUT_REDIRECT_URL: "https://mitxonline.mit.dev/logout?no_redirect=1&"
+  # Open edX's logout page, matching how the deployed envs set this.  It fans
+  # the logout out to every entry in the LMS's IDA_LOGOUT_URI_LIST -- MITx
+  # Online, studio and Learn -- which is what makes hq#12763 reproducible here.
+  #
+  # This used to point back at MITx Online's own /logout?no_redirect=1& because
+  # the openedx app was not deployed locally; that self-loop tore down only this
+  # application's session, so a cross-application logout bug could not show up.
+  LOGOUT_REDIRECT_URL: "https://lms.mit.dev/logout"
   MITX_ONLINE_DB_DISABLE_SSL: "True"
   MITX_ONLINE_USE_S3: "False"
   DEBUG: "False"

--- a/local-dev/apps/openedx/apisix-routes.yaml
+++ b/local-dev/apps/openedx/apisix-routes.yaml
@@ -1,0 +1,144 @@
+---
+# APISIX routes for Open edX in the ol-infrastructure local-dev cluster.
+#
+# Unlike the mit-learn and mitxonline routes, these carry no openid-connect
+# plugin: Open edX authenticates through its own social-auth pipeline, not the
+# gateway.  APISIX is only terminating TLS and routing here.
+apiVersion: apisix.apache.org/v2
+kind: ApisixTls
+metadata:
+  name: openedx-tls
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  hosts:
+  - "lms.mit.dev"
+  - "studio.mit.dev"
+  - "notes.mit.dev"
+  secret:
+    name: local-dev-tls
+    namespace: openedx
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixPluginConfig
+metadata:
+  name: openedx-shared-plugins
+  namespace: openedx
+spec:
+  plugins:
+  - name: redirect
+    enable: true
+    config:
+      http_to_https: true
+  - name: prometheus
+    enable: true
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: openedx-route
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  http:
+  # Mirrors the lms-logout route in
+  # src/ol_infrastructure/applications/edxapp/k8s_resources.py.
+  #
+  # This deployment serves X_FRAME_OPTIONS = "ALLOW-FROM canvas.mit.edu", a
+  # directive no current browser implements, so whether it restricts framing at
+  # all is UA-dependent (hq#12763).  Drop it for this path only and state the
+  # policy in CSP instead, which browsers do implement.  The rest of the LMS
+  # keeps whatever the app sends.
+  - name: lms-logout
+    priority: 10
+    match:
+      hosts:
+      - "lms.mit.dev"
+      paths:
+      - "/logout"
+      - "/logout/"
+    backends:
+    - serviceName: lms
+      servicePort: 8000
+    plugin_config_name: openedx-shared-plugins
+    plugins:
+    - name: response-rewrite
+      enable: true
+      config:
+        headers:
+          remove:
+          - "X-Frame-Options"
+          set:
+            Content-Security-Policy: "frame-ancestors 'self' https://api.learn.mit.dev"
+
+  - name: lms
+    priority: 0
+    match:
+      hosts:
+      - "lms.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: lms
+      servicePort: 8000
+    plugin_config_name: openedx-shared-plugins
+    timeout:
+      connect: 600s
+      read: 600s
+      send: 600s
+
+  # Studio is itself one of the IDAs the LMS logout page frames, and serves the
+  # same unimplemented ALLOW-FROM directive.  Name the allowed ancestors
+  # explicitly: the LMS host as the immediate parent, and Learn's because it
+  # sits above the LMS once Learn's interstitial is in play -- frame-ancestors
+  # is checked against every ancestor, not just the nearest.
+  - name: cms-logout
+    priority: 10
+    match:
+      hosts:
+      - "studio.mit.dev"
+      paths:
+      - "/logout"
+      - "/logout/"
+    backends:
+    - serviceName: cms
+      servicePort: 8010
+    plugin_config_name: openedx-shared-plugins
+    plugins:
+    - name: response-rewrite
+      enable: true
+      config:
+        headers:
+          remove:
+          - "X-Frame-Options"
+          set:
+            Content-Security-Policy: >-
+              frame-ancestors 'self' https://lms.mit.dev https://api.learn.mit.dev
+
+  - name: cms
+    priority: 0
+    match:
+      hosts:
+      - "studio.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: cms
+      servicePort: 8010
+    plugin_config_name: openedx-shared-plugins
+    timeout:
+      connect: 600s
+      read: 600s
+      send: 600s
+
+  - name: notes
+    priority: 0
+    match:
+      hosts:
+      - "notes.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: notes
+      servicePort: 8000
+    plugin_config_name: openedx-shared-plugins

--- a/local-dev/apps/openedx/configmaps/cms-config.yaml
+++ b/local-dev/apps/openedx/configmaps/cms-config.yaml
@@ -1,0 +1,56 @@
+---
+# Studio configuration for the ol-infrastructure local-dev integration.
+#
+# Full replacement for lehrer's local-dev/manifests/platform/configmap-cms.yaml
+# -- see the header of lms-config.yaml in this directory for why these are
+# copies rather than overlays, and keep the two in sync.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cms-config
+  namespace: openedx
+data:
+  MYSQL_HOST: "mysql.openedx.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  MYSQL_DB_NAME: "edxapp"
+  MYSQL_USER: "edxapp"
+
+  # Shared Valkey in local-infra, per the Tiltfile's redis_host.
+  CELERY_BROKER_TRANSPORT: "redis"
+  CELERY_BROKER_HOSTNAME: "valkey-primary.local-infra.svc.cluster.local"
+  CELERY_BROKER_USER: ""
+  CELERY_BROKER_PASSWORD: ""
+  CELERY_BROKER_VHOST: ""
+
+  MONGODB_HOST: "mongodb-svc.openedx.svc.cluster.local"
+  MONGODB_PORT: "27017"
+  MONGODB_USER: "edxapp"
+  MONGODB_DB: "edxapp"
+  MONGODB_REPLICASET: "mongodb"
+  MONGODB_AUTH_SOURCE: "admin"
+
+  # Shared OpenSearch in local-infra, per the Tiltfile's opensearch_host.
+  ELASTIC_SEARCH_HOST: "opensearch-master.local-infra.svc.cluster.local"
+  ELASTIC_SEARCH_PORT: "9200"
+
+  LMS_BASE_URL: "https://lms.mit.dev"
+  CMS_BASE_URL: "https://studio.mit.dev"
+
+  STATIC_ROOT_BASE: "/openedx/staticfiles"
+
+  LOG_DIR: "/openedx/data/var/log/edx"
+  LOGGING_ENV: "sandbox"
+  LOCAL_LOGLEVEL: "INFO"
+
+  DEBUG: "true"
+  ALLOWED_HOSTS: '["*"]'
+  HTTPS: "off"
+
+  OL_SETTINGS_DIR: ""
+
+  SERVICE_VARIANT: "cms"
+
+  # Studio is one of the IDAs the LMS's logout page frames, so it needs the same
+  # framing treatment -- see the cms-logout route in apisix-routes.yaml and the
+  # matching comment in edxapp/k8s_resources.py.  Same value production serves.
+  X_FRAME_OPTIONS: "ALLOW-FROM canvas.mit.edu"

--- a/local-dev/apps/openedx/configmaps/lms-config.yaml
+++ b/local-dev/apps/openedx/configmaps/lms-config.yaml
@@ -1,0 +1,104 @@
+---
+# LMS configuration for the ol-infrastructure local-dev integration.
+#
+# This is a full replacement for lehrer's own
+# local-dev/manifests/platform/configmap-lms.yaml, not an overlay: the Tiltfile
+# passes apply_platform_configmaps=False, and lehrer's setup() uses that only to
+# decide whether to apply its copy.  Its redis_host/opensearch_host/lms_base_url
+# arguments do not patch the ConfigMap, so every key lehrer's version sets has to
+# be repeated here.  Keep the two in sync when lehrer's changes.
+#
+# Differences from lehrer's copy:
+#   - Valkey and OpenSearch point at ol-infrastructure's shared instances in the
+#     local-infra namespace rather than per-namespace Helm installs.
+#   - Public URLs are the local-dev hostnames, not localhost ports.
+#   - The logout fan-out settings at the bottom, which are what make hq#12763
+#     reproducible locally.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lms-config
+  namespace: openedx
+data:
+  # MySQL and MongoDB are still deployed per-namespace (mysql_managed and
+  # mongo_managed are True in the Tiltfile; ol-infrastructure has neither).
+  MYSQL_HOST: "mysql.openedx.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  MYSQL_DB_NAME: "edxapp"
+  MYSQL_USER: "edxapp"
+
+  # Shared Valkey in local-infra, per the Tiltfile's redis_host.
+  CELERY_BROKER_TRANSPORT: "redis"
+  CELERY_BROKER_HOSTNAME: "valkey-primary.local-infra.svc.cluster.local"
+  CELERY_BROKER_USER: ""
+  CELERY_BROKER_PASSWORD: ""
+  CELERY_BROKER_VHOST: ""
+
+  MONGODB_HOST: "mongodb-svc.openedx.svc.cluster.local"
+  MONGODB_PORT: "27017"
+  MONGODB_USER: "edxapp"
+  MONGODB_DB: "edxapp"
+  MONGODB_REPLICASET: "mongodb"
+  MONGODB_AUTH_SOURCE: "admin"
+
+  # Shared OpenSearch in local-infra, per the Tiltfile's opensearch_host.
+  ELASTIC_SEARCH_HOST: "opensearch-master.local-infra.svc.cluster.local"
+  ELASTIC_SEARCH_PORT: "9200"
+
+  CODE_JAIL_REST_SERVICE_HOST: "http://codejail.openedx.svc.cluster.local:8000"
+  ENABLE_CODEJAIL_REST_SERVICE: "true"
+
+  EDXNOTES_INTERNAL_API: "http://notes.openedx.svc.cluster.local:8000/api/v1"
+  EDXNOTES_PUBLIC_API: "https://notes.mit.dev/api/v1"
+  ENABLE_EDXNOTES: "true"
+
+  # Service URLs (accessible from the browser), matching the Tiltfile's
+  # lms_base_url / cms_base_url and the APISIX routes alongside this file.
+  LMS_BASE_URL: "https://lms.mit.dev"
+  CMS_BASE_URL: "https://studio.mit.dev"
+
+  STATIC_ROOT_BASE: "/openedx/staticfiles"
+
+  LOG_DIR: "/openedx/data/var/log/edx"
+  LOGGING_ENV: "sandbox"
+  LOCAL_LOGLEVEL: "INFO"
+
+  DEBUG: "true"
+  # JSON-encoded: the aqueduct ALLOWED_HOSTS field is list[Any], and
+  # pydantic-settings parses list-typed env vars as JSON.
+  ALLOWED_HOSTS: '["*"]'
+  # APISIX terminates TLS in front of this, so the app itself speaks http.
+  HTTPS: "off"
+
+  OL_SETTINGS_DIR: ""
+
+  SERVICE_VARIANT: "lms"
+
+  # ---------------------------------------------------------------------- #
+  # Cross-application logout (hq#12763)
+  # ---------------------------------------------------------------------- #
+  # LogoutView renders one hidden iframe per entry here, each with
+  # ?no_redirect=1 appended, so that a logout started anywhere tears down every
+  # application's session.  Mirrors IDA_LOGOUT_URI_LIST in
+  # src/ol_infrastructure/applications/edxapp/k8s_configmaps.py.  Without this
+  # the local stack cannot reproduce the bug at all: nothing fans out.
+  #
+  # JSON-encoded for the same reason as ALLOWED_HOSTS above.
+  IDA_LOGOUT_URI_LIST: '["https://mitxonline.mit.dev/logout", "https://studio.mit.dev/logout",
+    "https://api.learn.mit.dev/logout"]'
+
+  # Gates the ?redirect_url= that Learn's logout interstitial passes; without
+  # Learn's host here is_safe_login_or_logout_redirect rejects it and the
+  # interstitial never learns the fan-out finished.
+  LOGIN_REDIRECT_WHITELIST: '["lms.mit.dev", "studio.mit.dev", "mitxonline.mit.dev",
+    "learn.mit.dev", "api.learn.mit.dev"]'
+
+  # Matches what this deployment actually serves in production -- the
+  # "mitxonline" overrides in edxapp/config_builder.py set ALLOW-FROM, beating
+  # the DENY in build_base_general_config.  Confirmed live:
+  #   $ curl -sI https://courses.learn.mit.edu/logout | grep -i x-frame
+  #   x-frame-options: ALLOW-FROM CANVAS.MIT.EDU
+  # Kept here rather than left unset so local behaviour matches production; the
+  # APISIX route beside this file replaces it with an explicit frame-ancestors
+  # CSP on /logout, since no current browser implements ALLOW-FROM.
+  X_FRAME_OPTIONS: "ALLOW-FROM canvas.mit.edu"

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -35,6 +35,7 @@ from ol_infrastructure.components.aws.eks import (
     OLEKSTrustRoleConfig,
 )
 from ol_infrastructure.components.services.apisix import (
+    OLApisixPluginConfig,
     OLApisixRoute,
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
@@ -2058,11 +2059,70 @@ def create_k8s_resources(  # noqa: C901
         ),
     )
 
+    # MIT Learn renders its own logout interstitial and frames this page inside
+    # it, so that the browser stays on Learn while openedx fans the logout out
+    # to every IDA in IDA_LOGOUT_URI_LIST (hq#12763).
+    #
+    # This deployment currently sends X_FRAME_OPTIONS = "ALLOW-FROM
+    # canvas.mit.edu" (config_builder.py, inside the "mitxonline" overrides,
+    # which beats the "DENY" in build_base_general_config).  Verified live:
+    #
+    #   $ curl -sI https://courses.learn.mit.edu/logout | grep -i x-frame
+    #   x-frame-options: ALLOW-FROM CANVAS.MIT.EDU
+    #
+    # ALLOW-FROM was only ever implemented by IE and old Firefox.  No current
+    # browser recognises the directive, so whether that header restricts framing
+    # at all is left to each UA -- most ignore an unrecognised value outright.
+    # Rather than rest the logout fan-out on that, drop the header for this one
+    # path and state the policy in CSP, which browsers do implement.  Scoped to
+    # /logout, so Canvas framing courseware elsewhere is unaffected either way.
+    #
+    # frame-ancestors is evaluated against the whole ancestor chain, not just the
+    # immediate parent, so Learn's host has to appear here even though it frames
+    # this page directly, and again on any page this page frames in turn.
+    def logout_framing_plugin(*frame_ancestors: str) -> OLApisixPluginConfig:
+        """Allow the named origins to frame this app's /logout page."""
+        return OLApisixPluginConfig(
+            name="response-rewrite",
+            secretRef=None,
+            config={
+                "headers": {
+                    "remove": ["X-Frame-Options"],
+                    "set": {
+                        "Content-Security-Policy": " ".join(
+                            ["frame-ancestors", "'self'", *frame_ancestors]
+                        ),
+                    },
+                },
+            },
+        )
+
+    mit_learn_frame_ancestor = (
+        f"https://{edxapp_config.require('mit_learn_api_domain')}"
+    )
+    lms_frame_ancestor = f"https://{edxapp_config.require_object('domains')['lms']}"
+
     lms_apisixroute = OLApisixRoute(
         name=f"ol-{stack_info.env_prefix}-edxapp-lms-apisix-route-{stack_info.env_suffix}",
         k8s_namespace=namespace,
         k8s_labels=k8s_global_labels,
         route_configs=[
+            OLApisixRouteConfig(
+                route_name="lms-logout",
+                priority=10,
+                plugins=[logout_framing_plugin(mit_learn_frame_ancestor)],
+                shared_plugin_config_name=edxapp_shared_plugins.resource_name,
+                hosts=[
+                    edxapp_config.require("backend_lms_domain"),
+                    edxapp_config.require_object("domains")["lms"],
+                ],
+                paths=["/logout", "/logout/"],
+                timeout_connect="600s",
+                timeout_read="600s",
+                timeout_send="600s",
+                backend_service_name=lms_webapp_deployment_name,
+                backend_service_port="http",
+            ),
             OLApisixRouteConfig(
                 route_name="lms-default",
                 priority=0,
@@ -2087,6 +2147,28 @@ def create_k8s_resources(  # noqa: C901
         k8s_namespace=namespace,
         k8s_labels=k8s_global_labels,
         route_configs=[
+            # studio is one of the IDAs openedx's logout interstitial frames,
+            # and it serves the same ALLOW-FROM header as the LMS above
+            # (verified live on studio.courses.learn.mit.edu/logout).  Same
+            # reasoning: name the allowed ancestors explicitly instead of
+            # depending on how a browser handles an unrecognised directive.
+            # The LMS host is listed because it is the immediate parent, and
+            # Learn's because it sits above the LMS in the chain (hq#12763).
+            OLApisixRouteConfig(
+                route_name="cms-logout",
+                priority=10,
+                plugins=[
+                    logout_framing_plugin(lms_frame_ancestor, mit_learn_frame_ancestor)
+                ],
+                shared_plugin_config_name=edxapp_shared_plugins.resource_name,
+                hosts=[
+                    edxapp_config.require("backend_studio_domain"),
+                    edxapp_config.require_object("domains")["studio"],
+                ],
+                paths=["/logout", "/logout/"],
+                backend_service_name=cms_webapp_deployment_name,
+                backend_service_port="http",
+            ),
             OLApisixRouteConfig(
                 route_name="cms-default",
                 priority=0,

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -820,12 +820,24 @@ proxy_rewrite_plugin_config = OLApisixPluginConfig(
     },
 )
 
+# openedx's logout interstitial frames our /logout?no_redirect=1 so that we tear
+# down our own gateway session, hence OPENEDX_API_BASE_URL below.  MIT Learn's
+# API host is here for hq#12763: Learn renders its own logout interstitial and
+# frames openedx's inside it, making the chain Learn -> openedx -> MITx Online.
+# frame-ancestors is evaluated against every ancestor, not just the immediate
+# parent, so omitting Learn here would have openedx's frame load and ours
+# silently refuse -- a logout that looks like it worked but left this session
+# alive.
 response_rewrite_plugin_config = OLApisixPluginConfig(
     name="response-rewrite",
     config={
         "headers": {
             "set": {
-                "Content-Security-Policy": f"frame-ancestors 'self' {env_vars['OPENEDX_API_BASE_URL']}"
+                "Content-Security-Policy": (
+                    "frame-ancestors 'self' "
+                    f"{env_vars['OPENEDX_API_BASE_URL']} "
+                    f"https://{learn_backend_domain}"
+                )
             }
         }
     },
@@ -844,6 +856,21 @@ direct_stale_session_cleanup = stale_session_cookie_cleanup_plugin(
     cookie_domains=[api_domain.removeprefix("api")],
 )
 prefixed_stale_session_cleanup = stale_session_cookie_cleanup_plugin()
+
+# Discards the caller's *current* MITx Online gateway session, for the
+# /switch-session route below.  Mechanically the same as the stale-cookie
+# cleanups above -- expire the cookie on the way out -- so it reuses that helper
+# rather than adding a near-identical one; only the intent differs, and the
+# parameter takes any cookie name despite being named for that use case.  Scoped
+# to the cookie name and parent domain the direct OIDC resource issues, since a
+# deletion has to match (name, domain, path) to land.
+direct_session_reset = stale_session_cookie_cleanup_plugin(
+    cookie_domains=[api_domain.removeprefix("api")],
+    stale_cookie_name=apisix_oidc_session_cookie_name(
+        "mitxonline",
+        stack_info.env_suffix,
+    ),
+)
 
 mitxonline_apisix_route_direct = OLApisixRoute(
     name=f"mitxonline-apisix-route-direct-{stack_info.env_suffix}",
@@ -891,6 +918,34 @@ mitxonline_apisix_route_direct = OLApisixRoute(
                 ),
                 response_rewrite_plugin_config,
                 direct_stale_session_cleanup,
+            ],
+            shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
+            backend_service_name=mitxonline_k8s_app.application_lb_service_name,
+            backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
+        ),
+        # Entry point for hand-offs from MIT Learn (hq#12763).  Learn and
+        # MITx Online keep separate gateway sessions on separate parent
+        # domains, so a browser arriving here can still be carrying the
+        # session of whoever used this browser before -- Learn's own session
+        # having been replaced in the meantime.  This route drops that session
+        # and bounces to the wrapped path; because "cart" below is
+        # unauth_action="auth", the follow-on request has no session, runs a
+        # fresh authorization-code flow, and comes back as whoever currently
+        # holds the Keycloak SSO session.
+        #
+        # No openid-connect plugin here on purpose: it would validate and
+        # possibly refresh the very session this route exists to discard.  The
+        # request still reaches Django, which owns validating `next` -- doing
+        # the redirect at the gateway with a regex would turn
+        # /switch-session//evil.example into a protocol-relative open redirect.
+        OLApisixRouteConfig(
+            route_name="switch-session",
+            priority=20,
+            hosts=[api_domain, frontend_domain],
+            paths=["/switch-session", "/switch-session/"],
+            plugins=[
+                response_rewrite_plugin_config,
+                direct_session_reset,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/12763

### Description (What does it do?)
Gateway and local-dev support for the cross-application logout and checkout hand-off work. Each application's APISIX session lives on its own parent domain, so a logout or user switch in one left the others asserting the previous user.

- Add a `/switch-session` route on MITxOnline that discards the caller's gateway session, reusing the existing `stale_session_cookie_cleanup_plugin`.
- Add Learn's API host to MITxOnline's `frame-ancestors` CSP.
- Add `/logout` routes for the Open edX LMS and studio that replace `X-Frame-Options` with an explicit `frame-ancestors` CSP.
- local-dev: stand up the `openedx` app, and bring the APISIX session config to production parity.

Companions: mitodl/mit-learn#3880 and mitodl/mitxonline#3912.

<details>
<summary><b>Implementation details</b></summary>
<br>

**The reset plugin.** No new helper: `stale_session_cookie_cleanup_plugin` already takes an arbitrary cookie name, and expiring the cookie is mechanically the same operation whether you are evicting one no route reads any more or deliberately ending the session this request arrived with. Only the intent differs, which the call site comments. The emitted plugin config was asserted byte-identical to a purpose-named wrapper's output before that wrapper was dropped, so `components/services/apisix.py` is untouched by this PR.

The `/switch-session` route carries that plugin and, deliberately, no `openid-connect` plugin: that plugin would validate and possibly refresh the very session the route exists to discard.

**The framing changes are not what the issue originally assumed.** The LMS and studio do not send `DENY`. The `"mitxonline"` overrides in `config_builder.py` set `ALLOW-FROM`, which beats the `DENY` in `build_base_general_config`. Verified against production:

```
$ curl -sI https://courses.learn.mit.edu/logout | grep -i x-frame-options
x-frame-options: ALLOW-FROM CANVAS.MIT.EDU
$ curl -sI https://studio.courses.learn.mit.edu/logout | grep -i x-frame-options
x-frame-options: ALLOW-FROM CANVAS.MIT.EDU
```

`ALLOW-FROM` was only ever implemented by IE and old Firefox. No current browser recognises the directive, so whether that header restricts framing at all is left to each UA. Rather than rest the logout fan-out on that, these routes drop the header for `/logout` only and state the policy in CSP, which browsers do implement. It is possible framing already works in practice on Chrome and Firefox, which ignore an unrecognised directive; the point is to stop depending on that.

**Why Learn's host has to be in MITxOnline's CSP.** MITxOnline does have a real policy, and it does not currently name a Learn host:

```
$ curl -sI https://mitxonline.mit.edu/logout | grep -i content-security-policy
content-security-policy: frame-ancestors 'self' https://courses.learn.mit.edu
```

`frame-ancestors` is checked against every ancestor, not just the immediate parent. With Learn's interstitial above Open edX's logout page, the chain becomes Learn -> Open edX -> MITxOnline, so without this the outer frame loads and the inner one is silently refused.

**local-dev.** `apps/openedx/` was a stub: its Tiltfile referenced `configmaps/lms-config.yaml`, `configmaps/cms-config.yaml` and `apisix-routes.yaml`, none of which existed. Because the Tiltfile passes `apply_platform_configmaps=False`, the configmaps here are full replacements for lehrer's rather than overlays, so every key lehrer sets is repeated - noted in a comment at the top of each. Separately, the session config used the nested `session.cookie.*` form, which lua-resty-session 4.x on the pinned APISIX 3.17.0 silently ignores; moving to the flat keys makes the cookie domain actually apply, and naming the cookies as production does makes the two sessions distinguishable in devtools, which is the whole subject of the issue.
</details>

### How can this be tested?
`ruff check`, `ruff format --check` and `mypy` pass on the changed files (pre-commit ran them, along with `yamlfmt`, `yamllint` and `check yaml`). YAML was additionally parsed and asserted on: the Lua body of the `/switch-session` route survived `yamlfmt`, and the `cart` route's session block carries the flat keys.

Not tested, and the main risk in this PR:

- **No `pulumi preview` has been run.** A reviewer should preview the mitxonline and edxapp-mitxonline stacks and diff the emitted route/plugin JSON before this merges.
- **No local-dev bring-up.** The new openedx configmaps are unexercised, so the MySQL/Mongo/Valkey wiring in them deserves a careful read.
- **No browser has exercised the framing.** That is what the whole `frame-ancestors` change is for, and it can only be confirmed with a real stack. The failure mode is quiet: the logout appears to work while the inner iframes never run, so watch the console for `Refused to frame` at both frame depths.

### Additional Context
Blast radius worth flagging: `logout_framing_plugin` is added in `edxapp/k8s_resources.py`, which is shared by all four edxapp deployments (`mitx`, `mitx-staging`, `xpro`, `mitxonline`), so the new `/logout` routes appear on all of them rather than only mitxonline. Scoped to `/logout`, so Canvas framing courseware on the residential stacks is unaffected either way - but if that is not wanted on the other three, the routes should be made conditional on `env_prefix`.
