### PR TITLE
feat(release-bot): announce RC/production deploys and report stalled releases

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -73,6 +73,9 @@ concourse_url = bot_config.get("concourse_url") or "https://cicd.odl.mit.edu"
 release_announce_channel = (
     bot_config.get("release_announce_channel") or "product-infrastructure"
 )
+# How long a release may sit cut-but-unfinished before the bot reports it in
+# Slack. Left unset the bot uses 24h, matching the cadence Doof nagged at.
+release_stuck_after_hours = bot_config.get("release_stuck_after_hours")
 
 # Derived from bridge.settings.apps -- the shared app registry also used by
 # the Concourse pipeline generator (k8s_apps/pipeline.py) -- so an app's repo,
@@ -217,6 +220,16 @@ bot_deployment = kubernetes.apps.v1.Deployment(
                                     )
                                 ]
                                 if release_announce_channel
+                                else []
+                            ),
+                            *(
+                                [
+                                    kubernetes.core.v1.EnvVarArgs(
+                                        name="RELEASE_STUCK_AFTER_HOURS",
+                                        value=release_stuck_after_hours,
+                                    )
+                                ]
+                                if release_stuck_after_hours
                                 else []
                             ),
                         ],

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -704,7 +704,10 @@ class ReleaseProgressState:
     after a restart, and re-reporting it once is the point.
     """
 
-    last_deployment: dict[tuple[str, str], int] = field(default_factory=dict)
+    # None means "polled and confirmed no successful deployment yet" -- a real
+    # baseline, distinct from a (app, environment) pair never having been
+    # polled at all (absent from the dict). See _announce_deployments.
+    last_deployment: dict[tuple[str, str], int | None] = field(default_factory=dict)
     nagged_at: dict[tuple[str, str], datetime] = field(default_factory=dict)
 
 
@@ -763,12 +766,22 @@ async def _announce_deployments(app, repos, state: ReleaseProgressState) -> None
                     "Failed to read %s deployments for %s", environment, app_name
                 )
                 continue
-            if deployment is None:
-                continue
             key = (app_name, environment)
+            # Distinguish "never polled this (app, environment)" from "polled
+            # it and there was no successful deployment yet" -- both leave
+            # `.get(key)` as None, but only the former should suppress the
+            # announcement. Collapsing them missed a brand-new app's very
+            # first deployment: it would poll None once (recording nothing),
+            # then see a real id with no key present and treat that first
+            # real deployment as the restart-seed case instead of a genuine
+            # no-deployment -> deployed transition.
+            first_observation = key not in state.last_deployment
+            if deployment is None:
+                state.last_deployment.setdefault(key, None)
+                continue
             previous = state.last_deployment.get(key)
             state.last_deployment[key] = deployment["id"]
-            if previous is None or previous == deployment["id"]:
+            if first_observation or previous == deployment["id"]:
                 # First observation seeds the watcher; an unchanged id is the
                 # steady state between releases.
                 continue

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -3,7 +3,8 @@
 import asyncio
 import logging
 import os
-from datetime import UTC, datetime
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from typing import Any
 
@@ -535,6 +536,11 @@ def create_app():
 _READY_TO_PROMOTE_POLL_SECONDS = 120
 
 
+def _announce_channel(cfg) -> str | None:
+    """Return the Slack channel for proactive posts about *cfg*'s app, if any."""
+    return cfg.channel or os.environ.get("RELEASE_ANNOUNCE_CHANNEL")
+
+
 def _ready_to_promote_blocks(
     app_name: str, version: str, issue_url: str, requester: str | None = None
 ) -> list[dict[str, object]]:
@@ -573,7 +579,7 @@ async def _notify_ready_to_promote(app, repos) -> None:
     polls don't re-send the same notification every cycle.
     """
     for app_name, cfg in repos.items():
-        channel = cfg.channel or os.environ.get("RELEASE_ANNOUNCE_CHANNEL")
+        channel = _announce_channel(cfg)
         if not channel:
             continue
         try:
@@ -658,9 +664,218 @@ async def _poll_ready_to_promote_loop(app, repos) -> None:
         await asyncio.sleep(_READY_TO_PROMOTE_POLL_SECONDS)
 
 
+_RELEASE_PROGRESS_POLL_SECONDS = 120
+# Doof nagged when a deploy had not landed within a timeout and then repeated
+# every 24h; that nag was the only thing in Slack that made a stalled release
+# visible. ol-analytics-api's releases/2026.8.3.1 sat cut-but-unfinished from
+# 2026-08-03 with no red build and no message anywhere.
+_STUCK_RENAG_INTERVAL = timedelta(hours=24)
+_DEFAULT_STUCK_AFTER_HOURS = 24.0
+
+
+def _stuck_release_after() -> timedelta:
+    raw = os.environ.get("RELEASE_STUCK_AFTER_HOURS", "").strip()
+    if not raw:
+        return timedelta(hours=_DEFAULT_STUCK_AFTER_HOURS)
+    try:
+        return timedelta(hours=float(raw))
+    except ValueError:
+        log.warning(
+            "RELEASE_STUCK_AFTER_HOURS=%r is not a number; using %sh",
+            raw,
+            _DEFAULT_STUCK_AFTER_HOURS,
+        )
+        return timedelta(hours=_DEFAULT_STUCK_AFTER_HOURS)
+
+
+@dataclass
+class ReleaseProgressState:
+    """What the release-progress poller has already said, held in process.
+
+    `last_deployment` is seeded on first observation rather than starting
+    empty, because the poller announces *transitions*: an empty map would
+    replay every app's current RC and Production deployment into Slack on
+    every bot restart. The cost of seeding is at most one missed announcement,
+    when the bot restarts in the window between a deploy landing and the next
+    poll -- much cheaper than a release channel that repeats itself, which is
+    the failure that makes people mute it.
+
+    `nagged_at` is deliberately not seeded: a stuck release is still stuck
+    after a restart, and re-reporting it once is the point.
+    """
+
+    last_deployment: dict[tuple[str, str], int] = field(default_factory=dict)
+    nagged_at: dict[tuple[str, str], datetime] = field(default_factory=dict)
+
+
+def _format_age(age: timedelta) -> str:
+    hours = int(age.total_seconds() // 3600)
+    return f"{hours}h" if hours < 24 else f"{hours // 24}d"  # noqa: PLR2004
+
+
+async def _milestone_text(app_name, cfg, environment, deployment) -> str:
+    """Render the Slack message for a deployment that just reached success."""
+    version = deployment["version"]
+    issue = None
+    try:
+        issue = await github.release_issue_for_version(cfg.repo, version)
+    except Exception:
+        # The milestone still goes out without the link; "what is in this
+        # release" is one click worse, not missing.
+        log.exception("Failed to find the release issue for %s %s", app_name, version)
+    link = f" <{issue['url']}|Release issue>" if issue else ""
+    if environment == github.PRODUCTION_ENVIRONMENT:
+        return f"🎉 `{app_name}` {version} is live in production.{link}"
+    return (
+        f"🚢 `{app_name}` {version} is deployed to RC.{link}"
+        " Check off your items once you have verified them."
+    )
+
+
+async def _announce_deployments(app, repos, state: ReleaseProgressState) -> None:
+    """Post to Slack when an app's RC or Production deployment changes.
+
+    Reads GitHub Deployments rather than watching the cluster: the pipeline
+    already records one per environment (`_define_release_resources`), and
+    they carry the release version and therefore the release issue, which a
+    Kubernetes rollout event does not.
+
+    This does not replace kubewatch-webhook-handler, and does not duplicate it
+    either. kubewatch reports *rollouts* -- every workload, including infra
+    changes that are not releases -- routed by the `ol.mit.edu/slack-channel`
+    pod label, which most workloads do not set, so it lands in the ops
+    channel. This reports *releases*, in the product channel from
+    bridge.settings.apps, naming the version and linking what is in it. The
+    two only collide if a team labels its workload with the same product
+    channel; that is a per-workload choice, not something to arbitrate here.
+    """
+    for app_name, cfg in repos.items():
+        channel = _announce_channel(cfg)
+        if not channel:
+            continue
+        for environment in (github.RC_ENVIRONMENT, github.PRODUCTION_ENVIRONMENT):
+            try:
+                deployment = await github.latest_successful_deployment(
+                    cfg.repo, environment
+                )
+            except Exception:
+                log.exception(
+                    "Failed to read %s deployments for %s", environment, app_name
+                )
+                continue
+            if deployment is None:
+                continue
+            key = (app_name, environment)
+            previous = state.last_deployment.get(key)
+            state.last_deployment[key] = deployment["id"]
+            if previous is None or previous == deployment["id"]:
+                # First observation seeds the watcher; an unchanged id is the
+                # steady state between releases.
+                continue
+            try:
+                await app.client.chat_postMessage(
+                    channel=channel,
+                    text=await _milestone_text(app_name, cfg, environment, deployment),
+                )
+            except Exception:
+                log.exception(
+                    "Failed to announce the %s deployment of %s", environment, app_name
+                )
+                # Put the previous id back so the next poll retries this
+                # milestone instead of silently treating it as announced.
+                state.last_deployment[key] = previous
+
+
+async def _stuck_release_text(app_name, cfg, in_flight, age: timedelta) -> str:
+    version = in_flight["version"]
+    reached = set()
+    for environment in (github.RC_ENVIRONMENT, github.PRODUCTION_ENVIRONMENT):
+        deployment = await github.latest_successful_deployment(cfg.repo, environment)
+        if deployment is not None and deployment["version"] == version:
+            reached.add(environment)
+    if github.PRODUCTION_ENVIRONMENT in reached:
+        # The deploy landed and `action: finish` did not. The release branch
+        # outliving its production deploy is what freezes the calver counter,
+        # so the next release silently reuses this version number.
+        state_line = (
+            "It reached production but the release never finished, so its "
+            "branch is still open and the next release will collide with "
+            "this version."
+        )
+    elif github.RC_ENVIRONMENT in reached:
+        state_line = "It is deployed to RC and waiting to be promoted."
+    else:
+        state_line = "It has not reached RC."
+    return (
+        f"⏳ `{app_name}` {version} was cut {_format_age(age)} ago and is not "
+        f"finished. {state_line} <{in_flight['url']}|{in_flight['branch']}>"
+    )
+
+
+async def _nag_stuck_releases(app, repos, state: ReleaseProgressState) -> None:
+    """Report releases that were cut and never shipped."""
+    threshold = _stuck_release_after()
+    now = datetime.now(tz=UTC)
+    for app_name, cfg in repos.items():
+        channel = _announce_channel(cfg)
+        if not channel:
+            continue
+        try:
+            in_flight = await github.in_flight_release(cfg.repo)
+        except Exception:
+            log.exception("Failed to check for a stuck release for %s", app_name)
+            continue
+        if not in_flight or in_flight.get("cut_at") is None:
+            continue
+        age = now - in_flight["cut_at"]
+        if age < threshold:
+            continue
+        key = (app_name, in_flight["version"])
+        last_nag = state.nagged_at.get(key)
+        if last_nag is not None and now - last_nag < _STUCK_RENAG_INTERVAL:
+            continue
+        try:
+            text = await _stuck_release_text(app_name, cfg, in_flight, age)
+        except Exception:
+            log.exception(
+                "Failed to describe the stuck release %s for %s",
+                in_flight["version"],
+                app_name,
+            )
+            continue
+        try:
+            await app.client.chat_postMessage(channel=channel, text=text)
+        except Exception:
+            log.exception(
+                "Failed to report the stuck release %s for %s",
+                in_flight["version"],
+                app_name,
+            )
+            continue
+        state.nagged_at[key] = now
+
+
+async def _poll_release_progress_loop(app, repos) -> None:
+    state = ReleaseProgressState()
+    while True:
+        for step, name in (
+            (_announce_deployments, "deployment milestone"),
+            (_nag_stuck_releases, "stuck release"),
+        ):
+            try:
+                await step(app, repos, state)
+            except Exception:
+                # Neither step may take the other down, and an unexpected
+                # exception here must not kill the task permanently and
+                # silently the way an unguarded loop body would.
+                log.exception("%s poll iteration failed", name)
+        await asyncio.sleep(_RELEASE_PROGRESS_POLL_SECONDS)
+
+
 async def main():
     app, repos = create_app()
     asyncio.create_task(_poll_ready_to_promote_loop(app, repos))  # noqa: RUF006
+    asyncio.create_task(_poll_release_progress_loop(app, repos))  # noqa: RUF006
     handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
     await handler.start_async()
 

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -349,3 +349,78 @@ async def close_release_issue(repo_slug: str, issue_number: int, comment: str) -
     Concourse's github-issues resource polls for closed issues.
     """
     await asyncio.to_thread(_close_release_issue_sync, repo_slug, issue_number, comment)
+
+
+# Environments the release pipeline creates GitHub Deployments for (see
+# _define_release_resources in
+# src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py). Each
+# deployment's `ref` is the calver version, because the pipeline starts it
+# with `ref: ((.:image_tag))` loaded from the release resource's version file.
+RC_ENVIRONMENT = "RC"
+PRODUCTION_ENVIRONMENT = "Production"
+
+# How far back to look for a successful deployment. A deployment whose Pulumi
+# job failed leaves a non-success status behind and the next release's
+# deployment is created above it, so the newest *successful* one can sit a few
+# entries down rather than always being first.
+_DEPLOYMENT_SCAN_LIMIT = 10
+# Release issues are created one per release, newest first, so the issue for a
+# just-deployed version is always near the top of the listing.
+_RELEASE_ISSUE_SCAN_LIMIT = 30
+
+
+def _latest_successful_deployment_sync(
+    repo_slug: str, environment: str
+) -> dict[str, Any] | None:
+    repo = _get_client().get_repo(repo_slug)
+    deployments = itertools.islice(
+        repo.get_deployments(environment=environment), _DEPLOYMENT_SCAN_LIMIT
+    )
+    for deployment in deployments:
+        # get_statuses() is newest-first, and only the newest counts: a
+        # deployment that failed and was re-run to success carries both.
+        latest_status = next(iter(itertools.islice(deployment.get_statuses(), 1)), None)
+        if latest_status is not None and latest_status.state == "success":
+            return {
+                "id": deployment.id,
+                "version": deployment.ref,
+                "sha": deployment.sha,
+                "environment": deployment.environment,
+                "deployed_at": latest_status.created_at,
+                # The github-deployments resource points this at the Concourse
+                # build that finished the deployment, when it supplies one.
+                "url": latest_status.target_url or "",
+            }
+    return None
+
+
+async def latest_successful_deployment(
+    repo_slug: str, environment: str
+) -> dict[str, Any] | None:
+    """Return the newest GitHub Deployment in *environment* that reached success."""
+    return await asyncio.to_thread(
+        _latest_successful_deployment_sync, repo_slug, environment
+    )
+
+
+def _release_issue_for_version_sync(
+    repo_slug: str, version: str
+) -> dict[str, Any] | None:
+    repo = _get_client().get_repo(repo_slug)
+    # state="all": the production milestone fires *after* the release issue was
+    # closed to open the promotion gate, so an open-only search would find
+    # nothing for exactly the announcement that most needs the link.
+    issues = repo.get_issues(
+        state="all", labels=["release"], sort="created", direction="desc"
+    )
+    for issue in itertools.islice(issues, _RELEASE_ISSUE_SCAN_LIMIT):
+        if extract_version(issue.body or "") == version:
+            return {"number": issue.number, "url": issue.html_url, "title": issue.title}
+    return None
+
+
+async def release_issue_for_version(
+    repo_slug: str, version: str
+) -> dict[str, Any] | None:
+    """Return the release issue whose checklist header names *version*, or None."""
+    return await asyncio.to_thread(_release_issue_for_version_sync, repo_slug, version)

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -5,6 +5,7 @@ can be driven directly with async stubs -- no Slack app or socket needed.
 """
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import bot
@@ -766,3 +767,284 @@ async def test_a_failed_post_keeps_the_requester_for_the_next_poll(repos, monkey
     await bot._notify_ready_to_promote(app, repos)
 
     assert bot._release_requesters["my-app"] == "UDANA"
+
+
+# ---------------------------------------------------------------------------
+# Deploy milestone announcements
+# ---------------------------------------------------------------------------
+
+
+def _deployment(deployment_id: int, version: str, environment: str) -> dict[str, Any]:
+    return {
+        "id": deployment_id,
+        "version": version,
+        "sha": "abc123",
+        "environment": environment,
+        "deployed_at": datetime.now(tz=UTC),
+        "url": "",
+    }
+
+
+@pytest.fixture
+def slack_app():
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock()
+    return app
+
+
+@pytest.fixture
+def _no_release_issue(monkeypatch):
+    monkeypatch.setattr(
+        bot.github, "release_issue_for_version", AsyncMock(return_value=None)
+    )
+
+
+def _deployments_by_environment(mapping: dict[str, dict[str, Any] | None]):
+    async def _lookup(_repo, environment):
+        return mapping.get(environment)
+
+    return _lookup
+
+
+@pytest.mark.usefixtures("_no_release_issue")
+async def test_first_poll_seeds_instead_of_announcing(repos, slack_app, monkeypatch):
+    """A restart must not replay whatever is already deployed into the channel.
+
+    The watcher reports transitions, so its first observation of an app is a
+    baseline, not news -- otherwise every bot deploy would re-announce every
+    app's current RC and production release.
+    """
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {
+                bot.github.RC_ENVIRONMENT: _deployment(1, "2026.9.2.1", "RC"),
+                bot.github.PRODUCTION_ENVIRONMENT: _deployment(
+                    2, "2026.9.1.1", "Production"
+                ),
+            }
+        ),
+    )
+    state = bot.ReleaseProgressState()
+
+    await bot._announce_deployments(slack_app, repos, state)
+
+    slack_app.client.chat_postMessage.assert_not_called()
+    assert state.last_deployment[("my-app", "RC")] == 1
+    assert state.last_deployment[("my-app", "Production")] == 2
+
+
+async def test_new_rc_deployment_announces_version_and_release_issue(
+    repos, slack_app, monkeypatch
+):
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {bot.github.RC_ENVIRONMENT: _deployment(7, "2026.9.2.1", "RC")}
+        ),
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "release_issue_for_version",
+        AsyncMock(
+            return_value={
+                "number": 12,
+                "url": "https://github.com/mitodl/my-app/issues/12",
+                "title": "Release my-app 2026.9.2.1",
+            }
+        ),
+    )
+    state = bot.ReleaseProgressState(last_deployment={("my-app", "RC"): 6})
+
+    await bot._announce_deployments(slack_app, repos, state)
+
+    text = slack_app.client.chat_postMessage.call_args.kwargs["text"]
+    assert "2026.9.2.1" in text
+    assert "RC" in text
+    # The link is the whole point: it is what makes "what is in this release"
+    # one click away, which is what the kubewatch notifications lack.
+    assert "https://github.com/mitodl/my-app/issues/12" in text
+
+
+@pytest.mark.usefixtures("_no_release_issue")
+async def test_production_deployment_announces_separately(
+    repos, slack_app, monkeypatch
+):
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {
+                bot.github.PRODUCTION_ENVIRONMENT: _deployment(
+                    9, "2026.9.2.1", "Production"
+                )
+            }
+        ),
+    )
+    state = bot.ReleaseProgressState(last_deployment={("my-app", "Production"): 8})
+
+    await bot._announce_deployments(slack_app, repos, state)
+
+    text = slack_app.client.chat_postMessage.call_args.kwargs["text"]
+    assert "production" in text.lower()
+    assert "2026.9.2.1" in text
+
+
+@pytest.mark.usefixtures("_no_release_issue")
+async def test_unchanged_deployment_is_not_re_announced(repos, slack_app, monkeypatch):
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {bot.github.RC_ENVIRONMENT: _deployment(7, "2026.9.2.1", "RC")}
+        ),
+    )
+    state = bot.ReleaseProgressState()
+
+    await bot._announce_deployments(slack_app, repos, state)
+    await bot._announce_deployments(slack_app, repos, state)
+    await bot._announce_deployments(slack_app, repos, state)
+
+    slack_app.client.chat_postMessage.assert_not_called()
+
+
+@pytest.mark.usefixtures("_no_release_issue")
+async def test_a_failed_post_is_retried_on_the_next_poll(repos, slack_app, monkeypatch):
+    """Recording a milestone as announced when the post failed loses it forever."""
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {bot.github.RC_ENVIRONMENT: _deployment(7, "2026.9.2.1", "RC")}
+        ),
+    )
+    slack_app.client.chat_postMessage = AsyncMock(
+        side_effect=RuntimeError("slack down")
+    )
+    state = bot.ReleaseProgressState(last_deployment={("my-app", "RC"): 6})
+
+    await bot._announce_deployments(slack_app, repos, state)
+
+    assert state.last_deployment[("my-app", "RC")] == 6
+    slack_app.client.chat_postMessage = AsyncMock()
+    await bot._announce_deployments(slack_app, repos, state)
+    slack_app.client.chat_postMessage.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Stuck-release reporting
+# ---------------------------------------------------------------------------
+
+
+def _in_flight(version: str, age: timedelta) -> dict[str, Any]:
+    return {
+        "version": version,
+        "branch": f"releases/{version}",
+        "url": f"https://github.com/mitodl/my-app/tree/releases/{version}",
+        "cut_at": datetime.now(tz=UTC) - age,
+    }
+
+
+async def test_a_young_release_is_not_reported_as_stuck(repos, slack_app, monkeypatch):
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.2.1", timedelta(hours=2))),
+    )
+
+    await bot._nag_stuck_releases(slack_app, repos, bot.ReleaseProgressState())
+
+    slack_app.client.chat_postMessage.assert_not_called()
+
+
+async def test_a_release_deployed_to_production_but_unfinished_is_called_out(
+    repos, slack_app, monkeypatch
+):
+    """The ol-analytics-api failure: shipped, branch never merged, nothing red.
+
+    This has to read differently from "waiting to be promoted" -- the branch
+    outliving its production deploy is what freezes the calver counter, so the
+    next release collides with this version.
+    """
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.8.3.1", timedelta(days=30))),
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "latest_successful_deployment",
+        _deployments_by_environment(
+            {
+                bot.github.RC_ENVIRONMENT: _deployment(1, "2026.8.3.1", "RC"),
+                bot.github.PRODUCTION_ENVIRONMENT: _deployment(
+                    2, "2026.8.3.1", "Production"
+                ),
+            }
+        ),
+    )
+    state = bot.ReleaseProgressState()
+
+    await bot._nag_stuck_releases(slack_app, repos, state)
+
+    text = slack_app.client.chat_postMessage.call_args.kwargs["text"]
+    assert "2026.8.3.1" in text
+    assert "30d" in text
+    assert "never finished" in text
+    assert "releases/2026.8.3.1" in text
+    assert state.nagged_at[("my-app", "2026.8.3.1")] is not None
+
+
+async def test_a_release_that_never_reached_rc_says_so(repos, slack_app, monkeypatch):
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.1.1", timedelta(days=2))),
+    )
+    monkeypatch.setattr(
+        bot.github, "latest_successful_deployment", _deployments_by_environment({})
+    )
+
+    await bot._nag_stuck_releases(slack_app, repos, bot.ReleaseProgressState())
+
+    text = slack_app.client.chat_postMessage.call_args.kwargs["text"]
+    assert "has not reached RC" in text
+
+
+async def test_a_stuck_release_is_not_re_reported_every_poll(
+    repos, slack_app, monkeypatch
+):
+    """Doof re-nagged every 24h, not every poll cycle."""
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.1.1", timedelta(days=2))),
+    )
+    monkeypatch.setattr(
+        bot.github, "latest_successful_deployment", _deployments_by_environment({})
+    )
+    state = bot.ReleaseProgressState()
+
+    await bot._nag_stuck_releases(slack_app, repos, state)
+    await bot._nag_stuck_releases(slack_app, repos, state)
+    await bot._nag_stuck_releases(slack_app, repos, state)
+
+    slack_app.client.chat_postMessage.assert_called_once()
+
+
+async def test_the_stuck_threshold_is_configurable(repos, slack_app, monkeypatch):
+    monkeypatch.setenv("RELEASE_STUCK_AFTER_HOURS", "1")
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.2.1", timedelta(hours=2))),
+    )
+    monkeypatch.setattr(
+        bot.github, "latest_successful_deployment", _deployments_by_environment({})
+    )
+
+    await bot._nag_stuck_releases(slack_app, repos, bot.ReleaseProgressState())
+
+    slack_app.client.chat_postMessage.assert_called_once()

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -911,6 +911,42 @@ async def test_unchanged_deployment_is_not_re_announced(repos, slack_app, monkey
 
 
 @pytest.mark.usefixtures("_no_release_issue")
+async def test_a_brand_new_apps_first_ever_deployment_is_announced(
+    repos, slack_app, monkeypatch
+):
+    """A never-deployed app's first real deployment is news, not a restart-seed.
+
+    Regression: collapsing "never polled this (app, environment)" and "polled
+    it and found nothing yet" both looked like `.get(key) is None`, so the
+    first real deployment for a brand-new app was silently swallowed as if it
+    were an already-known deployment observed right after a bot restart.
+    """
+    rc_calls = {"n": 0}
+
+    async def _lookup(_repo, environment):
+        # Production never has a deployment in this test; only RC's polls
+        # progress, so the assertions below can inspect a single message.
+        if environment != bot.github.RC_ENVIRONMENT:
+            return None
+        rc_calls["n"] += 1
+        return None if rc_calls["n"] == 1 else _deployment(7, "2026.9.2.1", "RC")
+
+    monkeypatch.setattr(bot.github, "latest_successful_deployment", _lookup)
+    state = bot.ReleaseProgressState()
+
+    await bot._announce_deployments(slack_app, repos, state)
+    slack_app.client.chat_postMessage.assert_not_called()
+    assert state.last_deployment[("my-app", "RC")] is None
+
+    await bot._announce_deployments(slack_app, repos, state)
+
+    slack_app.client.chat_postMessage.assert_called_once()
+    text = slack_app.client.chat_postMessage.call_args.kwargs["text"]
+    assert "2026.9.2.1" in text
+    assert state.last_deployment[("my-app", "RC")] == 7
+
+
+@pytest.mark.usefixtures("_no_release_issue")
 async def test_a_failed_post_is_retried_on_the_next_poll(repos, slack_app, monkeypatch):
     """Recording a milestone as announced when the post failed loses it forever."""
     monkeypatch.setattr(

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -212,15 +212,50 @@ class _FakeIssue:
             self.state = kwargs["state"]
 
 
+class _FakeDeploymentStatus:
+    def __init__(self, state, target_url=None):
+        self.state = state
+        self.created_at = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+        self.target_url = target_url
+
+
+class _FakeDeployment:
+    def __init__(self, deployment_id, ref, environment, statuses, sha="deadbeef"):
+        self.id = deployment_id
+        self.ref = ref
+        self.sha = sha
+        self.environment = environment
+        self._statuses = statuses
+
+    def get_statuses(self):
+        return list(self._statuses)
+
+
 class _FakeRepo:
     default_branch = "main"
 
-    def __init__(self, tags=(), comparison=None, commits=(), issues=(), branches=()):
+    def __init__(  # noqa: PLR0913
+        self,
+        tags=(),
+        comparison=None,
+        commits=(),
+        issues=(),
+        branches=(),
+        deployments=(),
+    ):
         self._tags = tags
         self._comparison = comparison
         self._commits = commits
         self._branches = branches
+        self._deployments = deployments
         self._issues = {issue.number: issue for issue in issues}
+
+    def get_deployments(self, environment=None, **_kwargs):
+        return [
+            deployment
+            for deployment in self._deployments
+            if environment in (None, deployment.environment)
+        ]
 
     def get_tags(self):
         return list(self._tags)
@@ -236,10 +271,13 @@ class _FakeRepo:
     def get_commits(self):
         return list(self._commits)
 
-    def get_issues(self, state=None, labels=None):
-        assert state == "open"
+    def get_issues(self, state=None, labels=None, sort=None, direction=None):  # noqa: ARG002
+        assert state in {"open", "all"}
         assert labels == ["release"]
-        return list(self._issues.values())
+        issues = list(self._issues.values())
+        if state == "open":
+            issues = [issue for issue in issues if issue.state == "open"]
+        return issues
 
     def get_issue(self, number):
         return self._issues[number]
@@ -611,3 +649,133 @@ def test_release_tags_warns_when_the_scan_cap_is_reached(
     with caplog.at_level("WARNING"):
         github._release_tags(repo)
     assert "Stopped scanning tags" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# GitHub Deployments
+# ---------------------------------------------------------------------------
+
+
+def test_latest_successful_deployment_reports_the_version_from_the_ref(fake_repo):
+    """The pipeline starts each deployment with ref=<calver>, which is the point.
+
+    A Kubernetes rollout event carries an image tag; this carries the release
+    version, which is what ties the announcement to a release issue.
+    """
+    fake_repo(
+        _FakeRepo(
+            deployments=[
+                _FakeDeployment(
+                    31, "2026.9.2.1", "RC", [_FakeDeploymentStatus("success")]
+                )
+            ]
+        )
+    )
+    deployment = github._latest_successful_deployment_sync("mitodl/thing", "RC")
+    assert deployment["id"] == 31
+    assert deployment["version"] == "2026.9.2.1"
+
+
+def test_latest_successful_deployment_skips_a_failed_newer_deployment(fake_repo):
+    """A failed deploy sits above the last good one, so first-is-newest is wrong."""
+    fake_repo(
+        _FakeRepo(
+            deployments=[
+                _FakeDeployment(
+                    32, "2026.9.2.2", "RC", [_FakeDeploymentStatus("failure")]
+                ),
+                _FakeDeployment(
+                    31, "2026.9.2.1", "RC", [_FakeDeploymentStatus("success")]
+                ),
+            ]
+        )
+    )
+    deployment = github._latest_successful_deployment_sync("mitodl/thing", "RC")
+    assert deployment["version"] == "2026.9.2.1"
+
+
+def test_latest_successful_deployment_reads_only_the_newest_status(fake_repo):
+    """A deploy that failed and was re-run to success counts as successful."""
+    fake_repo(
+        _FakeRepo(
+            deployments=[
+                _FakeDeployment(
+                    31,
+                    "2026.9.2.1",
+                    "RC",
+                    [
+                        _FakeDeploymentStatus("success"),
+                        _FakeDeploymentStatus("failure"),
+                    ],
+                )
+            ]
+        )
+    )
+    assert (
+        github._latest_successful_deployment_sync("mitodl/thing", "RC")["version"]
+        == "2026.9.2.1"
+    )
+
+
+def test_latest_successful_deployment_ignores_other_environments(fake_repo):
+    fake_repo(
+        _FakeRepo(
+            deployments=[
+                _FakeDeployment(
+                    40, "2026.9.2.1", "Production", [_FakeDeploymentStatus("success")]
+                )
+            ]
+        )
+    )
+    assert github._latest_successful_deployment_sync("mitodl/thing", "RC") is None
+
+
+def test_latest_successful_deployment_is_none_when_nothing_succeeded(fake_repo):
+    fake_repo(
+        _FakeRepo(
+            deployments=[
+                _FakeDeployment(
+                    31, "2026.9.2.1", "RC", [_FakeDeploymentStatus("in_progress")]
+                )
+            ]
+        )
+    )
+    assert github._latest_successful_deployment_sync("mitodl/thing", "RC") is None
+
+
+# ---------------------------------------------------------------------------
+# Locating a release issue by version
+# ---------------------------------------------------------------------------
+
+
+def test_release_issue_for_version_matches_the_checklist_header(fake_repo):
+    fake_repo(
+        _FakeRepo(
+            issues=[
+                _FakeIssue(7, "Release app 2026.9.1.1", "## Release 2026.9.1.1", []),
+                _FakeIssue(8, "Release app 2026.9.2.1", CHECKLIST_BODY, []),
+            ]
+        )
+    )
+    issue = github._release_issue_for_version_sync("mitodl/thing", "2026.7.22.1")
+    assert issue["number"] == 8
+
+
+def test_release_issue_for_version_finds_a_closed_issue(fake_repo):
+    """The production milestone fires after the issue was closed to promote.
+
+    An open-only search would find nothing for exactly the announcement that
+    most needs the link.
+    """
+    closed = _FakeIssue(9, "Release app 2026.9.2.1", "## Release 2026.9.2.1", [])
+    closed.edit(state="closed")
+    fake_repo(_FakeRepo(issues=[closed]))
+    issue = github._release_issue_for_version_sync("mitodl/thing", "2026.9.2.1")
+    assert issue["number"] == 9
+
+
+def test_release_issue_for_version_is_none_when_no_issue_matches(fake_repo):
+    fake_repo(
+        _FakeRepo(issues=[_FakeIssue(7, "Release app", "## Release 2026.9.1.1", [])])
+    )
+    assert github._release_issue_for_version_sync("mitodl/thing", "2026.9.9.9") is None


### PR DESCRIPTION
Doof narrated deploys. The new release bot did not: its only proactive message was ready-to-promote, so a release could reach RC, reach production, or fail to reach either, with nothing said in Slack. That silence is what let ol-analytics-api's `releases/2026.8.3.1` sit unmerged from 2026-08-03 with no red build to show for it (recorded in the `prod_post_steps` comment in `k8s_apps/pipeline.py`).

## Deploy milestones

Two messages, restoring what Doof's `_wait_for_deploy_rc` / `_wait_for_deploy_prod` posted:

- `🚢 \`app\` 2026.9.2.1 is deployed to RC. <Release issue> Check off your items once you have verified them.`
- `🎉 \`app\` 2026.9.2.1 is live in production. <Release issue>`

The source is the GitHub Deployments the pipeline already records per environment. `_build_release_resource_app_pipeline` starts each with `ref: ((.:image_tag))`, loaded from the release resource's version file, so the deployment carries the calver version — and therefore the release issue. A Kubernetes rollout event has only an image tag. Linking the issue is the specific gap pdpinch named in [RFC hq#10465](https://github.com/mitodl/hq/discussions/10465): the kubewatch posts "don't have the information that I need (e.g., what's in the release that just went to production)".

**This does not replace or duplicate kubewatch-webhook-handler.** kubewatch reports *rollouts* for every workload, routed by the `ol.mit.edu/slack-channel` pod label and falling back to its own `DEFAULT_SLACK_CHANNEL` when a workload has no such label. This reports *releases*, in the product channel from `bridge.settings.apps`. They only collide if a team labels its workload with the same product channel, which is a per-workload choice rather than something to arbitrate here.

## Stalled releases

Doof nagged on a deploy timeout and re-nagged every 24h; that nag was the only thing that made a stuck deploy visible in Slack. Restored, after `RELEASE_STUCK_AFTER_HOURS` (default 24h) and re-reported at most daily, distinguishing three states that need to read differently:

- has not reached RC
- deployed to RC, waiting on promotion
- **reached production but the release never finished** — the branch outliving its deploy freezes the calver counter, so the next release collides with that version

## Restart behavior

The poller announces transitions, so it seeds its first observation of each app rather than starting from an empty map — otherwise every bot restart would replay every app's current RC and production deployment into the channel. The cost is at most one missed announcement if the bot restarts between a deploy landing and the next poll, which is the cheaper of the two failures for a channel people are supposed to trust. A failed Slack post puts the previous deployment id back so the next cycle retries rather than recording the milestone as announced. Stuck-release nags are deliberately *not* seeded: a stuck release is still stuck after a restart.

## Verification

- `uv run pytest tests/ol_infrastructure/applications/release_bot/` — 88 passed, up from 70 on `main` (18 new)
- `pre-commit run --files <changed>` — ruff, ruff-format, mypy, detect-secrets all pass

Not verified: no message from this code has been sent to a live Slack channel, and no `pulumi preview` was run. `release_bot:release_stuck_after_hours` is unset, and the env var is only appended when it is set, so the stack is expected to show no diff — expected, not confirmed against a preview.

Part of https://github.com/mitodl/hq/issues/7185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4BxeTCBQLTb2KJrWqzXon
