### PR TITLE
fix(qdrant-cloud): reconcile production stack drift so pulumi applies cleanly

### DIFF
--- a/src/ol_infrastructure/infrastructure/qdrant_cloud/Pulumi.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/qdrant_cloud/Pulumi.mitlearn.Production.yaml
@@ -7,5 +7,4 @@ config:
   qdrant-cloud:number_of_nodes: 3
   qdrant-cloud:enable_high_availability: "true"
   qdrant-cloud:desired_package_name: mx2
-  qdrant-cloud:desired_disk_gib: "200"
-  qdrant-cloud:desired_ram_gib: "32"
+  qdrant-cloud:desired_disk_gib: "204"

--- a/src/ol_infrastructure/infrastructure/qdrant_cloud/__main__.py
+++ b/src/ol_infrastructure/infrastructure/qdrant_cloud/__main__.py
@@ -44,9 +44,11 @@ desired_package_name = qdrant_cloud_config.get("desired_package_name") or "mx2"
 # is represented by one entry in the package's available_additional_resources.
 desired_disk_gib = qdrant_cloud_config.get_int("desired_disk_gib")
 
-# Optional target total RAM per node in GiB. When set to a value larger than
-# the base package RAM, additional memory slabs are requested via
-# resource_configurations (the "memory slider" in the Qdrant Cloud UI).
+# Optional target total RAM per node in GiB. Unlike disk, RAM cannot be
+# purchased as an additional resource slab on any Qdrant Cloud package (the
+# booking catalogue's available_additional_resources only ever prices disk);
+# more RAM requires moving to a package with a larger base RAM allocation.
+# This is validated below once the package's booking data is available.
 desired_ram_gib = qdrant_cloud_config.get_int("desired_ram_gib")
 
 booking_result = qdrant_cloud.get_booking_packages(
@@ -122,21 +124,14 @@ if package.resource_configurations:
 
     if desired_ram_gib is not None:
         base_ram_gib = _parse_gib(package.resource_configurations[0].ram)
-        effective_ram_gib = desired_ram_gib - base_ram_gib
-        if effective_ram_gib > 0:
-            if not package.available_additional_resources:
-                msg = (
-                    f"Package {desired_package_name!r} does not support additional "
-                    "RAM (no available_additional_resources)."
-                )
-                raise ValueError(msg)
-            extra_resources.append(
-                qdrant_cloud.AccountsClusterConfigurationNodeConfigurationResourceConfigurationArgs(
-                    amount=effective_ram_gib,
-                    resource_type="ram",
-                    resource_unit="Gi",
-                )
+        if desired_ram_gib > base_ram_gib:
+            msg = (
+                f"Package {desired_package_name!r} has {base_ram_gib}Gi base RAM "
+                f"and cannot be topped up to {desired_ram_gib}Gi: RAM is not a "
+                "purchasable additional resource on any Qdrant Cloud package "
+                "(only disk is). Pick a package with a larger base RAM instead."
             )
+            raise ValueError(msg)
 
     if extra_resources:
         node_resource_configurations = extra_resources


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `mitlearn.Production` qdrant-cloud stack was out of sync with the live cluster, so every `pulumi up` attempted changes the Qdrant Cloud API can't make:

- `desired_disk_gib: "200"` was computed against a stale assumption about `mx2`'s base disk size. The catalogue now reports a larger base, so `__main__.py` derived an "extra disk" slab of 168Gi instead of the 172Gi already provisioned and running: a request to shrink live disk by 4Gi. Bumped to `"204"` to match what's actually live; no infrastructure change.
- `desired_ram_gib: "32"` has never actually applied. RAM is not a purchasable additional resource on any Qdrant Cloud package. Verified live against the booking catalogue: every package's `available_additional_resources` only prices disk. This setting has been silently failing since it was introduced in March. Dropped the override (production keeps running on `mx2`'s 8Gi base RAM), and the RAM code path now raises a clear `ValueError` if a future `desired_ram_gib` exceeds the package's base RAM, instead of silently building an API call that always fails.

### How can this be tested?
- `pulumi preview --stack mitlearn.Production --diff` now shows only the intentional `v1.18.2 → v1.19.0` version bump (the same pending upgrade already queued on QA/CI). No resource-shape diff.
- Confirmed the RAM finding by temporarily instrumenting `__main__.py` to dump the live booking catalogue during `pulumi preview` (no `up`); every package returned `available_additional_resources: [{'disk_price_per_hour': ...}]` with no RAM equivalent. Reverted before committing.
- `pre-commit run` (ruff, mypy, yaml checks) passes on the changed files.
- No `pulumi up` has been run against Production as part of this change.

### Additional Context
Dropping `desired_ram_gib` is a deliberate choice to unblock `pulumi apply`, not a capacity decision. If 8Gi RAM per node is genuinely insufficient for production, that requires moving to a larger package tier (e.g. `mx5`), which also changes CPU and disk and should be a separate, deliberate change.
