### PR TITLE
feat(mitxonline): wire CYBERSOURCE_INQUIRY_LOG_NACL_ENCRYPTION_KEY

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -238,6 +238,7 @@ def create_mitxonline_k8s_secrets(
                 "MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID": '{{ index .Secrets "google-sheets" "enrollment-change-sheet-id" }}',
                 "MITOL_HUBSPOT_API_PRIVATE_TOKEN": '{{ index .Secrets "hubspot" "private-api-token" }}',
                 "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN": '{{ index .Secrets "hubspot" "uai-private-api-token" }}',
+                "CYBERSOURCE_INQUIRY_LOG_NACL_ENCRYPTION_KEY": '{{ index .Secrets "cybersource" "inquiry-log-nacl-encryption-key" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY": '{{ index .Secrets "cybersource" "access-key" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_ID": '{{ index .Secrets "cybersource" "merchant-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET": '{{ index .Secrets "cybersource" "merchant-secret" }}',


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/12528

### Description (What does it do?)
Maps `CYBERSOURCE_INQUIRY_LOG_NACL_ENCRYPTION_KEY` into mitxonline's environment. mitxonline's export compliance module encrypts the cached CyberSource request/response payloads with a NaCl public key read from this setting.

<details>
<summary><b>Implementation details</b></summary>
<br>

One line in the `collected` templates dict of `src/ol_infrastructure/applications/mitxonline/k8s_secrets.py`, next to the existing `MITOL_PAYMENT_GATEWAY_CYBERSOURCE_*` entries. The name is unprefixed because mitxonline declares the setting itself ([`main/settings.py`](https://github.com/mitodl/mitxonline/blob/main/main/settings.py)) rather than inheriting it from `mitol-django-payment-gateway`. mitxpro has the same var wired at [`applications/xpro/k8s_secrets.py#L240`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/xpro/k8s_secrets.py#L240).

Every other setting mitxonline's `compliance/api.py` hard-requires is already wired: `MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_ID`, `_MERCHANT_SECRET`, and `_MERCHANT_SECRET_KEY_ID` come from the same collected blob, and `_REST_API_ENVIRONMENT` is plain Pulumi config in all three stacks.

No Vault policy change is needed: `mitxonline_policy.hcl` already grants `secret-mitxonline/*`, and `__main__.py` writes the whole SOPS file to `collected-static-secrets` as one blob, so a new SOPS key flows through with no further code change.

Merging before the SOPS values land is safe - the template renders an empty string, which matches today's behavior. The app's `_require_setting` only raises when an export check actually runs, gated by the `enable_export_compliance` PostHog flag.
</details>

### How can this be tested?

`ruff check` and `ruff format --check` pass on the changed file. I have not run `pulumi preview` - that needs stack credentials. A `preview` on the mitxonline CI stack should show a diff only on the VSO `VaultStaticSecret` rendering the `collected` template (one added key).

Once the secret values are in place, confirm the var reaches the pod without printing it:

```bash
kubectl -n mitxonline exec deploy/<web-deployment> -- sh -c 'echo ${CYBERSOURCE_INQUIRY_LOG_NACL_ENCRYPTION_KEY:+set}'
```

### Additional Context

**This does nothing until the SOPS values are added, which I can't do - I don't have KMS access.** Someone who does needs to add `inquiry-log-nacl-encryption-key` to the existing `cybersource:` map in all three of `src/bridge/secrets/mitxonline/secrets.{ci,qa,production}.yaml` (kebab-case, matching its siblings):

```bash
src/bridge/secrets/bin/sops set \
  src/bridge/secrets/mitxonline/secrets.qa.yaml \
  '["cybersource"]["inquiry-log-nacl-encryption-key"]' \
  '"<base64-public-key>"'
```

Generate one keypair per environment, so a CI/QA key can never decrypt production logs:

```python
from nacl.encoding import Base64Encoder
from nacl.public import PrivateKey

sk = PrivateKey.generate()
print("PRIVATE:", Base64Encoder.encode(bytes(sk)).decode())
print("PUBLIC: ", Base64Encoder.encode(bytes(sk.public_key)).decode())
```

Both halves come out as 44-char base64 (32 bytes). Only the **public** half goes in SOPS - the app only ever encrypts, via `SealedBox(PublicKey(...))`. The **private** half is stored out-of-band and typed at stdin by `manage.py decrypt_export_compliance_log --email <user>`; losing it makes the logged payloads unrecoverable, leaking it exposes every logged CyberSource request/response.

### Checklist:
- [ ] Add `cybersource.inquiry-log-nacl-encryption-key` to the CI, QA, and Production mitxonline SOPS files before merging
