### PR TITLE
feat(release-bot): @-mention commit authors instead of pasting their emails

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -121,6 +121,11 @@ bot_secret = kubernetes.core.v1.Secret(
         namespace=namespace,
     ),
     string_data={
+        # The bot token needs "users:read.email" on top of the usual
+        # chat/commands scopes: slack_users.py resolves each commit author's
+        # email to a Slack id so release notifications @-mention real people
+        # instead of pasting addresses. Without the scope the bot logs one
+        # error and degrades to plain-text names.
         "slack-bot-token": bot_secrets["slack-bot-token"],
         "slack-app-token": bot_secrets["slack-app-token"],
         "concourse-user": bot_secrets["concourse-username"],

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -10,6 +10,7 @@ from typing import Any
 import bot_config as config
 import concourse_client as concourse
 import github_client as github
+import slack_users
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
 
@@ -21,6 +22,14 @@ log = logging.getLogger(__name__)
 # A module global is safe here: Socket Mode connections are not multiplexed,
 # so this process runs exactly one AsyncApp (see __main__.py's replicas=1).
 _slack_app: AsyncApp | None = None
+
+
+# app name -> Slack user id of whoever last ran `/doof release` for it, so the
+# ready-to-promote notification can ping the person who owns the release
+# rather than posting into the channel addressed to no one (Doof pinged "the
+# Merginator" there). Process-local and deliberately not persisted: a bot
+# restart costs one mention, and the message is still posted either way.
+_release_requesters: dict[str, str] = {}
 
 
 _USAGE = (
@@ -48,7 +57,7 @@ def _describe_in_flight(in_flight: dict[str, Any]) -> str:
     return f"<{in_flight['url']}|{in_flight['version']}>{when}"
 
 
-async def _cmd_release(repos, ack, respond, command, _context):
+async def _cmd_release(repos, ack, respond, command, context):
     await ack()
     app_name = command["text"].strip()
     if app_name not in repos:
@@ -92,6 +101,10 @@ async def _cmd_release(repos, ack, respond, command, _context):
         log.exception("Failed to trigger release for %s", app_name)
         await respond(f"❌ Failed to trigger release for `{app_name}`. Check logs.")
         return
+
+    requester = (context or {}).get("user_id")
+    if requester:
+        _release_requesters[app_name] = requester
 
     message = f"🚀 Release triggered for `{app_name}`. Build: {build_url}"
     if in_flight:
@@ -233,6 +246,7 @@ async def _cmd_promote(repos, ack, respond, command, context):
         await concourse.check_resource(cfg.pipeline, f"{app_name}-release-gate")
     except Exception:
         log.exception("Failed to force release-gate check for %s", app_name)
+    _release_requesters.pop(app_name, None)
     await respond(
         f"✅ `{app_name}` {issues[0]['title']} promoted. Production deploy triggered."
     )
@@ -269,6 +283,7 @@ async def _cmd_abandon(repos, ack, respond, command, _context):
         log.exception("Failed to trigger abandon for %s", app_name)
         await respond(f"❌ Failed to trigger release abandon for `{app_name}`.")
         return
+    _release_requesters.pop(app_name, None)
     await respond(f"🗑️ Release abandon triggered for `{app_name}`. Build: {build_url}")
 
 
@@ -309,6 +324,7 @@ async def _handle_promote_button(repos, ack, body, say):
         await concourse.check_resource(cfg.pipeline, f"{app_name}-release-gate")
     except Exception:
         log.exception("Failed to force release-gate check for %s", app_name)
+    _release_requesters.pop(app_name, None)
     await say(
         f"🚀 <@{user_id}> promoted `{app_name}` `{version}` to Production. "
         "Concourse deploy triggered."
@@ -321,10 +337,6 @@ _CHECKBOX_POLL_SECONDS = 60
 # `/doof wait-for-checkboxes` for the same app doesn't start a duplicate loop
 # posting every progress message twice.
 _checkbox_watchers: set[str] = set()
-
-
-def _format_authors(authors) -> str:
-    return ", ".join(sorted(authors))
 
 
 async def _watch_checkboxes(app, app_name, cfg, channel) -> None:
@@ -390,7 +402,7 @@ async def _watch_checkboxes(app, app_name, cfg, channel) -> None:
                     channel=channel,
                     text=(
                         f"Thanks for checking off your boxes, "
-                        f"{_format_authors(newly_done)}!"
+                        f"{await slack_users.format_authors(app.client, newly_done)}!"
                     ),
                 )
     finally:
@@ -398,34 +410,41 @@ async def _watch_checkboxes(app, app_name, cfg, channel) -> None:
 
 
 def _checkbox_watch_preflight(repos, app_name):
-    """Return (channel, None) if a watcher can start, else (None, error message)."""
+    """Return (app, channel, None) if a watcher can start, else (None, None, error).
+
+    The app is handed back rather than re-read from the module global by the
+    caller, so the `_slack_app is None` check below is what narrows the type
+    for everything downstream.
+    """
     if app_name not in repos:
-        return None, f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}"
+        return None, None, f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}"
     channel = repos[app_name].channel or os.environ.get("RELEASE_ANNOUNCE_CHANNEL")
     if not channel:
-        return None, (
+        return (
+            None,
+            None,
             f"No Slack channel configured for `{app_name}`, so there is nowhere "
-            "to post checklist progress."
+            "to post checklist progress.",
         )
     if _slack_app is None:
-        return None, "Bot is still starting up; try again in a moment."
+        return None, None, "Bot is still starting up; try again in a moment."
     if app_name in _checkbox_watchers:
-        return None, f"Already watching `{app_name}`'s release checklist."
+        return None, None, f"Already watching `{app_name}`'s release checklist."
     # Reserve the slot here rather than after the GitHub lookup below. Nothing
     # awaits between this check and the add, so it is atomic on the event loop;
     # claiming it later would let two concurrent invocations both pass this
     # check, interleave at open_release_issues, and start duplicate watchers
     # that post every progress message twice.
     _checkbox_watchers.add(app_name)
-    return channel, None
+    return _slack_app, channel, None
 
 
 async def _cmd_wait_for_checkboxes(repos, ack, respond, command, _context):
     """Watch a release checklist and report who is still outstanding."""
     await ack()
     app_name = command["text"].strip()
-    channel, error = _checkbox_watch_preflight(repos, app_name)
-    if error:
+    app, channel, error = _checkbox_watch_preflight(repos, app_name)
+    if error or app is None:
         await respond(error)
         return
     cfg = repos[app_name]
@@ -454,12 +473,13 @@ async def _cmd_wait_for_checkboxes(repos, ack, respond, command, _context):
         return
 
     asyncio.create_task(  # noqa: RUF006
-        _watch_checkboxes(_slack_app, app_name, cfg, channel)
+        _watch_checkboxes(app, app_name, cfg, channel)
     )
     await respond(
         f"👀 Watching `{app_name}`'s <{issue['url']}|release checklist> "
         f"({checked}/{total} checked).\n"
-        f"Still waiting on: {_format_authors(outstanding)}"
+        f"Still waiting on: "
+        f"{await slack_users.format_authors(app.client, outstanding)}"
     )
 
 
@@ -516,8 +536,9 @@ _READY_TO_PROMOTE_POLL_SECONDS = 120
 
 
 def _ready_to_promote_blocks(
-    app_name: str, version: str, issue_url: str
+    app_name: str, version: str, issue_url: str, requester: str | None = None
 ) -> list[dict[str, object]]:
+    cc = f" cc <@{requester}>" if requester else ""
     return [
         {
             "type": "section",
@@ -525,7 +546,8 @@ def _ready_to_promote_blocks(
                 "type": "mrkdwn",
                 "text": (
                     f"✅ *`{app_name}` {version}* — all checklist items are "
-                    f"checked off. <{issue_url}|Release issue> ready for promotion."
+                    f"checked off. <{issue_url}|Release issue> ready for "
+                    f"promotion.{cc}"
                 ),
             },
         },
@@ -583,7 +605,12 @@ async def _notify_ready_to_promote(app, repos) -> None:
                 await app.client.chat_postMessage(
                     channel=channel,
                     text=f"✅ `{app_name}` {version} is ready to promote.",
-                    blocks=_ready_to_promote_blocks(app_name, version, issue["url"]),
+                    blocks=_ready_to_promote_blocks(
+                        app_name,
+                        version,
+                        issue["url"],
+                        _release_requesters.get(app_name),
+                    ),
                 )
             except Exception:
                 log.exception(

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -617,6 +617,12 @@ async def _notify_ready_to_promote(app, repos) -> None:
                     "Failed to send ready-to-promote notification for %s", app_name
                 )
                 continue
+            # The mention has been delivered. Dropping it here keeps a failed
+            # add_issue_label below -- which leaves the issue eligible on
+            # every 120s poll -- from re-pinging the same person on each
+            # repeat; the duplicate message is a nuisance, a repeating
+            # notification is not.
+            _release_requesters.pop(app_name, None)
             try:
                 await github.add_issue_label(
                     cfg.repo, issue["number"], github.PROMOTE_READY_LABEL

--- a/src/ol_infrastructure/applications/release_bot/slack_users.py
+++ b/src/ol_infrastructure/applications/release_bot/slack_users.py
@@ -1,0 +1,148 @@
+"""Resolve commit-author identities to Slack mentions.
+
+The release resource writes each checklist item as ``- [ ] <item> by
+<author>``, where ``<author>`` is the commit author's *email* (see
+``_parse_commit_log`` in ol-concourse's release resource). Posting those
+strings straight into Slack notifies nobody and puts addresses in a channel,
+so every author is resolved to a real Slack user with ``users.lookupByEmail``
+and rendered as ``<@U…>``.
+
+That lookup needs the ``users:read.email`` scope on the bot token. Without it
+Slack returns ``missing_scope``; lookups are then disabled for the life of the
+process (one loud log line rather than an API call per author per poll) and
+every author falls back to a plain-text handle.
+
+Doof did this with a difflib fuzzy match of the git author *name* against
+every Slack user's ``real_name`` at a 0.8 threshold, because the release PR
+gave it no emails. Emails make an exact lookup possible, so the fuzzy match is
+not carried over.
+"""
+
+import logging
+import re
+import time
+from collections.abc import Iterable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# A resolved Slack id effectively never changes, so cache it for a day. A
+# *failed* lookup expires much sooner: someone who joins Slack, or whose git
+# email is added to their profile, should start getting pinged without waiting
+# for a pod restart.
+_HIT_TTL_SECONDS = 24 * 60 * 60
+_MISS_TTL_SECONDS = 15 * 60
+
+# author string -> (rendered mention or fallback, expires_at)
+_cache: dict[str, tuple[str, float]] = {}
+
+# Set when Slack reports the token lacks users:read.email. Every lookup would
+# fail the same way, and the checkbox watcher polls every 60s per author.
+_lookups_disabled = False
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+$")
+# GitHub's no-reply addresses carry the account handle: both the legacy
+# "handle@users.noreply.github.com" and the current
+# "12345+handle@users.noreply.github.com".
+_GITHUB_NOREPLY_RE = re.compile(
+    r"^(?:\d+\+)?(?P<handle>[^@\s]+)@users\.noreply\.github\.com$", re.IGNORECASE
+)
+# Commit authors that are machines. The github-issues resource's
+# `auto_check_authors` normally checks their boxes off before anyone sees the
+# issue, so these should not reach a lookup -- but a repo that hasn't
+# configured it would otherwise spend an API call per poll failing to find a
+# Slack account for renovate.
+_BOT_AUTHOR_RE = re.compile(
+    r"(\[bot\]|^(renovate|dependabot|github-actions|noreply)@)", re.IGNORECASE
+)
+
+
+def _fallback(author: str) -> str:
+    """Render an author we can't mention, without leaking their address.
+
+    A GitHub handle is more use to a human than an address, and the address
+    is what Doof never put in the channel in the first place.
+    """
+    noreply = _GITHUB_NOREPLY_RE.match(author)
+    if noreply:
+        return f"`{noreply.group('handle')}`"
+    if _EMAIL_RE.match(author):
+        return f"`{author.split('@', 1)[0]}`"
+    return f"`{author}`"
+
+
+def _error_code(exc: Exception) -> str:
+    """Return Slack's error string from a SlackApiError, or "" for anything else.
+
+    Read reflectively so this module doesn't import slack_sdk: it is exercised
+    in a test environment that has neither slack_sdk nor slack_bolt installed.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return ""
+    try:
+        return str(response["error"])
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _cached(author: str) -> str | None:
+    entry = _cache.get(author)
+    if entry is None:
+        return None
+    rendered, expires_at = entry
+    if expires_at <= time.monotonic():
+        del _cache[author]
+        return None
+    return rendered
+
+
+def _store(author: str, rendered: str, ttl: float) -> str:
+    _cache[author] = (rendered, time.monotonic() + ttl)
+    return rendered
+
+
+async def mention(client: Any, author: str) -> str:
+    """Return ``<@U…>`` for *author*, or a plain-text fallback."""
+    global _lookups_disabled  # noqa: PLW0603
+
+    cached = _cached(author)
+    if cached is not None:
+        return cached
+    if _lookups_disabled or not _EMAIL_RE.match(author):
+        return _fallback(author)
+    if _BOT_AUTHOR_RE.search(author):
+        return _store(author, _fallback(author), _HIT_TTL_SECONDS)
+
+    try:
+        response = await client.users_lookupByEmail(email=author)
+    except Exception as exc:  # noqa: BLE001
+        code = _error_code(exc)
+        if code == "missing_scope":
+            _lookups_disabled = True
+            log.error(  # noqa: TRY400
+                "Slack rejected users.lookupByEmail for lack of the "
+                "users:read.email scope; release notifications will name "
+                "authors without @-mentioning them until the bot token is "
+                "reinstalled with that scope"
+            )
+        elif code != "users_not_found":
+            log.warning(
+                "Slack lookup for %s failed: %s", _fallback(author), code or exc
+            )
+        return _store(author, _fallback(author), _MISS_TTL_SECONDS)
+
+    user = (
+        (response.get("user") or {}) if hasattr(response, "get") else response["user"]
+    )
+    user_id = user.get("id")
+    if not user_id or user.get("deleted"):
+        # A deactivated account can still be looked up, and mentioning one
+        # notifies nobody while reading as though someone was pinged.
+        return _store(author, _fallback(author), _HIT_TTL_SECONDS)
+    return _store(author, f"<@{user_id}>", _HIT_TTL_SECONDS)
+
+
+async def format_authors(client: Any, authors: Iterable[str]) -> str:
+    """Render a set of commit authors as a comma-separated Slack mention list."""
+    return ", ".join([await mention(client, author) for author in sorted(authors)])

--- a/src/ol_infrastructure/applications/release_bot/slack_users.py
+++ b/src/ol_infrastructure/applications/release_bot/slack_users.py
@@ -66,9 +66,12 @@ def _fallback(author: str) -> str:
     noreply = _GITHUB_NOREPLY_RE.match(author)
     if noreply:
         return f"`{noreply.group('handle')}`"
-    if _EMAIL_RE.match(author):
-        return f"`{author.split('@', 1)[0]}`"
-    return f"`{author}`"
+    # Truncate at the first "@" whatever the rest looks like: a git author
+    # field is an arbitrary string, and something address-shaped but invalid
+    # ("alice@@example.com") must not post itself in full just because it
+    # fails _EMAIL_RE. That pattern gates API lookups, not redaction.
+    local_part = author.split("@", 1)[0]
+    return f"`{local_part or 'unknown author'}`"
 
 
 def _error_code(exc: Exception) -> str:

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -715,3 +715,54 @@ async def test_promote_clears_the_recorded_requester(repos, slack, monkeypatch):
     )
 
     assert "my-app" not in bot._release_requesters
+
+
+def _ready_issue():
+    return {
+        "number": 1,
+        "title": "Release my-app",
+        "url": "https://github.com/mitodl/my-app/issues/1",
+        "body": "## Release 2026.9.1.1\n\n- [x] **A** (#1) by alice@example.com",
+        "labels": ["release"],
+    }
+
+
+async def test_ready_to_promote_stops_pinging_after_the_first_post(repos, monkeypatch):
+    """A failed label write leaves the issue eligible on every 120s poll.
+
+    The duplicate message is a known nuisance; repeating the @-mention with it
+    would turn that into a notification every two minutes for the same person.
+    """
+    bot._release_requesters["my-app"] = "UDANA"
+    monkeypatch.setattr(
+        bot.github, "open_release_issues", AsyncMock(return_value=[_ready_issue()])
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "add_issue_label",
+        AsyncMock(side_effect=RuntimeError("GitHub is down")),
+    )
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock()
+
+    await bot._notify_ready_to_promote(app, repos)
+    await bot._notify_ready_to_promote(app, repos)
+
+    first, second = app.client.chat_postMessage.call_args_list
+    assert "<@UDANA>" in first.kwargs["blocks"][0]["text"]["text"]
+    assert "<@UDANA>" not in second.kwargs["blocks"][0]["text"]["text"]
+
+
+async def test_a_failed_post_keeps_the_requester_for_the_next_poll(repos, monkeypatch):
+    """Dropping the requester on a failed post would lose the ping entirely."""
+    bot._release_requesters["my-app"] = "UDANA"
+    monkeypatch.setattr(
+        bot.github, "open_release_issues", AsyncMock(return_value=[_ready_issue()])
+    )
+    monkeypatch.setattr(bot.github, "add_issue_label", AsyncMock())
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock(side_effect=RuntimeError("Slack is down"))
+
+    await bot._notify_ready_to_promote(app, repos)
+
+    assert bot._release_requesters["my-app"] == "UDANA"

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import bot
 import bot_config
 import pytest
+import slack_users
 
 
 @pytest.fixture
@@ -307,18 +308,57 @@ async def test_release_status_reports_checklist_progress(repos, slack, monkeypat
 # ---------------------------------------------------------------------------
 
 
+_NOT_FOUND = "users_not_found"
+
+
+def _slack_client(users=None):
+    """Return a Slack client resolving *users* by email and nothing else."""
+
+    class _Error(Exception):
+        def __init__(self, code):
+            super().__init__(code)
+            self.response = {"error": code}
+
+    resolved = users or {}
+
+    async def _lookup(email):
+        if email not in resolved:
+            raise _Error(_NOT_FOUND)
+        return {"user": {"id": resolved[email]}}
+
+    client = MagicMock()
+    client.users_lookupByEmail = _lookup
+    client.chat_postMessage = AsyncMock()
+    return client
+
+
 @pytest.fixture(autouse=True)
 def _clear_watchers(monkeypatch):
     """Reset the module-global watcher state so it cannot leak between tests.
 
     `_slack_app` is set here because create_app() always populates it before
     the socket handler starts accepting commands, so a handler observing it
-    unset is unreachable in the running bot.
+    unset is unreachable in the running bot. Its client resolves the fixture
+    authors to Slack ids so mention rendering is exercised rather than stubbed.
     """
-    monkeypatch.setattr(bot, "_slack_app", object())
+    app = MagicMock()
+    app.client = _slack_client(
+        {
+            "alice@example.com": "UALICE",
+            "bob@example.com": "UBOB",
+            "carol@example.com": "UCAROL",
+        }
+    )
+    monkeypatch.setattr(bot, "_slack_app", app)
     bot._checkbox_watchers.clear()
+    bot._release_requesters.clear()
+    slack_users._cache.clear()
+    slack_users._lookups_disabled = False
     yield
     bot._checkbox_watchers.clear()
+    bot._release_requesters.clear()
+    slack_users._cache.clear()
+    slack_users._lookups_disabled = False
 
 
 async def test_wait_for_checkboxes_names_who_is_outstanding(repos, slack, monkeypatch):
@@ -356,8 +396,10 @@ async def test_wait_for_checkboxes_names_who_is_outstanding(repos, slack, monkey
 
     said = slack.said
     assert "1/3 checked" in said
-    assert "bob@example.com, carol@example.com" in said
-    assert "alice@example.com" not in said
+    # Mentions, not the raw commit emails: only `<@U…>` notifies anyone.
+    assert "<@UBOB>, <@UCAROL>" in said
+    assert "bob@example.com" not in said
+    assert "<@UALICE>" not in said
     assert len(started) == 1
 
 
@@ -525,3 +567,151 @@ async def test_watch_checkboxes_sleeps_before_retrying_a_failed_refresh(
 
     # One sleep for the normal cadence, one after the failed refresh.
     assert sleeps == [bot._CHECKBOX_POLL_SECONDS, bot._CHECKBOX_POLL_SECONDS]
+
+
+async def test_watch_checkboxes_thanks_people_by_mention(repos, monkeypatch):
+    """The thank-you is also the signal that a box was seen; it must notify."""
+    issue = {
+        "number": 1,
+        "title": "Release my-app",
+        "url": "https://github.com/mitodl/my-app/issues/1",
+        "body": (
+            "- [ ] **A** (#1) by alice@example.com\n"
+            "- [ ] **B** (#2) by bob@example.com\n"
+        ),
+        "labels": ["release"],
+    }
+    alice_done = (
+        "- [x] **A** (#1) by alice@example.com\n- [ ] **B** (#2) by bob@example.com\n"
+    )
+    refreshed = {**issue, "body": alice_done}
+    done = {**issue, "body": alice_done.replace("- [ ]", "- [x]")}
+    bodies = [issue, refreshed, done]
+
+    async def _issues(_repo):
+        return [bodies.pop(0)] if bodies else [done]
+
+    monkeypatch.setattr(bot.github, "open_release_issues", _issues)
+    monkeypatch.setattr(bot.asyncio, "sleep", AsyncMock())
+    app = MagicMock()
+    app.client = _slack_client({"alice@example.com": "UALICE"})
+
+    await bot._watch_checkboxes(app, "my-app", repos["my-app"], "C123")
+
+    posted = app.client.chat_postMessage.call_args_list[0].kwargs["text"]
+    assert "<@UALICE>" in posted
+    assert "alice@example.com" not in posted
+
+
+# ---------------------------------------------------------------------------
+# ready-to-promote notification
+# ---------------------------------------------------------------------------
+
+
+async def test_release_records_who_asked_for_it(repos, slack, monkeypatch):
+    """The requester is who the ready-to-promote message has to ping."""
+    monkeypatch.setattr(bot.github, "in_flight_release", AsyncMock(return_value=None))
+    monkeypatch.setattr(bot.concourse, "check_resource", AsyncMock())
+    monkeypatch.setattr(
+        bot.concourse, "trigger_job", AsyncMock(return_value="http://build/1")
+    )
+
+    await bot._cmd_release(
+        repos, slack.ack, slack.respond, _command("my-app"), {"user_id": "UDANA"}
+    )
+
+    assert bot._release_requesters["my-app"] == "UDANA"
+
+
+async def test_ready_to_promote_pings_the_release_requester(repos, monkeypatch):
+    """Posting "ready to promote" addressed to nobody chases nobody.
+
+    Doof pinged the release manager here; the closest thing this bot knows is
+    whoever ran `/doof release`.
+    """
+    bot._release_requesters["my-app"] = "UDANA"
+    monkeypatch.setattr(
+        bot.github,
+        "open_release_issues",
+        AsyncMock(
+            return_value=[
+                {
+                    "number": 1,
+                    "title": "Release my-app",
+                    "url": "https://github.com/mitodl/my-app/issues/1",
+                    "body": (
+                        "## Release 2026.9.1.1\n\n- [x] **A** (#1) by alice@example.com"
+                    ),
+                    "labels": ["release"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(bot.github, "add_issue_label", AsyncMock())
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock()
+
+    await bot._notify_ready_to_promote(app, repos)
+
+    blocks = app.client.chat_postMessage.call_args.kwargs["blocks"]
+    assert "<@UDANA>" in blocks[0]["text"]["text"]
+
+
+async def test_ready_to_promote_omits_the_ping_when_nobody_is_recorded(
+    repos, monkeypatch
+):
+    """A bot restart loses the requester; the notification still has to go out."""
+    monkeypatch.setattr(
+        bot.github,
+        "open_release_issues",
+        AsyncMock(
+            return_value=[
+                {
+                    "number": 1,
+                    "title": "Release my-app",
+                    "url": "https://github.com/mitodl/my-app/issues/1",
+                    "body": (
+                        "## Release 2026.9.1.1\n\n- [x] **A** (#1) by alice@example.com"
+                    ),
+                    "labels": ["release"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(bot.github, "add_issue_label", AsyncMock())
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock()
+
+    await bot._notify_ready_to_promote(app, repos)
+
+    blocks = app.client.chat_postMessage.call_args.kwargs["blocks"]
+    assert "cc" not in blocks[0]["text"]["text"]
+    assert blocks[1]["elements"][0]["value"] == "my-app:2026.9.1.1"
+
+
+async def test_promote_clears_the_recorded_requester(repos, slack, monkeypatch):
+    """A stale requester would ping the wrong person on the next release."""
+    bot._release_requesters["my-app"] = "UDANA"
+    monkeypatch.setattr(
+        bot.github,
+        "open_release_issues",
+        AsyncMock(
+            return_value=[
+                {
+                    "number": 1,
+                    "title": "Release my-app",
+                    "url": "https://github.com/mitodl/my-app/issues/1",
+                    "body": "## Release 2026.9.1.1\n",
+                    "labels": ["release"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(bot.github, "close_release_issue", AsyncMock())
+    monkeypatch.setattr(bot.concourse, "check_resource", AsyncMock())
+
+    await bot._cmd_promote(
+        repos, slack.ack, slack.respond, _command("my-app"), {"user_id": "UOTHER"}
+    )
+
+    assert "my-app" not in bot._release_requesters

--- a/tests/ol_infrastructure/applications/release_bot/test_slack_users.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_slack_users.py
@@ -136,3 +136,23 @@ async def test_a_failed_lookup_is_retried_sooner_than_a_successful_one(monkeypat
     client.users["alice@example.com"] = {"id": "U1"}
 
     assert await slack_users.mention(client, "alice@example.com") == "<@U1>"
+
+
+async def test_malformed_addresses_are_still_redacted():
+    """A git author field is an arbitrary string, not a valid address.
+
+    Anything with an "@" is truncated at the first one whether or not it
+    parses as an email, so a malformed address cannot post itself in full.
+    """
+    client = _FakeClient()
+
+    assert await slack_users.mention(client, "alice@@example.com") == "`alice`"
+    assert await slack_users.mention(client, '"alice@work"@example.com') == '`"alice`'
+    assert client.lookups == []
+
+
+async def test_a_bare_name_is_left_alone():
+    """Not every author string is address-shaped; one without "@" survives."""
+    client = _FakeClient()
+
+    assert await slack_users.mention(client, "Alice Example") == "`Alice Example`"

--- a/tests/ol_infrastructure/applications/release_bot/test_slack_users.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_slack_users.py
@@ -1,0 +1,138 @@
+"""Tests for resolving commit-author emails to Slack mentions."""
+
+import pytest
+import slack_users
+
+_NOT_FOUND = "users_not_found"
+
+
+class _FakeSlackError(Exception):
+    """Stand-in for slack_sdk's SlackApiError, which isn't installed here."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"error": code}
+
+
+class _FakeClient:
+    def __init__(self, users=None, error=None):
+        self.users = users or {}
+        self.error = error
+        self.lookups: list[str] = []
+
+    async def users_lookupByEmail(self, email):  # noqa: N802
+        self.lookups.append(email)
+        if self.error:
+            raise _FakeSlackError(self.error)
+        if email not in self.users:
+            raise _FakeSlackError(_NOT_FOUND)
+        return {"user": self.users[email]}
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    slack_users._cache.clear()
+    slack_users._lookups_disabled = False
+    yield
+    slack_users._cache.clear()
+    slack_users._lookups_disabled = False
+
+
+async def test_email_resolves_to_a_real_mention():
+    """The whole point: `<@U…>` notifies, a pasted email does not."""
+    client = _FakeClient({"alice@example.com": {"id": "U1"}})
+
+    assert await slack_users.mention(client, "alice@example.com") == "<@U1>"
+
+
+async def test_lookups_are_cached():
+    """The checkbox watcher polls every 60s; re-resolving each cycle is waste."""
+    client = _FakeClient({"alice@example.com": {"id": "U1"}})
+
+    await slack_users.mention(client, "alice@example.com")
+    await slack_users.mention(client, "alice@example.com")
+
+    assert client.lookups == ["alice@example.com"]
+
+
+async def test_unknown_email_is_not_leaked_into_the_channel():
+    """A failed lookup falls back to a handle, never the full address."""
+    client = _FakeClient()
+
+    rendered = await slack_users.mention(client, "alice@example.com")
+
+    assert rendered == "`alice`"
+    assert "@example.com" not in rendered
+
+
+async def test_github_noreply_addresses_render_as_the_github_handle():
+    """`12345+handle@users.noreply.github.com` carries a usable identity."""
+    client = _FakeClient()
+
+    assert (
+        await slack_users.mention(client, "1234+octocat@users.noreply.github.com")
+        == "`octocat`"
+    )
+    assert (
+        await slack_users.mention(client, "hubot@users.noreply.github.com") == "`hubot`"
+    )
+
+
+async def test_bot_authors_are_never_looked_up():
+    """Renovate has no Slack account and must never be pinged or searched for."""
+    client = _FakeClient()
+
+    await slack_users.mention(client, "29139614+renovate[bot]@users.noreply.github.com")
+    await slack_users.mention(client, "renovate@whitesourcesoftware.com")
+
+    assert client.lookups == []
+
+
+async def test_missing_scope_disables_further_lookups():
+    """Without users:read.email every lookup fails identically -- stop asking.
+
+    The watcher polls per author per minute; hammering a scope error would
+    burn rate limit for a result that cannot change until the token is
+    reinstalled.
+    """
+    client = _FakeClient(error="missing_scope")
+
+    first = await slack_users.mention(client, "alice@example.com")
+    second = await slack_users.mention(client, "bob@example.com")
+
+    assert first == "`alice`"
+    assert second == "`bob`"
+    assert client.lookups == ["alice@example.com"]
+    assert slack_users._lookups_disabled
+
+
+async def test_deactivated_accounts_are_not_mentioned():
+    """Mentioning a deleted account notifies nobody while looking like it did."""
+    client = _FakeClient({"alice@example.com": {"id": "U1", "deleted": True}})
+
+    assert await slack_users.mention(client, "alice@example.com") == "`alice`"
+
+
+async def test_format_authors_renders_a_sorted_mention_list():
+    client = _FakeClient(
+        {"alice@example.com": {"id": "U1"}, "bob@example.com": {"id": "U2"}}
+    )
+
+    rendered = await slack_users.format_authors(
+        client, {"bob@example.com", "alice@example.com"}
+    )
+
+    assert rendered == "<@U1>, <@U2>"
+
+
+async def test_a_failed_lookup_is_retried_sooner_than_a_successful_one(monkeypatch):
+    """Someone who joins Slack should get pinged without a pod restart."""
+    client = _FakeClient()
+    now = [1000.0]
+    monkeypatch.setattr(slack_users.time, "monotonic", lambda: now[0])
+
+    await slack_users.mention(client, "alice@example.com")
+    now[0] += slack_users._MISS_TTL_SECONDS + 1
+    client.users["alice@example.com"] = {"id": "U1"}
+
+    assert await slack_users.mention(client, "alice@example.com") == "<@U1>"


### PR DESCRIPTION
## What are the relevant tickets?

Part of the Doof decommission epic (mitodl/hq#7185, RFC mitodl/hq#10465). Closes the largest day-to-day regression from Doof in the Slack-behavior variance matrix.

## Description (What does it do?)

Release checkbox chasing only works if the people with unchecked boxes get a Slack notification. The bot named them by joining the raw `by <author>` strings off the release checklist, and the release resource writes that field as the commit **email** (`_parse_commit_log` in ol-concourse's release resource). The channel got a list of addresses, which notifies nobody and puts those addresses in front of everyone.

New `slack_users.py` resolves each author to `<@U…>` via `users.lookupByEmail`:

- Doof fuzzy-matched git author names against Slack `real_name` at a 0.8 difflib threshold because the release PR gave it no emails. The checklist does, so the lookup is exact and the fuzzy match is not carried over.
- Cached: 24h for hits, 15m for misses, because the checkbox watcher polls every 60s. The short miss TTL means someone who joins Slack (or adds their git email to their profile) starts getting pinged without a pod restart.
- A failed lookup falls back to the GitHub handle (`12345+handle@users.noreply.github.com` → `handle`) or the address's local part. The full address never reaches the channel.
- Bot committers (renovate, dependabot, `[bot]` no-reply addresses) are never looked up or pinged. `auto_check_authors` in the `github-issues` resource normally checks their boxes off first, but a repo that has not configured it would otherwise burn a lookup per poll.
- A `missing_scope` response disables lookups for the life of the process after one error log, rather than failing per author per poll.

The ready-to-promote notification named nobody at all (Doof pinged the release manager there). It now cc's whoever ran `/doof release`, tracked process-locally and cleared once that release is promoted or abandoned.

## Deploy notes / how can this be tested?

**Requires `users:read.email` on the release bot's Slack bot token** — the app has to be reinstalled with that scope. Without it the bot logs one error and degrades to plain-text names, so this can merge and deploy before the scope is added; the mentions just will not resolve until it is.

`uv run pytest tests/ol_infrastructure/applications/release_bot` — 84 passed, including new coverage for the mention rendering, the cache TTLs, the bot-author skip, the missing-scope shutoff, deactivated accounts, and the requester cc.

Not verified in production: no release has been cut with this build yet, and the scope is not yet granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fJUUnTeht7kfR2brU1hCc
