### PR TITLE
fix(celery): drop inert CELERY_* env vars from k8s workers

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
@@ -49,7 +49,6 @@ config:
     AI_MIT_SYLLABUS_URL: "https://api.ci.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.ci.learn.mit.edu/api/v0/vector_content_files_search/"
     APPZI_URL: ""
-    CELERY_WORKER_CONCURRENCY: 1
     CSRF_COOKIE_NAME: "learn_ci_csrftoken"
     COURSE_ARCHIVE_BUCKET_NAME: "ol-data-lake-landing-zone-qa"
     DEBUG: "false"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -81,7 +81,6 @@ config:
     AWS_S3_CUSTOM_DOMAIN: "learn.mit.edu"
     AWS_S3_PREFIX: "media"
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
-    CELERY_WORKER_CONCURRENCY: 1
     COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: "learn_csrftoken"
     DEBUG: "false"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -57,7 +57,6 @@ config:
     AWS_S3_PREFIX: "media"
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
     COURSE_ARCHIVE_BUCKET_NAME: "ol-data-lake-landing-zone-qa"
-    CELERY_WORKER_CONCURRENCY: 1
     CREATE_HIDDEN_OCW_LEARNING_MATERIALS: "true"
     COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"rc.learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: "learn_rc_csrftoken"

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -2342,17 +2342,7 @@ class OLApplicationK8s(ComponentResource):
                                         "--concurrency=2",  # Don't try to use all cores on node
                                         "--prefetch-multiplier=1",
                                     ],
-                                    env=[
-                                        kubernetes.core.v1.EnvVarArgs(
-                                            name="CELERY_TASK_ACKS_LATE",
-                                            value="True",
-                                        ),
-                                        kubernetes.core.v1.EnvVarArgs(
-                                            name="CELERY_TASK_REJECT_ON_WORKER_LOST",
-                                            value="True",
-                                        ),
-                                        *application_deployment_env_vars,
-                                    ],
+                                    env=application_deployment_env_vars,
                                     env_from=application_deployment_envfrom,
                                     resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                         requests=celery_worker_config.resource_requests,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Removes three `CELERY_*` environment variables that were set on Kubernetes pods but
never actually reached Celery:

- `CELERY_TASK_ACKS_LATE` and `CELERY_TASK_REJECT_ON_WORKER_LOST`, injected into
  every app's celery worker container by
  [`k8s.py#L2345-L2355`](https://github.com/mitodl/ol-infrastructure/blob/a208cc45ef0bd91631c6c6b7039fd0ab9f61359d/src/ol_infrastructure/components/services/k8s.py#L2345-L2355)
- `CELERY_WORKER_CONCURRENCY: 1`, set in the mit-learn `Pulumi.CI/QA/Production.yaml`
  `mitlearn:vars` blocks

Celery only reads config via `app.config_from_object("django.conf:settings",
namespace="CELERY")`, so a `CELERY_*` env var is live only if the Django settings
module explicitly reads it. None of the seven consumer apps (`learn_ai`,
`micromasters`, `mit_learn`, `mitxonline`, `ocw_studio`, `odl_video_service`, `xpro`)
read any of these three.

Verified on a running production worker — the env var says `True`, Celery disagrees:

```
$ kubectl -n mitlearn exec <default-celery-worker-pod> -c celery-worker -- env | grep ACKS
CELERY_TASK_ACKS_LATE=True

>>> settings.CELERY_TASK_ACKS_LATE   # AttributeError - unset
>>> app.conf.task_acks_late
False
```

These are worse than dead — they mislead during incident response. A responder sees
`CELERY_WORKER_CONCURRENCY=1` in the pod env while the worker is really running
`--concurrency=2` from
[the command line](https://github.com/mitodl/ol-infrastructure/blob/a208cc45ef0bd91631c6c6b7039fd0ab9f61359d/src/ol_infrastructure/components/services/k8s.py#L2342),
which is what actually governs DB connection fan-out. Acks-late behavior likewise
comes from per-task decorator arguments in the application repos, not from here.

No runtime behavior changes.

### How can this be tested?
`pre-commit run --files` on the four changed files passes (ruff, mypy, yamllint,
detect-secrets). The 5 pre-existing `D1xx` docstring errors in `k8s.py` are identical
on `main`.

`pulumi preview` on **mit_learn Production** shows 5 deployments updated plus the
pre-deploy Job (immutable, replaced on every deploy). The env removals account
exactly — 7 total `CELERY_WORKER_CONCURRENCY` removals:

| Resource | Vars removed |
|---|---|
| 3 celery worker deployments | 3 each |
| celery-beat deployment | 1 (built by a separate code path that never had the other two) |
| app deployment | 2 (`mitlearn-app` + `collectstatic` init container) |
| pre-deploy job | 1 |

Because `k8s.py` is shared, I also previewed **mitxonline Production**: `main`
already shows pre-existing fastly + app-deployment drift, and this branch adds only
the 2 mitxonline celery worker deployments.

To reproduce (previews need the image tag CI normally injects):

```bash
cd src/ol_infrastructure/applications/mit_learn
MIT_LEARN_DOCKER_TAG=0.78.2 pulumi preview --stack Production --diff

cd ../mitxonline
MITXONLINE_DOCKER_TAG=1.164.1 pulumi preview --stack Production
```

The diffs are noisy because Pulumi diffs env lists positionally, so removing one
variable shifts every subsequent entry — read the trailing `- [n]` removals, not the
`~` renames.
