### PR TITLE
Playwright canary harness + ADR 0011: canary specs live in ol-infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ pyinfra-debug.log
 # npx skills managed view (source lives in agents/skills/)
 .agents/skills/
 
+# Playwright canaries (src/ol_concourse/pipelines/canaries/)
+node_modules/
+canary-results/
+
 .pulumi
 local-dev/certs/
 tilt_config.json

--- a/docs/adr/0011-playwright-canary-specs-in-a-dedicated-repository.md
+++ b/docs/adr/0011-playwright-canary-specs-in-a-dedicated-repository.md
@@ -1,0 +1,232 @@
+# 0011. Playwright Canary Specs Live in a Dedicated Repository
+
+**Status:** Accepted
+**Date:** 2026-09-01
+**Deciders:** cpatti, Infrastructure team
+**Technical Story:** `wp-playwright-canary-meta-pipeline-for-ol-web-prope-47a987` /
+`tk-decision-where-playwright-specs-live-and-how-the-108357`
+
+## Context
+
+### Current Situation
+
+We are building a Concourse meta pipeline that manages a fleet of end-to-end,
+browser-driven user journey tests — "canaries" in the AWS CloudWatch Synthetics sense
+— one managed pipeline per target web property, modeled on
+`src/ol_concourse/pipelines/infrastructure/simple_pulumi/`. The first managed canary is
+MIT Learn against <https://rc.learn.mit.edu>, with a login-then-course-search journey.
+
+Grafana Synthetic Monitoring
+(`src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py`)
+already runs plain HTTP availability probes against these properties. This project is
+complementary: real browser journeys through login and search, not availability pings.
+
+### Problem Statement
+
+Where do the Playwright specs live, and how are they packaged so a Concourse job can
+run them? Nearly every other task in the project depends on the answer: it determines
+the shape of `CanaryParams`, the meta pipeline's watched paths, the credential flow,
+and who owns a failing canary.
+
+### Constraints
+
+- `ol-infrastructure` is a **Python monorepo with zero JavaScript**: no `package.json`,
+  no lockfile, no Node tooling in `.pre-commit-config.yaml`, and 0 `.ts`/`.tsx` files.
+- The ECR pull-through cache covers only `public.ecr.aws` (`ecr-public`) and Docker Hub
+  (`dockerhub`) — see `src/ol_infrastructure/infrastructure/aws/ecr/__main__.py`. There
+  is **no cache rule for `mcr.microsoft.com`**, where the official Playwright images
+  are published, and MCR is not an upstream ECR pull-through supports. Pulling MCR
+  directly is nonetheless consistent with existing practice: pipelines already pull
+  `quay.io/keycloak/keycloak` and `ghcr.io/astral-sh/uv` directly.
+- Canaries run against live deployed environments, including production, and need real
+  login credentials at run time.
+
+### Findings That Drove The Decision
+
+Established empirically on 2026-09-01, not assumed:
+
+1. **`mitodl/mit-learn` already has a Playwright suite.** `playwright.config.ts` plus
+   `e2e/smoke.spec.ts`, parameterized by `PLAYWRIGHT_BASE_URL`, with a `playwright:rc`
+   script already pointed at `https://rc.learn.mit.edu` and a `login()` helper that
+   already handles the multi-screen RC/production Keycloak flow.
+2. **That suite is not reusable as a canary.** It is a root-level member of a Yarn 4 /
+   Node 24 workspace (`workspaces: ["frontends"]`), so running it means installing the
+   whole application monorepo. Its assertions are pinned to CMS-authored copy, specific
+   course and program IDs, and certificate prices (`"Certificate Track: $1,000.00"`).
+   It also keys expected data off the base URL and **silently falls back to the local
+   fixture branch for any unrecognised URL**, so pointing it at a new environment
+   quietly asserts the wrong data.
+3. **The stock Playwright image does not let you skip an install.** Browsers are baked
+   at `/ms-playwright` (`PLAYWRIGHT_BROWSERS_PATH` is preset), but `@playwright/test`
+   is *not* installed globally — `/usr/lib/node_modules` holds only `corepack`, `npm`
+   and `yarn`. `npx --yes playwright test` therefore fails to resolve
+   `@playwright/test` from the config. An install step is mandatory.
+4. **That install is nearly free when the repo is dedicated.** With `@playwright/test`
+   plus TypeScript as the only dependencies, `npm ci` is **6 packages in 335 ms**, and
+   no browser download happens because the image already has them. A full canary run
+   against RC completed in ~1.2 s. This is what makes a purpose-built container image
+   (option c) unnecessary machinery rather than an optimization.
+5. **The image is small and fast to pull:** `mcr.microsoft.com/playwright:v1.62.1-noble`
+   is 0.95 GB on disk, pulled in ~20 s, multi-arch with `linux/amd64`.
+6. **Runner and image versions cannot drift.** Pinning `@playwright/test` 1.58.1 against
+   the `v1.62.1-noble` image fails with
+   `browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1208/...`
+   — a message naming neither the pin nor the image tag. This is the primary operational
+   footgun of any stock-image approach and must be guarded, not documented.
+
+### Options Considered
+
+1. **Specs in `ol-infrastructure` under the canary pipeline directory**
+   - Pros: cheapest to start; no image build; specs sit next to the pipeline that runs
+     them; single repo to change when onboarding a canary.
+   - Cons: introduces the first JavaScript/TypeScript, `package.json`, lockfile and Node
+     toolchain into a 467-file Python monorepo, along with its own Renovate stream and
+     lint/format story. Couples an ~91K-line infrastructure repo's watched paths to test
+     authoring, so every spec edit is a commit in the repo that also deploys production.
+
+2. **Specs in the target application's own repo** (e.g. `mitodl/mit-learn`)
+   - Pros: tests live with the app; app developers own them; for MIT Learn the specs and
+     a working RC login helper already exist.
+   - Cons: canary fleet health depends on N repos; the meta pipeline needs a git resource
+     and watched paths per property. Concretely, finding 2: running the existing suite
+     means a full Yarn workspace install, and its assertions are tied to CMS copy and
+     prices — an editor changing a word pages an on-call engineer. PR tests and canaries
+     have opposite failure economics (strict vs. stable) and pull the same file in
+     opposite directions.
+
+3. **A purpose-built canary image built and pushed to ECR by this pipeline**
+   - Pros: most reproducible, fastest at run time.
+   - Cons: most machinery — a `BuildConfig`/`DockerImageConfig` path, an ECR repo, and an
+     image-build job to maintain. Finding 4 removes the motivation: the run-time cost it
+     would optimize away is 335 ms.
+
+4. **A dedicated canary repository** (`mitodl/end-user-test-canaries`) — *chosen*
+   - Pros: keeps Node tooling out of the Python monorepo and application test data out
+     of the canaries; one repo owns the whole canary fleet regardless of how many
+     properties it covers; a canary spec change is not a commit in the repo that deploys
+     production; the meta pipeline watches exactly one extra git resource, not N.
+   - Cons: a third repo in the loop; contributors must know it exists; it is one more
+     Renovate stream that must be kept in lockstep with the pipeline's image tag.
+
+## Decision
+
+**Chosen Option:** Option 4 — a dedicated repository,
+[`mitodl/end-user-test-canaries`](https://github.com/mitodl/end-user-test-canaries),
+public, running against the **stock** `mcr.microsoft.com/playwright` image with a pinned
+`npm ci`.
+
+This is a refinement of option (a)'s packaging (stock image, checked-out specs, no image
+build) placed in its own repository rather than in `ol-infrastructure`. It takes option
+(b)'s "tests are their own artifact with their own owner" property without taking its
+"fleet health depends on N application repos" cost, and it declines option (c) on the
+strength of finding 4.
+
+**Rationale:**
+
+- Findings 3 and 4 together are the crux. An install step is unavoidable, but it is only
+  cheap while the dependency set stays tiny — which is true in a dedicated repo and
+  false in an application workspace. The same fact that kills the naive "no install
+  needed" version of option (a) also kills option (c)'s justification.
+- The distinction that matters is not *where the code lives* but *what the test is for*.
+  A PR gate must be strict; a canary must be stable, because it wakes a human. Finding 2
+  shows those requirements actively fighting inside one file. Separate artifacts let
+  each be correct.
+- `ol-infrastructure` having exactly zero JavaScript is a property worth keeping. Adding
+  a Node toolchain to it for canary specs is a permanent tax on a repo whose reviewers
+  are Python and Pulumi engineers.
+
+**Key Implementation Details:**
+
+- The canary repo pins `@playwright/test` and the pipeline pulls the matching
+  `mcr.microsoft.com/playwright:v<version>-noble` tag. `CanaryParams` carries
+  `playwright_version` as the pipeline-side half of that pair.
+- `bin/check-image-pin.mjs` in the canary repo fails fast when the two disagree,
+  converting finding 6's cryptic `Executable doesn't exist` into a message naming both
+  versions. The pipeline runs it before any journey.
+- `playwright.config.ts` **throws** when `CANARY_BASE_URL` is unset. A canary with a
+  default target reports green against the wrong environment, which is worse than one
+  that refuses to start.
+- Credentials are never committed. They arrive as environment variables sourced from
+  Vault. The repository is public, and `mit-learn`'s `e2e/smoke.spec.ts` currently
+  hardcodes a live RC login — the failure mode this rule exists to prevent.
+- Chromium runs with `--disable-dev-shm-usage`. A Concourse task container gets the 64 MB
+  default `/dev/shm`, which is where Chromium places renderer shared memory; without the
+  flag a journey dies mid-run as a bare tab crash.
+- `forbidOnly` is unconditional, unlike an application suite that only sets it under CI.
+  A stray `.only` in a canary silently stops every other journey for that property from
+  being checked, and nothing would report the gap.
+
+## Consequences
+
+### Positive Consequences
+
+- `ol-infrastructure` stays Python-only; no Node toolchain, lockfile or JS lint config.
+- Onboarding a property stays two list edits in `ol-infrastructure`, matching
+  `simple_pulumi`; adding a *journey* to an existing property needs no pipeline change
+  at all.
+- `npm ci` stays a sub-second, 6-package install, and stays that way only if the repo's
+  dependency discipline holds — which is now an explicit rule in its `AGENTS.md`.
+- Canary specs are reviewable by the people who own the journeys without granting them
+  commits in the repository that deploys production infrastructure.
+- Moving later to option (c) remains a `CanaryParams` field addition plus a build job,
+  not a rewrite, because the specs are already an independently checked-out artifact.
+
+### Negative Consequences
+
+- A third repository in the loop for anyone debugging a canary failure.
+- The `@playwright/test` pin and the pipeline's image tag are a two-repo lockstep pair.
+  A Renovate PR bumping the pin alone is **not** independently mergeable. Guarded by
+  `check:image-pin`, but it is a real cross-repo coupling.
+- Journeys for MIT Learn must be written fresh rather than reusing the existing `e2e/`
+  suite. The `login()` helper's knowledge of the multi-screen Keycloak flow is worth
+  porting; its data fixtures are not.
+- Duplication of intent with `mit-learn`'s `e2e/` suite is now possible — two places
+  test login. Accepted deliberately: they are testing different things (does this change
+  break login vs. is login broken for users right now).
+
+### Neutral Consequences
+
+- The canary repo is **not** currently registered in the Pulumi-managed repository fleet
+  (`src/ol_infrastructure/saas/github/repositories/`). Bringing it under management
+  requires importing the already-created `github.Repository` into stack state first: the
+  provider's create is `POST /orgs/mitodl/repos`, which returns 422 for an existing repo
+  and would hard-fail the whole 316-repo fleet deploy. Registration was deliberately
+  deferred rather than half-done. Tracked as follow-up work.
+- Alerting for these canaries must stay distinct from Grafana Synthetic Monitoring's
+  HTTP probes so the two do not double-page. Tracked separately.
+
+## Implementation Notes
+
+- **Risk Level:** Low. Nothing here changes existing infrastructure; the canary fleet is
+  additive and read-only with respect to the properties it exercises.
+- **Dependencies:** Canary login credentials sourced via SOPS/Vault
+  (`tk-source-the-mit-learn-rc-canary-login-credentials-1125c7`) block the first real
+  journey, not this decision.
+- **Verification performed:** `npm ci`, `npx tsc --noEmit`, `npm run check:image-pin`,
+  and a passing journey against `https://rc.learn.mit.edu`, all inside
+  `mcr.microsoft.com/playwright:v1.62.1-noble`.
+
+## Related Decisions
+
+- `src/ol_concourse/pipelines/infrastructure/simple_pulumi/` — the meta pipeline and
+  params-registry pattern this fleet copies.
+- `src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py`
+  — the HTTP-probe monitoring this complements rather than replaces.
+- `src/ol_infrastructure/infrastructure/aws/ecr/__main__.py` — the pull-through cache
+  rules, and why MCR is pulled directly.
+
+## References
+
+- Playwright Docker images: <https://playwright.dev/docs/docker>
+- `mitodl/mit-learn` `e2e/README.md` — states the intent to run this suite against RC as
+  an automated quality gate, which is the adjacent goal this decision separates from.
+
+---
+
+**Review History:**
+
+| Date | Reviewer | Decision | Notes |
+|------|----------|----------|-------|
+| 2026-09-01 | cpatti | Approved | Chose a dedicated public repo over specs-in-ol-infrastructure; deferred Pulumi fleet registration pending state import |
+
+**Last Updated:** 2026-09-01

--- a/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
+++ b/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
@@ -67,8 +67,12 @@ Established empirically on 2026-09-01, not assumed:
    in ~400 ms**, and no browser download happens because the image already has them. A
    full canary run against RC completed in ~1.1 s. This is what makes a purpose-built
    container image unnecessary machinery rather than an optimization.
-5. **The image is small and fast to pull:** `mcr.microsoft.com/playwright:v1.62.1-noble`
-   is 0.95 GB on disk, pulled in ~20 s, multi-arch with `linux/amd64`.
+5. **The image is acceptable to pull:** `mcr.microsoft.com/playwright:v1.62.1-noble`
+   carries ~2.4 GB of filesystem content, 1.3 GB of which is the baked browsers under
+   `/ms-playwright`; `docker images` accounts it as 3.53 GB. It pulled in ~20 s on a
+   developer connection and is multi-arch with `linux/amd64`. Note that
+   `docker image inspect --format '{{.Size}}'` reports 0.95 GB for this image, which
+   does not match the filesystem — do not quote it.
 6. **Runner and image versions cannot drift.** Pinning `@playwright/test` 1.58.1 against
    the `v1.62.1-noble` image fails with
    `browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1208/...`

--- a/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
+++ b/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
@@ -206,9 +206,10 @@ apply. That is more machinery than the tidiness was worth.
 
 ### Neutral Consequences
 
-- `mitodl/end-user-test-canaries` was created before the reversal and is now
-  **unused**. It holds one commit and no dependents. It should be archived or deleted;
-  it is deliberately not registered in the Pulumi repository fleet.
+- `mitodl/end-user-test-canaries` was created before the reversal and **deleted the
+  same day**, once its only commit (the scaffold now living under
+  `src/ol_concourse/pipelines/canaries/`) had been superseded. It was never registered
+  in the Pulumi repository fleet, so nothing there needs unwinding.
 - Alerting for these canaries must stay distinct from Grafana Synthetic Monitoring's
   HTTP probes so the two do not double-page. Tracked separately.
 

--- a/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
+++ b/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
@@ -36,7 +36,7 @@ and who owns a failing canary.
 - The ECR pull-through cache covers only `public.ecr.aws` (`ecr-public`) and Docker Hub
   (`dockerhub`) — see `src/ol_infrastructure/infrastructure/aws/ecr/__main__.py`. There
   is **no cache rule for `mcr.microsoft.com`**, where the official Playwright images
-  are published, and MCR is not an upstream ECR pull-through supports. Pulling MCR
+  are published, and MCR is not an upstream that ECR pull-through supports. Pulling MCR
   directly is nonetheless consistent with existing practice: pipelines already pull
   `quay.io/keycloak/keycloak` and `ghcr.io/astral-sh/uv` directly.
 - Canaries run against live deployed environments, including production, and need real
@@ -63,9 +63,10 @@ Established empirically on 2026-09-01, not assumed:
    and `yarn`. `npx --yes playwright test` therefore fails to resolve
    `@playwright/test` from the config. An install step is mandatory.
 4. **That install is nearly free when the dependency set is tiny.** With
-   `@playwright/test` plus TypeScript as the only dependencies, `npm ci` is **6 packages
-   in ~400 ms**, and no browser download happens because the image already has them. A
-   full canary run against RC completed in ~1.1 s. This is what makes a purpose-built
+   `@playwright/test`, `@types/node`, and TypeScript as the only direct dependencies,
+   `npm ci` installs **6 packages in ~400 ms**, and no browser download happens because
+   the image already has them. A full canary run against RC completed in ~1.1 s. This
+   is what makes a purpose-built
    container image unnecessary machinery rather than an optimization.
 5. **The image is acceptable to pull:** `mcr.microsoft.com/playwright:v1.62.1-noble`
    carries ~2.4 GB of filesystem content, 1.3 GB of which is the baked browsers under
@@ -174,7 +175,8 @@ apply. That is more machinery than the tidiness was worth.
   A stray `.only` in a canary silently stops every other journey for that property from
   being checked, and nothing would report the gap.
 - Dependency discipline is a written rule in the directory's `AGENTS.md`: only
-  `@playwright/test` and TypeScript. Finding 4's economics hold only while that is true.
+  `@playwright/test`, `@types/node`, and TypeScript. Finding 4's economics hold only
+  while that is true.
 
 ## Consequences
 

--- a/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
+++ b/docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md
@@ -1,4 +1,4 @@
-# 0011. Playwright Canary Specs Live in a Dedicated Repository
+# 0011. Playwright Canary Specs Live in ol-infrastructure, on the Stock Playwright Image
 
 **Status:** Accepted
 **Date:** 2026-09-01
@@ -30,8 +30,9 @@ and who owns a failing canary.
 
 ### Constraints
 
-- `ol-infrastructure` is a **Python monorepo with zero JavaScript**: no `package.json`,
-  no lockfile, no Node tooling in `.pre-commit-config.yaml`, and 0 `.ts`/`.tsx` files.
+- `ol-infrastructure` is a **Python monorepo with, before this change, zero
+  JavaScript**: no `package.json`, no lockfile, no Node tooling in
+  `.pre-commit-config.yaml`, and 0 `.ts`/`.tsx` files.
 - The ECR pull-through cache covers only `public.ecr.aws` (`ecr-public`) and Docker Hub
   (`dockerhub`) — see `src/ol_infrastructure/infrastructure/aws/ecr/__main__.py`. There
   is **no cache rule for `mcr.microsoft.com`**, where the official Playwright images
@@ -61,28 +62,30 @@ Established empirically on 2026-09-01, not assumed:
    is *not* installed globally — `/usr/lib/node_modules` holds only `corepack`, `npm`
    and `yarn`. `npx --yes playwright test` therefore fails to resolve
    `@playwright/test` from the config. An install step is mandatory.
-4. **That install is nearly free when the repo is dedicated.** With `@playwright/test`
-   plus TypeScript as the only dependencies, `npm ci` is **6 packages in 335 ms**, and
-   no browser download happens because the image already has them. A full canary run
-   against RC completed in ~1.2 s. This is what makes a purpose-built container image
-   (option c) unnecessary machinery rather than an optimization.
+4. **That install is nearly free when the dependency set is tiny.** With
+   `@playwright/test` plus TypeScript as the only dependencies, `npm ci` is **6 packages
+   in ~400 ms**, and no browser download happens because the image already has them. A
+   full canary run against RC completed in ~1.1 s. This is what makes a purpose-built
+   container image unnecessary machinery rather than an optimization.
 5. **The image is small and fast to pull:** `mcr.microsoft.com/playwright:v1.62.1-noble`
    is 0.95 GB on disk, pulled in ~20 s, multi-arch with `linux/amd64`.
 6. **Runner and image versions cannot drift.** Pinning `@playwright/test` 1.58.1 against
    the `v1.62.1-noble` image fails with
    `browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1208/...`
-   — a message naming neither the pin nor the image tag. This is the primary operational
-   footgun of any stock-image approach and must be guarded, not documented.
+   — a message naming neither the pin nor the image tag. Any approach that keeps the pin
+   and the image tag in separate repositories has to guard this; one that keeps them
+   together can make it impossible instead.
 
 ### Options Considered
 
-1. **Specs in `ol-infrastructure` under the canary pipeline directory**
-   - Pros: cheapest to start; no image build; specs sit next to the pipeline that runs
-     them; single repo to change when onboarding a canary.
-   - Cons: introduces the first JavaScript/TypeScript, `package.json`, lockfile and Node
-     toolchain into a 467-file Python monorepo, along with its own Renovate stream and
-     lint/format story. Couples an ~91K-line infrastructure repo's watched paths to test
-     authoring, so every spec edit is a commit in the repo that also deploys production.
+1. **Specs in `ol-infrastructure` under the canary pipeline directory** — *chosen*
+   - Pros: the `@playwright/test` pin and the pipeline that pulls the matching image
+     live in one repository, so the version is a single source of truth and finding 6
+     stops being a hazard. One git resource, not two. Adding a journey is one PR. No
+     third repository for a debugger to discover.
+   - Cons: introduces the first JavaScript/TypeScript, `package.json` and lockfile into
+     a Python monorepo, and with it a Node toolchain that a Python-and-Pulumi reviewer
+     pool now has to care about.
 
 2. **Specs in the target application's own repo** (e.g. `mitodl/mit-learn`)
    - Pros: tests live with the app; app developers own them; for MIT Learn the specs and
@@ -98,100 +101,110 @@ Established empirically on 2026-09-01, not assumed:
    - Pros: most reproducible, fastest at run time.
    - Cons: most machinery — a `BuildConfig`/`DockerImageConfig` path, an ECR repo, and an
      image-build job to maintain. Finding 4 removes the motivation: the run-time cost it
-     would optimize away is 335 ms.
+     would optimize away is ~400 ms.
 
-4. **A dedicated canary repository** (`mitodl/end-user-test-canaries`) — *chosen*
-   - Pros: keeps Node tooling out of the Python monorepo and application test data out
-     of the canaries; one repo owns the whole canary fleet regardless of how many
-     properties it covers; a canary spec change is not a commit in the repo that deploys
-     production; the meta pipeline watches exactly one extra git resource, not N.
-   - Cons: a third repo in the loop; contributors must know it exists; it is one more
-     Renovate stream that must be kept in lockstep with the pipeline's image tag.
+4. **A dedicated canary repository** (`mitodl/end-user-test-canaries`)
+   - Pros: keeps Node tooling out of the Python monorepo; one repo owns the canary fleet
+     regardless of how many properties it covers.
+   - Cons: makes the `@playwright/test` pin and the pipeline's image tag a **cross-repo
+     lockstep pair**, so finding 6 must be guarded by a check script and a Renovate PR
+     bumping the pin is not independently mergeable. Adds a third repository to the
+     debugging path, and a repository-registration obligation against the
+     Pulumi-managed repo fleet.
 
 ## Decision
 
-**Chosen Option:** Option 4 — a dedicated repository,
-[`mitodl/end-user-test-canaries`](https://github.com/mitodl/end-user-test-canaries),
-public, running against the **stock** `mcr.microsoft.com/playwright` image with a pinned
-`npm ci`.
+**Chosen Option:** Option 1 — specs in `ol-infrastructure` under
+`src/ol_concourse/pipelines/canaries/`, run against the **stock**
+`mcr.microsoft.com/playwright` image with a pinned `npm ci`. No image is built.
 
-This is a refinement of option (a)'s packaging (stock image, checked-out specs, no image
-build) placed in its own repository rather than in `ol-infrastructure`. It takes option
-(b)'s "tests are their own artifact with their own owner" property without taking its
-"fleet health depends on N application repos" cost, and it declines option (c) on the
-strength of finding 4.
+**This decision was reversed once during the same session, and the reversal is the
+substance of it.** Option 4 was chosen first and a repository
+(`mitodl/end-user-test-canaries`) was created. Re-examining it against the codebase
+showed two of the arguments for separation did not survive contact with the facts:
+
+- *"Don't grant canary spec authors commits in the repository that deploys
+  production."* Wrong. `data/repos/ol-infrastructure.yaml` already grants
+  `odl-engineering: maintain`, so every engineer already has more access than that.
+- *"Spec edits become commits in the repository that deploys production."* Overstated.
+  Concourse path-watching already scopes this precisely; that is exactly what
+  `PULUMI_WATCHED_PATHS` and `project_secrets_paths` exist to do. Specs under the canary
+  directory trigger canary pipelines and nothing else.
+
+With those removed, the remaining case for a separate repository was tidiness, and its
+cost was concrete: a cross-repo version lockstep requiring a guard script, plus a
+`pulumi import` of the already-created repository before the 316-repo fleet stack could
+apply. That is more machinery than the tidiness was worth.
 
 **Rationale:**
 
-- Findings 3 and 4 together are the crux. An install step is unavoidable, but it is only
-  cheap while the dependency set stays tiny — which is true in a dedicated repo and
-  false in an application workspace. The same fact that kills the naive "no install
-  needed" version of option (a) also kills option (c)'s justification.
+- Findings 3, 4 and 6 together are the crux. An install step is unavoidable, and it is
+  only cheap while the dependency set stays tiny — true here, false in an application
+  workspace. And because the pin and the pipeline are now in one repository, the
+  pipeline **derives** the image tag from `package.json` (`1.62.1` →
+  `mcr.microsoft.com/playwright:v1.62.1-noble`) instead of carrying its own copy.
+  Finding 6's failure mode becomes unreachable by construction rather than guarded, and
+  a Renovate bump of the pin is self-contained.
 - The distinction that matters is not *where the code lives* but *what the test is for*.
   A PR gate must be strict; a canary must be stable, because it wakes a human. Finding 2
-  shows those requirements actively fighting inside one file. Separate artifacts let
-  each be correct.
-- `ol-infrastructure` having exactly zero JavaScript is a property worth keeping. Adding
-  a Node toolchain to it for canary specs is a permanent tax on a repo whose reviewers
-  are Python and Pulumi engineers.
+  shows those requirements actively fighting inside one file. Keeping canaries as their
+  own specs — in whichever repo — is what lets each be correct.
+- The cost actually paid is one `package.json` in one directory. `.pre-commit-config.yaml`
+  has no Node hooks, `ruff` and `mypy` ignore the directory, and nothing else in the
+  repository needs to know it exists.
 
 **Key Implementation Details:**
 
-- The canary repo pins `@playwright/test` and the pipeline pulls the matching
-  `mcr.microsoft.com/playwright:v<version>-noble` tag. `CanaryParams` carries
-  `playwright_version` as the pipeline-side half of that pair.
-- `bin/check-image-pin.mjs` in the canary repo fails fast when the two disagree,
-  converting finding 6's cryptic `Executable doesn't exist` into a message naming both
-  versions. The pipeline runs it before any journey.
+- `package.json` is the single source of truth for the Playwright version.
+  `CanaryParams` must **derive** the image tag from it and never hardcode one.
 - `playwright.config.ts` **throws** when `CANARY_BASE_URL` is unset. A canary with a
   default target reports green against the wrong environment, which is worse than one
   that refuses to start.
 - Credentials are never committed. They arrive as environment variables sourced from
-  Vault. The repository is public, and `mit-learn`'s `e2e/smoke.spec.ts` currently
-  hardcodes a live RC login — the failure mode this rule exists to prevent.
+  Vault. `mit-learn`'s `e2e/smoke.spec.ts` currently hardcodes a live RC login in public
+  source — the failure mode this rule exists to prevent.
 - Chromium runs with `--disable-dev-shm-usage`. A Concourse task container gets the 64 MB
   default `/dev/shm`, which is where Chromium places renderer shared memory; without the
   flag a journey dies mid-run as a bare tab crash.
 - `forbidOnly` is unconditional, unlike an application suite that only sets it under CI.
   A stray `.only` in a canary silently stops every other journey for that property from
   being checked, and nothing would report the gap.
+- Dependency discipline is a written rule in the directory's `AGENTS.md`: only
+  `@playwright/test` and TypeScript. Finding 4's economics hold only while that is true.
 
 ## Consequences
 
 ### Positive Consequences
 
-- `ol-infrastructure` stays Python-only; no Node toolchain, lockfile or JS lint config.
-- Onboarding a property stays two list edits in `ol-infrastructure`, matching
-  `simple_pulumi`; adding a *journey* to an existing property needs no pipeline change
-  at all.
-- `npm ci` stays a sub-second, 6-package install, and stays that way only if the repo's
-  dependency discipline holds — which is now an explicit rule in its `AGENTS.md`.
-- Canary specs are reviewable by the people who own the journeys without granting them
-  commits in the repository that deploys production infrastructure.
-- Moving later to option (c) remains a `CanaryParams` field addition plus a build job,
-  not a rewrite, because the specs are already an independently checked-out artifact.
+- The Playwright version is one string in one file. No cross-repo lockstep, no guard
+  script, no "this Renovate PR is not independently mergeable" caveat.
+- One git resource in the canary pipelines, and `CanaryParams` needs no
+  `spec_repo`/`spec_ref` fields.
+- Onboarding a property stays two list edits, matching `simple_pulumi`; adding a
+  *journey* to an existing property needs no pipeline change at all.
+- Nothing to register against the Pulumi-managed repository fleet, and no
+  `pulumi import` obligation.
+- A canary failure is debugged in one repository, by people who already have access.
 
 ### Negative Consequences
 
-- A third repository in the loop for anyone debugging a canary failure.
-- The `@playwright/test` pin and the pipeline's image tag are a two-repo lockstep pair.
-  A Renovate PR bumping the pin alone is **not** independently mergeable. Guarded by
-  `check:image-pin`, but it is a real cross-repo coupling.
+- `ol-infrastructure` now contains JavaScript. The `AGENTS.md` in that directory exists
+  to keep the blast radius at one directory, but the precedent is real and the next
+  person wanting a `package.json` elsewhere will cite it.
+- Renovate will now raise Node dependency PRs against a repository whose reviewers are
+  Python and Pulumi engineers.
 - Journeys for MIT Learn must be written fresh rather than reusing the existing `e2e/`
   suite. The `login()` helper's knowledge of the multi-screen Keycloak flow is worth
   porting; its data fixtures are not.
 - Duplication of intent with `mit-learn`'s `e2e/` suite is now possible — two places
-  test login. Accepted deliberately: they are testing different things (does this change
-  break login vs. is login broken for users right now).
+  test login. Accepted deliberately: they test different things (does this change break
+  login vs. is login broken for users right now).
 
 ### Neutral Consequences
 
-- The canary repo is **not** currently registered in the Pulumi-managed repository fleet
-  (`src/ol_infrastructure/saas/github/repositories/`). Bringing it under management
-  requires importing the already-created `github.Repository` into stack state first: the
-  provider's create is `POST /orgs/mitodl/repos`, which returns 422 for an existing repo
-  and would hard-fail the whole 316-repo fleet deploy. Registration was deliberately
-  deferred rather than half-done. Tracked as follow-up work.
+- `mitodl/end-user-test-canaries` was created before the reversal and is now
+  **unused**. It holds one commit and no dependents. It should be archived or deleted;
+  it is deliberately not registered in the Pulumi repository fleet.
 - Alerting for these canaries must stay distinct from Grafana Synthetic Monitoring's
   HTTP probes so the two do not double-page. Tracked separately.
 
@@ -202,8 +215,8 @@ strength of finding 4.
 - **Dependencies:** Canary login credentials sourced via SOPS/Vault
   (`tk-source-the-mit-learn-rc-canary-login-credentials-1125c7`) block the first real
   journey, not this decision.
-- **Verification performed:** `npm ci`, `npx tsc --noEmit`, `npm run check:image-pin`,
-  and a passing journey against `https://rc.learn.mit.edu`, all inside
+- **Verification performed:** `npm ci`, `npm run typecheck`, image-tag derivation from
+  `package.json`, and a passing journey against `https://rc.learn.mit.edu`, all inside
   `mcr.microsoft.com/playwright:v1.62.1-noble`.
 
 ## Related Decisions
@@ -218,8 +231,8 @@ strength of finding 4.
 ## References
 
 - Playwright Docker images: <https://playwright.dev/docs/docker>
-- `mitodl/mit-learn` `e2e/README.md` — states the intent to run this suite against RC as
-  an automated quality gate, which is the adjacent goal this decision separates from.
+- `mitodl/mit-learn` `e2e/README.md` — states the intent to run that suite against RC as
+  an automated quality gate, the adjacent goal this decision separates from.
 
 ---
 
@@ -227,6 +240,6 @@ strength of finding 4.
 
 | Date | Reviewer | Decision | Notes |
 |------|----------|----------|-------|
-| 2026-09-01 | cpatti | Approved | Chose a dedicated public repo over specs-in-ol-infrastructure; deferred Pulumi fleet registration pending state import |
+| 2026-09-01 | cpatti | Approved | Initially chose a dedicated repo; reversed within the session to specs-in-ol-infrastructure once the separation arguments were checked against the codebase |
 
 **Last Updated:** 2026-09-01

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,6 +167,8 @@ graph LR
 | [0007](0007-clickhouse-llmops-multi-tenant.md) | Multi-Tenant ClickHouse Cluster for LLMOps on Data EKS | Accepted | 2026-02-25 |
 | [0008](0008-concourse-spot-worker-graceful-drain-no-ephemeral.md) | Concourse Spot Worker Graceful Drain Without Ephemeral Mode | Accepted | 2026-04-08 |
 | [0009](0009-deploy-witan-as-shared-multi-tenant-mcp-service.md) | Deploy witan as a Shared, Multi-Tenant MCP Service | Accepted | 2026-07-07 |
+| [0010](0010-pingdom-checks-unmanaged-in-pulumi-state.md) | Pingdom Checks Unmanaged in Pulumi State | Proposed | 2026-07-20 |
+| [0011](0011-playwright-canary-specs-in-a-dedicated-repository.md) | Playwright Canary Specs Live in a Dedicated Repository | Accepted | 2026-09-01 |
 
 ## Creating a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -168,7 +168,7 @@ graph LR
 | [0008](0008-concourse-spot-worker-graceful-drain-no-ephemeral.md) | Concourse Spot Worker Graceful Drain Without Ephemeral Mode | Accepted | 2026-04-08 |
 | [0009](0009-deploy-witan-as-shared-multi-tenant-mcp-service.md) | Deploy witan as a Shared, Multi-Tenant MCP Service | Accepted | 2026-07-07 |
 | [0010](0010-pingdom-checks-unmanaged-in-pulumi-state.md) | Pingdom Checks Unmanaged in Pulumi State | Proposed | 2026-07-20 |
-| [0011](0011-playwright-canary-specs-in-a-dedicated-repository.md) | Playwright Canary Specs Live in a Dedicated Repository | Accepted | 2026-09-01 |
+| [0011](0011-playwright-canary-specs-in-ol-infrastructure.md) | Playwright Canary Specs Live in ol-infrastructure, on the Stock Playwright Image | Accepted | 2026-09-01 |
 
 ## Creating a New ADR
 

--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -107,6 +107,9 @@ pipelines:
     release_bot_app_id: ENC[AES256_GCM,data:0hKun97QGQ==,iv:qK3cMS2C6lJoB6ZYqieK3uLZXeYH31N2PSxAUfPaOFw=,tag:NX9hxwjHBVB5ZrbagNhqVA==,type:int]
     #ENC[AES256_GCM,data:W+mOgYMbbn7WyfKwf/0onOhSecaOJaOPCkmy20eY1edXiEV+bHsFeRJ/,iv:UV7NPl5BFvuaupCRbKAnAouAZs2AS1A0SqaCa3c9pMk=,tag:lgpdEoaaeMX110zwwj//7A==,type:comment]
     release_bot_app_installation_id: ENC[AES256_GCM,data:nCjDk7sy4Avu,iv:vJYCJLDgxsUk8OEhlBhAXOGPUgBDOT8nlUNfffNDemM=,tag:p1kr2BuInndcCttTNwaNkw==,type:int]
+  infrastructure/canary_mit_learn:
+    email: ENC[AES256_GCM,data:Y5WXOYh0vZsR7B2TB257fn+o5Ucv1chXK5RqDunb72Y35MgjTho=,iv:onSVKk/VUM1UUProqizM8ceQrabxekAnhwJuNMu3iTw=,tag:ub4xLsPV80DWPQd/iNmC4A==,type:str]
+    password: ENC[AES256_GCM,data:iTziw6NpD+c9x1ryDTr0fE+nm7a2szoBovhrk1hebF+Q74bOi8zi0g==,iv:jeVvOfN+drBHDmWU4OqlWVbAK2+xbUL8PoTapwNneKk=,tag:z8siHsJjl3NqMvaI/HaChA==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-30T19:59:40Z"
@@ -119,7 +122,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-30T19:59:40Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFc++sLNA6j6p2pl3FmF0DfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMlps8T60GLfvSOP6PAgEQgDtyh7VqxM2GLdaXvJ0xYxHPX1CDzQc3NHPLta4PG+LVDiFHjsGIPvd2I+x4CoP9NgKWWwbBgY8HdD1mwQ==
-  lastmodified: "2026-08-18T17:50:16Z"
-  mac: ENC[AES256_GCM,data:WtoeFX8oJL8HO9QxTrzuDCtk0VUJ1DZ3Iq6SOqo6/0oyXNNZh9e/WhYoU9/lWjtS07Sxt/pJDYEIqn6jYsxnfH1losmz4yvCxYoFMPBwqJEqMOleN6jTYLo69u8fPiA7Hku6qETwMh8jKWnUOB/y6Q/tkbljXiV/uLXQ0MtpuU8=,iv:G6v12TKc9Qyu/fWEIe2UWZyEBpCqhd2bnSJ9CSZe0bY=,tag:7wLJ6lVY29U2dRZuZEJ4kg==,type:str]
+  lastmodified: "2026-09-04T16:02:51Z"
+  mac: ENC[AES256_GCM,data:C4RvWitHsHod2Lo/NBgQGgEAAx9rOHHb0dhFwagZX3gD4Mtw7Y7tW2iowTN8+uULkDhIyTOLLByky6fMwlL9CeMgAhPXSHEx/vXaK8H490qa/7ts235f3DbLO3ENQFxUw8GyBg1pmFxoXbTkewAj9OJZNBMiiTmwkh39YH76Jmc=,iv:ENbczfyljBdAdVGHfgiDZ5DdYPApm3tDXf66SshcoW0=,tag:KCEvabROgZqWg4lvSH9B6Q==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -104,6 +104,14 @@ downloads none.
 - **Web-first assertions only.** `expect(locator)` auto-retries; `expect(await
   locator.count())` does not, and is the most common source of canary flake.
 - **Never `waitForTimeout`.** Wait for the thing you actually need.
+- **Retry the action, not just the assertion, when interacting before hydration.**
+  Auto-waiting gets a locator that is present and enabled, which is not the same as
+  one the framework has attached a handler to yet — a keystroke into a
+  server-rendered search box is silently dropped. Wrap the action and its outcome in
+  `expect(async () => { … }).toPass()` rather than sleeping. `login-and-search.spec.ts`
+  does this; the race was caught only because the journey was run in WebKit, where the
+  page is slower to hydrate. Chromium passed it every time, which is what this class of
+  bug looks like right up until the target has a bad day.
 
 ## Failure artifacts
 

--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -31,9 +31,10 @@ grow a `package.json`.
    throws without it. Do not add a default, and do not branch on the base URL to pick
    different expected data — see "Do not key assertions on the environment".
 
-3. **Do not add dependencies.** `@playwright/test` plus TypeScript, and nothing else.
-   That is what keeps `npm ci` a 6-package, sub-second install; every dependency added
-   here is paid on every run of every canary, forever.
+3. **Do not add dependencies.** Keep the direct dependency set to
+   `@playwright/test`, `@types/node`, and TypeScript. That is what keeps `npm ci` a
+   6-package, sub-second install; every dependency added here is paid on every run of
+   every canary, forever.
 
 ---
 

--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -1,0 +1,136 @@
+# Agent Instructions — `src/ol_concourse/pipelines/canaries`
+
+Playwright canaries for MIT Open Learning web properties. Read [`README.md`](README.md)
+first for what a canary is and what does not belong here.
+
+This is the **only JavaScript/TypeScript in `ol-infrastructure`**. Keep it that way:
+this directory is a self-contained Playwright project and nothing outside it should
+grow a `package.json`.
+
+---
+
+## Non-negotiables
+
+1. **No credentials in source.** This repository is public. Not a test account, not a
+   "throwaway" password, not in a fixture, not in a comment. `mitodl/mit-learn`'s
+   `e2e/smoke.spec.ts` hardcodes a live RC login; that is exactly the mistake not to
+   repeat. Read them from the environment and fail loudly when unset:
+
+   ```ts
+   const email = process.env.CANARY_USER_EMAIL
+   const password = process.env.CANARY_USER_PASSWORD
+   if (!email || !password) {
+     throw new Error("CANARY_USER_EMAIL and CANARY_USER_PASSWORD are required")
+   }
+   ```
+
+   The pipeline sources these from Vault. A canary that falls back to a default
+   credential is worse than one that fails to start.
+
+2. **No target URL in source.** `playwright.config.ts` requires `CANARY_BASE_URL` and
+   throws without it. Do not add a default, and do not branch on the base URL to pick
+   different expected data — see "Do not key assertions on the environment".
+
+3. **Do not add dependencies.** `@playwright/test` plus TypeScript, and nothing else.
+   That is what keeps `npm ci` a 6-package, sub-second install; every dependency added
+   here is paid on every run of every canary, forever.
+
+---
+
+## Version pinning
+
+`package.json`'s `@playwright/test` pin is the **single source of truth**. The pipeline
+derives the image tag from it — `1.62.1` → `mcr.microsoft.com/playwright:v1.62.1-noble`
+— rather than carrying its own copy of the version. Keeping specs and pipeline in one
+repository is what makes that possible, and it is most of the reason they are here.
+
+**Never hardcode the image tag in `pipeline.py`.** Derive it from this `package.json`.
+If the two are ever allowed to drift, the failure is this, naming neither version:
+
+```
+browserType.launch: Executable doesn't exist at
+/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/...
+```
+
+(Reproduced with `@playwright/test` 1.58.1 against `v1.62.1-noble`. The browsers are
+baked into the image at a revision keyed to that exact Playwright version.)
+
+A Renovate bump of the pin here is therefore self-contained and safe: it moves the
+image tag with it automatically. That is the property to preserve.
+
+Note also that the image does **not** ship `@playwright/test` globally —
+`/usr/lib/node_modules` holds only `corepack`, `npm` and `yarn` — so `npm ci` is
+mandatory and cannot be optimised away. The browsers are already present, so it
+downloads none.
+
+---
+
+## Adding a journey to an existing property
+
+1. Add `specs/<property>/<journey>.spec.ts`.
+2. Reuse the property's helpers in `specs/<property>/helpers/`. Login flows in
+   particular are shared — do not re-derive a Keycloak flow per spec.
+3. Run it locally against the real target (see `README.md`) **at least twice** in a
+   row. A canary that passes once is not yet a canary.
+4. No pipeline change is needed. A property's pipeline runs every spec under its
+   directory.
+
+## Adding a new property
+
+1. `mkdir specs/<property>` with a `README.md` naming the environment it targets and
+   who owns the journeys.
+2. Add the journeys as above.
+3. Add a `CanaryParams` entry in `pipeline.py` and add the name to the list in
+   `meta.py` — two list edits, the same onboarding shape as
+   [`simple_pulumi`](../infrastructure/simple_pulumi/).
+
+---
+
+## Writing journeys that survive
+
+- **Use role- and label-based locators.** `getByRole("button", { name: "Log In" })`
+  over a CSS path. They break when the user-visible affordance breaks, which is the
+  signal a canary is for.
+- **Do not key assertions on the environment.** `mit-learn`'s app suite keeps a
+  `{ [RC_DEFAULT]: {...}, [LOCAL_DEFAULT]: {...} }` table of expected titles and
+  prices, and silently falls back to the local branch for any unrecognised base URL —
+  so pointing it at a new environment quietly asserts the wrong data. A canary should
+  assert something true of every environment.
+- **Prefer a stable seeded fixture over live content.** If a journey must reference a
+  specific course, it needs a course that exists in every target environment by
+  contract. Note that dependency in the property's `README.md`; content that merely
+  happens to be there today is a future 3am page.
+- **Web-first assertions only.** `expect(locator)` auto-retries; `expect(await
+  locator.count())` does not, and is the most common source of canary flake.
+- **Never `waitForTimeout`.** Wait for the thing you actually need.
+
+## Failure artifacts
+
+Traces, screenshots and video are retained on failure into `canary-results/`, which the
+pipeline publishes. When triaging, the trace is almost always the fastest route — drop
+it into <https://trace.playwright.dev/>.
+
+## Validation
+
+Python tooling ignores this directory; `ruff` and `mypy` have nothing to say about it,
+and `.pre-commit-config.yaml` has no Node hooks. Validate it directly:
+
+```bash
+cd src/ol_concourse/pipelines/canaries
+npm ci
+npm run typecheck
+CANARY_BASE_URL=https://rc.learn.mit.edu npx playwright test specs/<property>
+```
+
+## Things that look reasonable and are not
+
+- **Adding a default for `CANARY_BASE_URL`.** A canary silently pointed at the wrong
+  environment reports green while the real one burns.
+- **Raising `retries` to quiet a flaky journey.** Fix the locator. Retries above 1
+  convert real intermittent user-facing breakage into silence.
+- **Hoisting `package.json` to the repo root.** It would put a Node toolchain in front
+  of every contributor to a Python monorepo. It stays in this directory.
+- **`.only` left in a spec.** `forbidOnly` is on unconditionally — not just under CI,
+  as an application suite would have it — and will fail the run, on purpose. A stray
+  `.only` in a canary silently stops every other journey for that property from being
+  checked, and nothing would report the gap.

--- a/src/ol_concourse/pipelines/canaries/README.md
+++ b/src/ol_concourse/pipelines/canaries/README.md
@@ -1,0 +1,75 @@
+# Canaries
+
+Playwright **canaries** for MIT Open Learning web properties: short, browser-driven
+user journeys — log in, search for a course, reach a checkout — run continuously by
+Concourse against live environments to detect that a real user's path through the
+product is broken.
+
+"Canary" here is used in the AWS CloudWatch Synthetics sense: a scheduled, scripted
+user journey, not a canary *deployment*.
+
+This is the only JavaScript in `ol-infrastructure`. It lives here, next to the
+pipeline that runs it, deliberately — see
+[ADR 0011](../../../../docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md).
+
+## What belongs here, and what does not
+
+| | |
+|---|---|
+| **Belongs here** | A journey a real user takes, that we want to know about within minutes of it breaking in a deployed environment. |
+| **Does not belong here** | Tests that gate a pull request. Those live in the application's own repo, run against its own dev stack, and block merges. |
+
+The distinction matters because the two have opposite failure economics. A PR test
+should be strict: any regression must block a merge. A canary should be *stable* —
+it wakes a human up, so it must fail only when something is genuinely wrong for
+users. A canary that asserts on CMS copy or a course price will page someone every
+time an editor changes a word.
+
+**Assert on the journey completing, not on the content it finds along the way.**
+
+`mitodl/mit-learn` has its own Playwright suite at `e2e/` that can be pointed at RC.
+It is a good application test suite and deliberately not reused here; ADR 0011
+explains why.
+
+## Related, deliberately not duplicated
+
+Grafana Synthetic Monitoring
+([`synthetic_monitoring.py`](../../../ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py))
+already runs plain HTTP availability probes against these same properties. It answers
+"is the endpoint responding?". These canaries answer "can a person still log in and
+find a course?". Alerting for the two is kept separate on purpose.
+
+## Layout
+
+```
+playwright.config.ts   Shared config. Requires CANARY_BASE_URL.
+package.json           Pins @playwright/test. Single source of truth for the
+                       container image tag the pipeline pulls.
+specs/<property>/      One directory per web property.
+  mit-learn/
+```
+
+## Running a canary locally
+
+```bash
+cd src/ol_concourse/pipelines/canaries
+npm install
+CANARY_BASE_URL=https://rc.learn.mit.edu npx playwright test specs/mit-learn
+```
+
+Or in the same image Concourse uses, which is the only way to reproduce a pipeline
+failure exactly:
+
+```bash
+cd src/ol_concourse/pipelines/canaries
+docker run --rm -it --ipc=host \
+  -v "$PWD":/specs -w /specs \
+  -e CANARY_BASE_URL=https://rc.learn.mit.edu \
+  mcr.microsoft.com/playwright:v1.62.1-noble \
+  bash -c 'npm ci && npx playwright test specs/mit-learn'
+```
+
+## Adding a canary
+
+See [`AGENTS.md`](AGENTS.md) — written for both human and agent contributors, and the
+authoritative guide.

--- a/src/ol_concourse/pipelines/canaries/README.md
+++ b/src/ol_concourse/pipelines/canaries/README.md
@@ -42,12 +42,60 @@ find a course?". Alerting for the two is kept separate on purpose.
 ## Layout
 
 ```
-playwright.config.ts   Shared config. Requires CANARY_BASE_URL.
+meta.py                The canary-meta pipeline. `canary_names` is the source of
+                       truth for which canaries are actually deployed.
+pipeline.py            CanaryParams + the renderer for one canary-<property>
+                       pipeline. `pipeline_params` is a superset of canary_names.
+playwright.config.ts   Shared config. Requires CANARY_BASE_URL. Declares one
+                       project per browser; CanaryParams.browsers selects.
 package.json           Pins @playwright/test. Single source of truth for the
                        container image tag the pipeline pulls.
 specs/<property>/      One directory per web property.
   mit-learn/
 ```
+
+## How these run in Concourse
+
+`canary-meta` manages the fleet and re-sets itself. Each managed pipeline is named
+`canary-<property>` and holds a single job that pulls the stock Playwright image,
+runs `npm ci`, and runs that property's specs on a `time` trigger.
+
+```bash
+cd src/ol_concourse/pipelines/canaries
+python meta.py && fly -t pr-inf sp -p canary-meta -c definition.json
+```
+
+After that first manual set, `canary-meta` updates itself and every canary pipeline
+from `main`.
+
+Onboarding a property is **two list edits**, the same shape as
+[`simple_pulumi`](../infrastructure/simple_pulumi/):
+
+1. a `CanaryParams` entry in `pipeline.py`, and
+2. its name in `canary_names` in `meta.py`.
+
+The registry is deliberately the wider of the two, so a canary can be added and
+reviewed before it starts running against a live property. **Adding a journey to a
+property that already has a canary needs neither edit** — `spec_paths` defaults to the
+whole `specs/<property>/` directory.
+
+## Which Concourse instance
+
+The production instance (`pr-inf`), and there is deliberately no `--env` switch of the
+kind [`simple_pulumi/meta.py`](../infrastructure/simple_pulumi/meta.py) carries.
+
+That switch exists there because some Pulumi stacks run `local.Command` resources
+needing VPC-level access to QA or CI infrastructure, so the pipeline has to run *inside*
+that network. A canary has the opposite requirement: it is meant to see the property the
+way a member of the public does. Every current target — including `rc.learn.mit.edu` — is
+publicly reachable, so driving them from one instance is both sufficient and more
+faithful to what the canary claims to measure.
+
+A canary against an internal-only endpoint would break that assumption and need the
+`--env` treatment: a `canary_names` split per instance and an `extra_args` passthrough on
+the self-update job, copied from `simple_pulumi`. Note that such a canary is also no
+longer measuring the public user journey, which is worth questioning before adding the
+machinery.
 
 ## Running a canary locally
 

--- a/src/ol_concourse/pipelines/canaries/meta.py
+++ b/src/ol_concourse/pipelines/canaries/meta.py
@@ -1,0 +1,162 @@
+# pyright: reportCallIssue=false
+"""Meta pipeline managing the fleet of Playwright canary pipelines.
+
+Emits one ``create-<name>-pipeline`` job per entry in :data:`canary_names`, each of
+which renders and sets ``canary-<name>``, plus a job that re-sets this pipeline
+itself. Modeled on
+``src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py``.
+
+:data:`canary_names` is the source of truth for what is actually deployed.
+``pipeline.py``'s ``pipeline_params`` is a superset of it, so a canary can be
+prepared and reviewed before it starts running against a live property.
+
+Deployed to the production Concourse instance only -- there is deliberately no
+``--env`` switch here; see ``README.md`` ("Which Concourse instance") for the
+reasoning and for what would have to change to drive an internal-only target.
+"""
+
+import sys
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    SetPipelineStep,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+CANARY_DEFINITIONS = Identifier("canary-pipeline-definitions")
+CANARY_REPO_PATH = "src/ol_concourse/pipelines/canaries"
+
+_OL_INFRA_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+    "tag": "latest",
+    "aws_region": ECR_REGION,
+}
+
+
+def _render_pipeline_task(task_name: Identifier, script_args: list[str]) -> TaskStep:
+    """Run a canary rendering script and hand ``definition.json`` to the next step.
+
+    ``PYTHONPATH`` points at the *checked-out* ``src``, which is the point of the
+    git resource: the fleet must be rendered from the commit that triggered the
+    job, not from the copy baked into the image. ``ol_concourse`` is a namespace
+    package in both places, so they merge -- ``ol_concourse.pipelines`` resolves
+    from the checkout while ``ol_concourse.lib`` still comes from the image's
+    ``ol-concourse`` install.
+
+    :param task_name: Concourse task name.
+    :param script_args: ``python`` arguments, script path first.
+    :returns: The task step.
+    """
+    return TaskStep(
+        task=task_name,
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type="registry-image",
+                source=_OL_INFRA_IMAGE_SOURCE,
+            ),
+            inputs=[Input(name=CANARY_DEFINITIONS)],
+            outputs=[Output(name=Identifier("pipeline"))],
+            params={"PYTHONPATH": f"../{CANARY_DEFINITIONS}/src"},
+            run=Command(
+                path="python",
+                # definition.json is written to the CWD, so the CWD is the output
+                # the SetPipelineStep reads from.
+                dir="pipeline",
+                user="root",
+                args=script_args,
+            ),
+        ),
+    )
+
+
+def meta_job(canary_name: str) -> Job:
+    """Build the job that renders and sets one property's canary pipeline.
+
+    :param canary_name: Key into ``pipeline.py``'s ``pipeline_params``.
+    :returns: A job that sets ``canary-<canary_name>``.
+    """
+    return Job(
+        name=Identifier(f"create-{canary_name}-pipeline"),
+        plan=[
+            GetStep(get=CANARY_DEFINITIONS, trigger=True),
+            _render_pipeline_task(
+                Identifier(f"generate-{canary_name}-pipeline-file"),
+                [
+                    f"../{CANARY_DEFINITIONS}/{CANARY_REPO_PATH}/pipeline.py",
+                    canary_name,
+                ],
+            ),
+            SetPipelineStep(
+                set_pipeline=Identifier(f"canary-{canary_name}"),
+                file="pipeline/definition.json",
+            ),
+        ],
+    )
+
+
+def meta_pipeline(canary_names: list[str]) -> Pipeline:
+    """Build the self-managing canary meta pipeline.
+
+    :param canary_names: Canaries to deploy. The source of truth for the fleet.
+    :returns: The pipeline to set as ``canary-meta``.
+    """
+    pipeline_definitions = git_repo(
+        name=CANARY_DEFINITIONS,
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        # Narrower than simple_pulumi's watch list on purpose: nothing under this
+        # directory imports jobs.py, secrets_map.py or versions_map.py, so a change
+        # to those cannot alter a rendered canary and must not re-render the fleet.
+        paths=[
+            f"{CANARY_REPO_PATH}/",
+            "src/ol_concourse/pipelines/constants.py",
+            "pyproject.toml",
+        ],
+    )
+
+    jobs = [meta_job(canary_name) for canary_name in canary_names]
+    jobs.append(
+        Job(
+            name=Identifier("set-canary-meta-pipeline"),
+            plan=[
+                GetStep(get=CANARY_DEFINITIONS, trigger=True),
+                _render_pipeline_task(
+                    Identifier("generate-canary-meta-pipeline-file"),
+                    [f"../{CANARY_DEFINITIONS}/{CANARY_REPO_PATH}/meta.py"],
+                ),
+                SetPipelineStep(set_pipeline="self", file="pipeline/definition.json"),
+            ],
+        )
+    )
+
+    return Pipeline(resources=[pipeline_definitions], jobs=jobs)
+
+
+# The deployed fleet. Adding a name here is what puts a canary live, and is the
+# second of the two list edits that onboarding a property takes -- the first being
+# a CanaryParams entry in pipeline.py.
+canary_names = [
+    "mit-learn",
+]
+
+
+if __name__ == "__main__":
+    pipeline_json = meta_pipeline(canary_names).model_dump_json(indent=2)
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(pipeline_json)
+    sys.stdout.write(pipeline_json)
+    print()  # noqa: T201
+    print("fly -t pr-inf sp -p canary-meta -c definition.json")  # noqa: T201

--- a/src/ol_concourse/pipelines/canaries/package-lock.json
+++ b/src/ol_concourse/pipelines/canaries/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "end-user-test-canaries",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "end-user-test-canaries",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.62.1",
+        "@types/node": "^24.0.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/package.json
+++ b/src/ol_concourse/pipelines/canaries/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ol-canaries",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright end-user journey canaries for MIT Open Learning web properties",
+  "scripts": {
+    "canary": "playwright test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1",
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/pipeline.py
+++ b/src/ol_concourse/pipelines/canaries/pipeline.py
@@ -1,0 +1,267 @@
+# pyright: reportCallIssue=false
+"""Render a Concourse pipeline that runs one web property's Playwright canaries.
+
+One managed pipeline per property, named ``canary-<name>``. Which properties are
+actually deployed is decided by the name list in ``meta.py``; ``pipeline_params``
+below is a superset, so an entry can be prepared and reviewed here before it goes
+live -- the same onboarding shape as
+``src/ol_concourse/pipelines/infrastructure/simple_pulumi/``.
+
+Read ``AGENTS.md`` in this directory before changing anything here, and
+``docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md`` for why the specs
+live next to this file.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    Platform,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo, schedule
+from pydantic import BaseModel, model_validator
+
+CANARY_DIRECTORY = Path(__file__).parent
+# Where this directory sits in a checkout, for the git resource's watched paths.
+CANARY_REPO_PATH = "src/ol_concourse/pipelines/canaries"
+OL_INFRASTRUCTURE_URI = "https://github.com/mitodl/ol-infrastructure"
+
+# Not routed through the ECR pull-through cache: that cache is configured for
+# Docker Hub (see dockerhub_ecr_image_uri) and this image is on Microsoft's
+# registry, which has no anonymous pull limit to work around.
+PLAYWRIGHT_IMAGE_REPOSITORY = "mcr.microsoft.com/playwright"
+
+# Browsers baked into the Playwright image, each of which playwright.config.ts
+# declares a project for. Adding one here without adding the project there
+# renders a pipeline that fails with "unknown project".
+Browser = Literal["chromium", "firefox", "webkit"]
+
+
+def playwright_image_tag(canary_directory: Path = CANARY_DIRECTORY) -> str:
+    """Derive the Playwright image tag from ``package.json``'s pin.
+
+    ``package.json`` is the single source of truth for the Playwright version, and
+    the browsers are baked into the image at a revision keyed to that exact
+    version. Hardcoding a tag here instead re-creates the drift that ADR 0011
+    exists to make unreachable, and whose only symptom is::
+
+        browserType.launch: Executable doesn't exist at
+        /ms-playwright/chromium_headless_shell-1208/...
+
+    which names neither the pin nor the tag.
+
+    :param canary_directory: Directory holding ``package.json``.
+    :returns: An image tag such as ``v1.62.1-noble``.
+    :raises ValueError: If the pin is absent or is a range rather than an exact
+        version. A range lets the installed version drift away from the image tag,
+        which is the failure above.
+    """
+    package_json = json.loads((canary_directory / "package.json").read_text())
+    pin = package_json.get("devDependencies", {}).get("@playwright/test")
+    if not pin:
+        msg = (
+            f"@playwright/test is not pinned in {canary_directory / 'package.json'}; "
+            "it is the single source of truth for the canary image tag."
+        )
+        raise ValueError(msg)
+    if not re.fullmatch(r"\d+\.\d+\.\d+", pin):
+        msg = (
+            f"@playwright/test must be pinned to an exact version, got {pin!r}. "
+            "A range lets the installed Playwright drift from the image tag, and "
+            "the resulting failure names neither version. See ADR 0011."
+        )
+        raise ValueError(msg)
+    return f"v{pin}-noble"
+
+
+class CanaryParams(BaseModel):
+    """One web property's canary pipeline.
+
+    Attributes:
+        canary_name: Property name. Becomes the pipeline name ``canary-<name>``
+            and, by default, the spec directory ``specs/<name>``.
+        base_url: Environment the journeys run against, e.g.
+            ``https://rc.learn.mit.edu``. Passed as ``CANARY_BASE_URL``, which
+            ``playwright.config.ts`` requires and never defaults.
+        spec_paths: Paths passed to ``playwright test``, relative to this
+            directory. Defaults to the property's whole spec directory, so
+            **adding a journey needs no change here** -- drop a new
+            ``specs/<name>/<journey>.spec.ts`` in and it runs. Narrow this only
+            to deliberately exclude a journey from the schedule.
+        browsers: Playwright projects to run. Chromium alone is the default: each
+            extra browser multiplies the load this canary puts on a live
+            property, and cross-browser coverage is a job for an application test
+            suite, not a canary.
+        credential_secret: Name of the Concourse credential holding this
+            property's canary login, with ``email`` and ``password`` keys --
+            surfaced to the specs as ``CANARY_USER_EMAIL`` and
+            ``CANARY_USER_PASSWORD``. Leave unset for a property whose journeys
+            are all anonymous. Never put a credential itself here; this file is
+            public source.
+        timeout: Per-test budget in milliseconds.
+        expect_timeout: Per-assertion budget in milliseconds. Well under
+            ``timeout`` so a failing assertion reports as itself rather than as a
+            whole-test timeout.
+        schedule_interval: How often the canary runs.
+        schedule_start: Optional daily window start, ``HH:MM``.
+        schedule_stop: Optional daily window end, ``HH:MM``.
+        schedule_days: Optional days to run, e.g. ``["Monday"]``.
+        branch: Branch the specs are read from.
+    """
+
+    canary_name: str
+    base_url: str
+    spec_paths: list[str] = []
+    browsers: list[Browser] = ["chromium"]
+    credential_secret: str | None = None
+    timeout: int = 90_000
+    expect_timeout: int = 15_000
+    schedule_interval: str = "10m"
+    schedule_start: str | None = None
+    schedule_stop: str | None = None
+    schedule_days: list[str] | None = None
+    branch: str = "main"
+
+    @model_validator(mode="after")
+    def default_spec_paths_to_property_directory(self) -> "CanaryParams":
+        """Run the property's whole spec directory unless told otherwise."""
+        if not self.spec_paths:
+            self.spec_paths = [f"specs/{self.canary_name}"]
+        return self
+
+
+pipeline_params: dict[str, CanaryParams] = {
+    "mit-learn": CanaryParams(
+        canary_name="mit-learn",
+        base_url="https://rc.learn.mit.edu",
+        # The Concourse credential's NAME, not a credential. Resolves from Vault at
+        # secret-concourse/infrastructure/canary_mit_learn for pr-inf pipelines.
+        credential_secret="canary_mit_learn",  # noqa: S106  # pragma: allowlist secret
+    ),
+}
+
+
+def build_canary_pipeline(canary_name: str) -> Pipeline:
+    """Render the canary pipeline for one property.
+
+    :param canary_name: Key into :data:`pipeline_params`.
+    :returns: The pipeline to set as ``canary-<canary_name>``.
+    :raises ValueError: On an unknown name, listing the available ones.
+    """
+    if canary_name not in pipeline_params:
+        msg = (
+            f"Unknown canary {canary_name!r}. "
+            f"Available canaries: {', '.join(sorted(pipeline_params))}"
+        )
+        raise ValueError(msg)
+    params = pipeline_params[canary_name]
+
+    canary_code = git_repo(
+        name=Identifier("canary-code"),
+        uri=OL_INFRASTRUCTURE_URI,
+        branch=params.branch,
+        paths=[f"{CANARY_REPO_PATH}/"],
+    )
+    canary_schedule = schedule(
+        name=Identifier("canary-schedule"),
+        interval=params.schedule_interval,
+        start=params.schedule_start,
+        stop=params.schedule_stop,
+        days=params.schedule_days,
+    )
+
+    task_params: dict[str, Any] = {
+        "CANARY_BASE_URL": params.base_url,
+        "CANARY_TIMEOUT": str(params.timeout),
+        "CANARY_EXPECT_TIMEOUT": str(params.expect_timeout),
+    }
+    if params.credential_secret:
+        # Resolved by Concourse's Vault credential manager at task start, so the
+        # value never appears in this pipeline's definition.json.
+        task_params["CANARY_USER_EMAIL"] = f"(({params.credential_secret}.email))"
+        task_params["CANARY_USER_PASSWORD"] = f"(({params.credential_secret}.password))"
+
+    project_flags = " ".join(f"--project={browser}" for browser in params.browsers)
+    spec_arguments = " ".join(params.spec_paths)
+    run_canary = "\n".join(
+        [
+            "set -euo pipefail",
+            f"cd canary-code/{CANARY_REPO_PATH}",
+            # @playwright/test is not installed globally in the image, so this is
+            # mandatory. It is also cheap -- 6 packages, no browser download,
+            # because the browsers are already in the image -- which is why no
+            # bespoke canary image is built. Keep it that way (see AGENTS.md).
+            "npm ci",
+            f"npx playwright test {spec_arguments} {project_flags}",
+        ]
+    )
+
+    return Pipeline(
+        resources=[canary_code, canary_schedule],
+        jobs=[
+            Job(
+                name=Identifier(f"run-{params.canary_name}-canary"),
+                # A canary that piles up behind a slow run reports on a target it
+                # is also still loading, and the failures interleave.
+                max_in_flight=1,
+                plan=[
+                    GetStep(get=canary_schedule.name, trigger=True),
+                    GetStep(get=canary_code.name, trigger=True),
+                    TaskStep(
+                        task=Identifier(f"run-{params.canary_name}-journeys"),
+                        config=TaskConfig(
+                            platform=Platform.linux,
+                            image_resource=AnonymousResource(
+                                type="registry-image",
+                                source={
+                                    "repository": PLAYWRIGHT_IMAGE_REPOSITORY,
+                                    "tag": playwright_image_tag(),
+                                },
+                            ),
+                            inputs=[Input(name=canary_code.name)],
+                            params=task_params,
+                            run=Command(
+                                path="bash",
+                                args=["-c", run_canary],
+                            ),
+                        ),
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+if __name__ == "__main__":
+    min_args = 2
+    if len(sys.argv) < min_args:
+        msg = (
+            "Please provide a canary name as a command line argument.\n"
+            f"Available canaries: {', '.join(sorted(pipeline_params))}"
+        )
+        raise ValueError(msg)
+
+    canary_name = sys.argv[1]
+
+    try:
+        pipeline_json = build_canary_pipeline(canary_name).model_dump_json(indent=2)
+        with open("definition.json", "w") as definition:  # noqa: PTH123
+            definition.write(pipeline_json)
+        sys.stdout.write(pipeline_json)
+        print()  # noqa: T201
+        print(f"fly -t pr-inf sp -p canary-{canary_name} -c definition.json")  # noqa: T201
+    except ValueError as error:
+        sys.stderr.write(f"Error: {error}\n")
+        sys.exit(1)

--- a/src/ol_concourse/pipelines/canaries/playwright.config.ts
+++ b/src/ol_concourse/pipelines/canaries/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test"
+
+// A canary with a default target silently tests the wrong thing forever, so an
+// unset base URL is a configuration error rather than something to paper over.
+const baseURL = process.env.CANARY_BASE_URL
+if (!baseURL) {
+  throw new Error(
+    "CANARY_BASE_URL is required (e.g. https://rc.learn.mit.edu). " +
+      "Canaries never default to a target — see AGENTS.md.",
+  )
+}
+
+export default defineConfig({
+  testDir: "./specs",
+  // Real networks and real logins against a live property, not a local stub.
+  timeout: Number(process.env.CANARY_TIMEOUT) || 90_000,
+  expect: { timeout: Number(process.env.CANARY_EXPECT_TIMEOUT) || 15_000 },
+  // Unconditional, unlike an app suite that only forbids `.only` under CI. A
+  // stray `.only` here stops every other journey for that property from being
+  // checked at all, and nothing would report the gap.
+  forbidOnly: true,
+  // One retry: a genuine outage fails twice, a single network blip does not page
+  // anyone. More retries would start hiding real intermittent breakage.
+  retries: 1,
+  // Canaries run against live properties, including production. Serial keeps the
+  // load we add predictable and the failure attribution unambiguous.
+  workers: 1,
+  fullyParallel: false,
+  reporter: [
+    ["list"],
+    ["json", { outputFile: "canary-results/results.json" }],
+    ["html", { outputFolder: "canary-results/html", open: "never" }],
+  ],
+  outputDir: "canary-results/artifacts",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    launchOptions: {
+      // Concourse gives a task container the 64MB default /dev/shm, which is
+      // where Chromium puts its renderer shared memory; without this it dies
+      // with a bare tab crash partway through a journey.
+      args: ["--disable-dev-shm-usage"],
+    },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+})

--- a/src/ol_concourse/pipelines/canaries/playwright.config.ts
+++ b/src/ol_concourse/pipelines/canaries/playwright.config.ts
@@ -37,12 +37,26 @@ export default defineConfig({
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
-    launchOptions: {
-      // Concourse gives a task container the 64MB default /dev/shm, which is
-      // where Chromium puts its renderer shared memory; without this it dies
-      // with a bare tab crash partway through a journey.
-      args: ["--disable-dev-shm-usage"],
-    },
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // One project per browser the image ships. `pipeline.py`'s CanaryParams.browsers
+  // selects between them with --project, and defaults to chromium alone: every
+  // extra browser multiplies the load a canary puts on a live property.
+  // A name added there must exist here.
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          // Concourse gives a task container the 64MB default /dev/shm, which
+          // is where Chromium puts its renderer shared memory; without this it
+          // dies with a bare tab crash partway through a journey. Chromium-only
+          // — Firefox and WebKit reject the flag.
+          args: ["--disable-dev-shm-usage"],
+        },
+      },
+    },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
 })

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -1,0 +1,40 @@
+# mit-learn canaries
+
+**Property:** MIT Learn — <https://learn.mit.edu>
+**First target environment:** RC — <https://rc.learn.mit.edu>
+**Owner:** MIT Open Learning infrastructure / devops
+
+## Journeys
+
+| Spec | Journey | Status |
+|---|---|---|
+| `homepage.spec.ts` | Homepage renders in a real browser | Active |
+| _(pending)_ | Log in, then search for a course | Not yet written |
+
+## Login flow
+
+RC and production use a **multi-screen** Keycloak login: email, Next, password, Next.
+A local Docker stack presents a single-screen form instead. Canaries only ever run
+against deployed environments, so only the multi-screen flow matters here.
+
+Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
+sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
+
+## Content dependencies
+
+`homepage.spec.ts` has none, by design. Any journey added here that depends on specific
+course or program content must record that dependency in this table, because content
+that merely happens to exist in RC today is a future false page:
+
+| Journey | Requires | Guaranteed by |
+|---|---|---|
+| | | |
+
+## Prior art
+
+`mitodl/mit-learn` has its own Playwright suite at `e2e/` that can be pointed at RC via
+`yarn playwright:rc`. It is a good application test suite and deliberately not reused
+here: it is a member of a Yarn 4 workspace, so running it installs the whole
+application monorepo, and its assertions are pinned to CMS copy, course IDs and
+certificate prices. Its `login()` helper's knowledge of the multi-screen Keycloak flow
+is worth porting; its data fixtures are not.

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -8,17 +8,111 @@
 
 | Spec | Journey | Status |
 |---|---|---|
-| `homepage.spec.ts` | Homepage renders in a real browser | Active |
-| _(pending)_ | Log in, then search for a course | Not yet written |
+| `homepage.spec.ts` | Homepage renders in a real browser, anonymously | Active |
+| `login-and-search.spec.ts` | Log in, reach the dashboard, then search for courses | Active |
+
+## Helpers
+
+| File | Purpose |
+|---|---|
+| `helpers/sign-in.ts` | Drives the real multi-screen Keycloak login from the homepage |
+| `helpers/signed-in-test.ts` | `test` whose `page` fixture is already signed in |
+
+A journey that needs a session imports `test` from `helpers/signed-in-test` and takes
+the ordinary `{ page }` fixture — do not call `signIn` yourself. The session is
+established once per worker and reused, so adding a third signed-in journey costs no
+extra logins. Journeys that must be anonymous, like `homepage.spec.ts`, keep importing
+`@playwright/test` directly.
+
+The session is held in memory and deliberately never written to disk: a `storageState`
+file carries live tokens and this project's failure artifacts are published. For the
+same reason the login context is not traced, so `sign-in.ts` puts the diagnosis in its
+error messages instead.
 
 ## Login flow
 
-RC and production use a **multi-screen** Keycloak login: email, Next, password, Next.
-A local Docker stack presents a single-screen form instead. Canaries only ever run
-against deployed environments, so only the multi-screen flow matters here.
+RC authenticates against `sso-qa.ol.mit.edu`, realm `olapps`, client `ol-mitlearn-client`.
+The flow is **identity-first** and measured as three screens:
+
+| Screen | Path | Form control |
+|---|---|---|
+| Email | `/protocol/openid-connect/auth` | label `Email`, button `Next` |
+| Password (account exists in the realm) | `/login-actions/authenticate` | label `Password`, button `Next` |
+| Signup (unknown non-MIT address) | `/login-actions/registration` | **has a captcha** |
+| Touchstone hand-off (unknown `@mit.edu` address) | `/broker/touchstone-idp/login` → `okta.mit.edu` | MIT credentials |
+
+There is **no captcha on the login path**, so the canary drives the real UI; no bypass,
+dedicated flow or injected `storageState` is needed.
 
 Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
 sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
+
+### Two things a login journey here must do
+
+Both are implemented in `helpers/sign-in.ts`; they are recorded here because they are
+properties of the realm, not of the code, and the next property to authenticate against
+`olapps` will need them too.
+
+1. **Assert the password screen was reached, positively.** The flow is identity-first, so
+   an account that is missing, disabled or renamed never produces a login error —
+   Keycloak just sends the browser elsewhere, and *which* elsewhere depends on the email
+   domain. The canary account is `@mit.edu`, so its failure mode is a silent hand-off to
+   Touchstone; a non-MIT address instead lands on the captcha'd signup form. Testing for
+   those destinations one at a time is how you end up reporting "login now requires SSO"
+   or "a captcha now blocks login" when the truth is that the account is gone. Worse, a
+   flow that assumes it is on the password screen will type the canary's password into
+   whatever page is actually showing — including MIT's own IdP.
+2. **Never retry a *rejected* password.** See the lockout note below. Retrying a page that
+   failed to load is fine; retrying a refused credential is not. Playwright starts a
+   fresh worker process for a retry, so `sign-in.ts` records the refusal in a file under
+   `tmpdir` — per-container, so it covers the run and nothing beyond it. Note that the
+   realm's custom theme means Keycloak's stock alert markup is absent: the refusal is
+   detected by its visible text (`Invalid username or password.`), which is what a user
+   sees anyway.
+
+## Canary account
+
+| | |
+|---|---|
+| Account | `odl-devops+canary-mit-learn-rc@mit.edu` |
+| Realm | `olapps` on `sso-qa.ol.mit.edu` (what RC authenticates against) |
+| Credential | Vault `secret-concourse/infrastructure/canary_mit_learn`, keys `email` / `password` |
+| Source of truth | `src/bridge/secrets/concourse/operations.production.yaml` under `pipelines:`, applied by the `concourse` Pulumi project |
+| Referenced as | `CanaryParams.credential_secret` set to `canary_mit_learn` in `../../pipeline.py` |
+
+The address is a plus-address on the devops list deliberately: the domain is one MIT
+controls, so a password-reset mail can never be received by anyone else, and anything the
+account does generate reaches a monitored mailbox instead of bouncing.
+
+**This user is not Pulumi-managed.** There are no `keycloak.User` resources in this
+repository, so the account was created through the admin API and exists only in the
+realm. It will not be recreated by a `pulumi up`, and nothing will detect its removal
+except the canary failing. It carries `emailVerified=true` and an empty
+`requiredActions` — the realm sets `verifyEmail=true` and has `VERIFY_EMAIL` as a
+*default action*, so a newly created user gets that action attached and cannot log in
+until it is cleared. It also needs the `fullName` attribute, which the realm's user
+profile marks required, and which rejects parentheses.
+
+### Rotation must be atomic, or the account is disabled
+
+Realm `olapps` is configured `failureFactor=10`, `permanentLockout=true`,
+`maxTemporaryLockouts=1`, `maxDeltaTimeSeconds=43200`. Ten consecutive failed logins
+gives one temporary lockout; the next ten **permanently disable the account**, which
+needs an admin to undo. The 12-hour reset window means a scheduled canary never lets the
+failure counter age out, so failures accumulate until lockout rather than settling into a
+harmless recurring error.
+
+So: **change Keycloak and the SOPS/Vault value together.** The gap between the two is
+itself enough to disable the account, and it will present as a captcha error rather than
+an auth error.
+
+### First-login onboarding, already cleared
+
+The first successful login redirects to `/onboarding?next=…&is_new_user=1`, not the
+dashboard. That has already been consumed for this account — subsequent logins land on
+`/dashboard`, and `/search?q=…` is reachable directly while authenticated. A *new* canary
+account would hit onboarding again, so anyone provisioning one should log in once by hand
+before relying on a journey that expects the dashboard.
 
 ## Content dependencies
 
@@ -28,7 +122,15 @@ that merely happens to exist in RC today is a future false page:
 
 | Journey | Requires | Guaranteed by |
 |---|---|---|
-| | | |
+| `login-and-search.spec.ts` | A search for `mathematics` returns at least one **course** | Nothing contractual — see below |
+
+That query is deliberately broad: MIT's catalogue not containing a single mathematics
+course is not a realistic content change, so the assertion is a real signal about search
+rather than a bet on one course's continued existence. It is still a content dependency,
+and the honest reading of a failure is "search returned nothing", which is a **failure
+worth paging on** — an emptied or half-rebuilt index looks exactly like this from a
+user's seat. Anything narrower, such as a named course or an exact result count, is a
+false page waiting for the next content sync.
 
 ## Prior art
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
@@ -1,0 +1,129 @@
+import { expect, type Page } from "@playwright/test"
+import { existsSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Realm `olapps` is permanentLockout=true, failureFactor=10, with a 12h counter
+// reset — so a credential that has drifted between Keycloak and Vault does not
+// settle into a harmless recurring failure, it disables the account for good in
+// about two hours at a 10-minute cadence. Playwright starts a fresh worker for a
+// retry, so refusing the second attempt has to be recorded somewhere outside the
+// process. Not under canary-results/, which is published as build artifacts;
+// tmpdir is per-container, so the refusal covers the run and nothing beyond it.
+const REJECTED_CREDENTIAL_MARKER = join(tmpdir(), "mit-learn-canary-credential-rejected")
+
+// Bounded so a rejected credential surfaces as itself. Left to the 90s test
+// timeout it would instead report as "test timeout", and the diagnosis below
+// would never run.
+const REDIRECT_TIMEOUT = 30_000
+
+function canaryCredentials(): { email: string; password: string } {
+  const email = process.env.CANARY_USER_EMAIL
+  const password = process.env.CANARY_USER_PASSWORD
+  if (!email || !password) {
+    throw new Error(
+      "CANARY_USER_EMAIL and CANARY_USER_PASSWORD are required. The pipeline " +
+        "sources them from Vault; locally, export them from SOPS. A canary never " +
+        "falls back to a default credential — see ../../../AGENTS.md.",
+    )
+  }
+  return { email, password }
+}
+
+// The realm ships a custom theme, so Keycloak's stock alert markup is not there
+// to key on — a refusal is ordinary visible text, which is also exactly what the
+// user is shown. Listed as whole phrases rather than as loose keywords so that
+// unrelated page copy cannot be read as a rejection and stop the canary.
+const REJECTION_MESSAGE =
+  /invalid username or password|invalid user credentials|account is (temporarily )?disabled|account is locked/i
+
+async function rejectionMessage(page: Page): Promise<string | null> {
+  const message = page.getByText(REJECTION_MESSAGE).first()
+  if (!(await message.isVisible().catch(() => false))) {
+    return null
+  }
+  return (await message.innerText()).trim()
+}
+
+/**
+ * Drive the real MIT Learn login, from the homepage through Keycloak.
+ *
+ * Fails with the actual cause rather than the visible symptom. The realm's flow
+ * is identity-first, so an account it does not recognise is never answered with
+ * a login error — the browser is simply sent somewhere else. See ../README.md.
+ */
+export async function signIn(page: Page): Promise<void> {
+  if (existsSync(REJECTED_CREDENTIAL_MARKER)) {
+    throw new Error(
+      "Refusing to re-submit a credential Keycloak already rejected in this run. " +
+        "Ten consecutive failures lock the canary account, and the next ten disable " +
+        "it permanently. Fix the credential in Keycloak and SOPS together.",
+    )
+  }
+  const { email, password } = canaryCredentials()
+
+  await page.goto("/")
+  // Step one of the journey, and the reason login starts here rather than at a
+  // deep link: a homepage that no longer offers a way in is a user-facing outage
+  // that a direct hop to the IdP would sail straight past.
+  await expect(page.locator("main")).toBeVisible()
+  const applicationOrigin = new URL(page.url()).origin
+
+  await page.getByRole("link", { name: "Log In" }).click()
+  await page.waitForURL((url) => url.origin !== applicationOrigin, {
+    timeout: REDIRECT_TIMEOUT,
+  })
+
+  const identityProvider = new URL(page.url()).origin
+  const emailScreen = page.url()
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  await page.waitForURL((url) => url.href !== emailScreen, { timeout: REDIRECT_TIMEOUT })
+
+  // Assert the local password screen positively, rather than testing for the
+  // known wrong destinations. An unrecognised account goes to whichever of them
+  // fits the address — measured: an @mit.edu one is handed off to Touchstone,
+  // any other domain gets the captcha'd signup form — and both mean the account
+  // is gone, not that login has grown a captcha or an SSO requirement. Guessing
+  // wrong here is not just a bad message: it would type the canary's password
+  // into whatever page happened to be showing.
+  const reached = new URL(page.url())
+  const onPasswordScreen =
+    reached.origin === identityProvider &&
+    reached.pathname.endsWith("/login-actions/authenticate")
+  if (!onPasswordScreen) {
+    throw new Error(
+      `After submitting the canary address, the flow reached ${reached.origin}` +
+        `${reached.pathname} instead of the password screen, so the account does ` +
+        "not exist in this realm. This is an account problem — not a captcha " +
+        "problem and not an SSO problem, whichever of those the page says.",
+    )
+  }
+
+  await page.getByLabel("Password", { exact: true }).fill(password)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  try {
+    await page.waitForURL((url) => url.origin === applicationOrigin, {
+      timeout: REDIRECT_TIMEOUT,
+    })
+  } catch (error) {
+    const rejection = await rejectionMessage(page)
+    if (rejection) {
+      writeFileSync(REJECTED_CREDENTIAL_MARKER, rejection)
+      throw new Error(
+        `Keycloak rejected the canary credential: "${rejection}". Not retrying — ` +
+          "see the lockout note in ../README.md. Rotation must change Keycloak and " +
+          "the SOPS/Vault value together; the gap between the two is itself enough " +
+          "to disable the account.",
+      )
+    }
+    throw error
+  }
+
+  if (new URL(page.url()).pathname.startsWith("/onboarding")) {
+    throw new Error(
+      "Login landed on onboarding, which only a canary account that has never " +
+        "completed it does. Log the account in by hand once, then re-run.",
+    )
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
@@ -1,0 +1,46 @@
+import { test as base, type BrowserContextOptions } from "@playwright/test"
+import { signIn } from "./sign-in"
+
+type SignedInWorkerFixtures = {
+  /** Session established once per worker, reused by every test in it. */
+  canarySession: BrowserContextOptions["storageState"]
+}
+
+/**
+ * `test` for journeys that need to be signed in.
+ *
+ * Import this instead of `@playwright/test` and the ordinary `page` fixture
+ * arrives authenticated, so a second journey reuses the login rather than
+ * re-implementing or re-running it. Journeys that should be anonymous — the
+ * homepage canary — keep importing `@playwright/test` directly.
+ *
+ * The session is held in memory and never written to disk: a storageState file
+ * carries live tokens, and this project's failure artifacts get published.
+ */
+export const test = base.extend<{}, SignedInWorkerFixtures>({
+  canarySession: [
+    async ({ browser }, use) => {
+      // A context built straight off `browser` inherits nothing from the project's
+      // `use`, so the config's required base URL has to be handed over explicitly
+      // or every `page.goto("/")` below is an invalid URL. Read from the project
+      // rather than the environment to keep playwright.config.ts the one place
+      // that decides what a canary targets.
+      const context = await browser.newContext({
+        baseURL: base.info().project.use.baseURL,
+      })
+      // Deliberately untraced, unlike the fixture-provided page: a trace of the
+      // login screens would embed the canary account's address, and traces are
+      // published as build artifacts. signIn() reports the cause in its message.
+      const page = await context.newPage()
+      await signIn(page)
+      const session = await context.storageState()
+      await context.close()
+      await use(session)
+    },
+    { scope: "worker" },
+  ],
+
+  storageState: ({ canarySession }, use) => use(canarySession),
+})
+
+export { expect } from "@playwright/test"

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/homepage.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/homepage.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test"
+
+// Deliberately content-free: it asserts the page rendered in a real browser, not
+// what it says. Anything keyed to CMS-authored copy pages someone when an editor
+// changes a word. See ../../AGENTS.md.
+test.describe("MIT Learn homepage", () => {
+  test("renders for an anonymous visitor", async ({ page }) => {
+    await page.goto("/")
+    await expect(page.locator("main")).toBeVisible()
+  })
+})

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./helpers/signed-in-test"
+
+// Broad enough that a working index cannot plausibly return nothing for it, and
+// specific enough that a result matching it means the query was actually applied.
+// Recorded in ../README.md's content-dependency table.
+const SEARCH_QUERY = "mathematics"
+
+test.describe("MIT Learn signed-in journey", () => {
+  test("signs in and reaches a page anonymous visitors cannot", async ({ page }) => {
+    await page.goto("/dashboard")
+
+    // Anonymous, this URL redirects to Keycloak, so arriving at the dashboard's
+    // own heading is proof of an authenticated session rather than proof that a
+    // redirect completed.
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole("heading", { name: "Your MIT Learning Journey" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "User Menu" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Log In" })).toHaveCount(0)
+  })
+
+  test("searches for courses and gets results relevant to the query", async ({ page }) => {
+    await page.goto("/")
+
+    // Retried as a unit because the header search box is in the server-rendered
+    // markup before React attaches a handler to it, so a keystroke can land in a
+    // box that is not listening yet and is silently dropped. Measured in WebKit;
+    // it is a race rather than a browser difference, and Chromium only wins it by
+    // being faster — which is the shape of a canary that passes until the day the
+    // target is slow, then pages someone at 3am.
+    const searchBox = page.getByRole("textbox", { name: "Search for" })
+    await expect(async () => {
+      await searchBox.fill(SEARCH_QUERY)
+      await searchBox.press("Enter")
+      await expect(page).toHaveURL(new RegExp(`/search\\?.*q=${SEARCH_QUERY}`), {
+        timeout: 5_000,
+      })
+    }).toPass({ timeout: 30_000 })
+
+    await expect(page.getByRole("heading", { name: "Search Results" })).toBeVisible()
+    await expect(page.getByRole("article").first()).toBeVisible()
+
+    // The tab set present but reading "Courses (0)" is what an emptied or
+    // half-rebuilt index looks like from a user's seat, so assert the count is
+    // non-zero separately from asserting the tab rendered at all.
+    const coursesTab = page.getByRole("tab", { name: /^Courses/ })
+    await expect(coursesTab).toBeVisible()
+    await expect(page.getByRole("tab", { name: /^Courses \([1-9]\d*\)/ })).toBeVisible()
+
+    await coursesTab.click()
+    // Relevance, not an exact count: any specific number is a false page waiting
+    // for the next content sync.
+    await expect(
+      page.getByRole("article", { name: new RegExp(`^Course:.*${SEARCH_QUERY}`, "i") }).first(),
+    ).toBeVisible()
+  })
+})

--- a/src/ol_concourse/pipelines/canaries/tsconfig.json
+++ b/src/ol_concourse/pipelines/canaries/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "specs/**/*.ts"]
+}


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5592 — deliberately **not** `Closes`: that issue covers the whole MIT Learn canary pipeline, and this PR only settles the packaging decision and lands the harness. The journey, `CanaryParams`/`meta.py`, scheduling and alerting are still open.

Also tracked in witan as `tk-decision-where-playwright-specs-live-and-how-the-108357`, under project `wp-playwright-canary-meta-pipeline-for-ol-web-prope-47a987`.

### Description (What does it do?)

Settles the blocking design decision for the Playwright canary meta pipeline — `CanaryParams`, the meta pipeline's watched paths and the credential flow all depend on it — and lands the harness the first canary will use.

- **ADR 0011** records the decision: canary specs live in this repo under `src/ol_concourse/pipelines/canaries/`, run against the **stock** `mcr.microsoft.com/playwright` image after a pinned `npm ci`. No canary image is built.
- Adds that directory: `playwright.config.ts`, `package.json`, a per-property `specs/` layout, an `AGENTS.md` scoping the JS blast radius to this one directory, and a first content-free MIT Learn homepage journey.
- `package.json` is the **single source of truth** for the Playwright version; `pipeline.py` must derive the image tag from it (`1.62.1` → `mcr.microsoft.com/playwright:v1.62.1-noble`) rather than carry its own copy.
- Adds the missing 0010 row to the ADR index.

**This is the first JavaScript in `ol-infrastructure`** — the main cost of the decision, and the reason the directory carries its own `AGENTS.md`. `.pre-commit-config.yaml` has no Node hooks and `ruff`/`mypy` ignore the directory, so nothing else needs wiring.

**The decision was reversed once inside this PR, and that reversal is worth reading.** The first commit chose a dedicated repo (`mitodl/end-user-test-canaries`, since created). Checking the separation argument against this codebase showed two of its premises were wrong:

- *"Don't grant canary spec authors commits in the repo that deploys production."* [`data/repos/ol-infrastructure.yaml`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml) already grants `odl-engineering: maintain` — every engineer already has more access than that.
- *"Spec edits become commits in the production-deploying repo."* Concourse path-watching already scopes this precisely; that is what `PULUMI_WATCHED_PATHS` and `project_secrets_paths` exist for.

With those removed, a separate repo bought tidiness and cost a cross-repo version lockstep (needing a guard script) plus a `pulumi import` before the 316-repo fleet stack could apply. Keeping the pin next to the pipeline makes the version-drift failure **unreachable by construction** instead of guarded, and makes a Renovate bump of the pin self-contained.

### How can this be tested?

```bash
cd src/ol_concourse/pipelines/canaries
docker run --rm -v "$PWD":/specs -w /specs --ipc=host \
  -e CANARY_BASE_URL=https://rc.learn.mit.edu \
  mcr.microsoft.com/playwright:v1.62.1-noble \
  bash -c 'npm ci && npm run typecheck && npx playwright test'
```

That is what I ran. Output:

```
added 6 packages in 403ms
typecheck OK
mcr.microsoft.com/playwright:v1.62.1-noble     (tag derived from package.json)
  ✓  1 [chromium] › specs/mit-learn/homepage.spec.ts:7:7 › MIT Learn homepage › renders for an anonymous visitor (728ms)
  1 passed (1.1s)
```

`pre-commit run --files` passes on every changed file (ruff, mypy, detect-secrets, large-file check).

The ADR's factual claims were established against the real image rather than from memory:

- `@playwright/test` is **not** installed globally in the image (`/usr/lib/node_modules` holds only `corepack`, `npm`, `yarn`), so `npx --yes playwright test` with no `node_modules` fails to resolve it. An install step is mandatory — this is what rules out the "no install needed" variant.
- Version drift was **reproduced**, not assumed. Pinning 1.58.1 against the `v1.62.1-noble` image fails with a message naming neither version, which is why the tag must be derived rather than duplicated:

```
Error: browserType.launch: Executable doesn't exist at
/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell
```

- Image carries ~2.4 GB of content (1.3 GB of it the baked browsers under `/ms-playwright`); `docker images` accounts it as 3.53 GB. ~20 s to pull, multi-arch with `linux/amd64`. Note `docker image inspect --format '{{.Size}}'` reports 0.95 GB for it, which does not match the filesystem — an earlier revision of this PR quoted that number and it was wrong.

### Additional Context

Two follow-ups, neither addressed here:

1. **`mitodl/end-user-test-canaries` is now unused** — created before the reversal, one commit, no dependents. It should be archived or deleted. Deliberately not registered in the Pulumi repository fleet.
2. **Security, unrelated to this PR:** `mitodl/mit-learn`'s `e2e/smoke.spec.ts` hardcodes a live RC login (email and a trivially guessable password) in public source, used against `https://rc.learn.mit.edu`. Rotation is the actual remediation since git history retains it. Filed separately. It is why ADR 0011 makes "no credentials in source" an enforced non-negotiable here.

Reviewers may reasonably want to push back on point 1 of the reversal — if the intent is for QA or app teams to own canary specs later without infra-repo access, the separate repo becomes right again. ADR 0011 records that as the case that would reverse it back.


