### PR TITLE
revert: roll back hardened ol-python-base rebase (unblocks releases)

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -9,8 +9,7 @@ This directory contains Dockerfiles for MIT Open Learning services.
 Published as `mitodl/ol-python-base:{3.11,3.12,3.13}` via the Concourse pipeline at
 [`pipelines/infrastructure/ol_python_base_docker.yaml`](../pipelines/infrastructure/ol_python_base_docker.yaml).
 
-Bakes the substrate every app Dockerfile previously duplicated: hardened Python
-(Docker Hardened Images `-dev` variant, Debian 13; pulls require `docker login dhi.io`), common-core
+Bakes the substrate every app Dockerfile previously duplicated: Python slim, common-core
 apt packages, the `uv` binary, non-root `mitodl` user, `/opt/venv` + `UV_CACHE_DIR`
 env vars. App Dockerfiles do `FROM mitodl/ol-python-base:<python-version>` and add only
 app-specific layers.

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -2,21 +2,12 @@
 # Shared Python base image for MIT Open Learning services.
 #
 # Bakes the substrate that every Python app Dockerfile previously duplicated:
-# hardened Python, the common-core apt packages, the uv binary, a non-root
-# `mitodl` user, and the /opt/venv environment configuration. App images do
+# slim Python, the common-core apt packages, the uv binary, a non-root `mitodl`
+# user, and the /opt/venv environment configuration. App images do
 # `FROM mitodl/ol-python-base:<python-version>` and add only their app-specific
 # layers (extra apt, node build stages, project source, run command).
 #
-# The base is Docker Hardened Images' Python `-dev` variant (Debian 13/trixie):
-# near-zero-CVE, continuously rebuilt, signed provenance. The `-dev` variant is
-# deliberate — it keeps the shell and apt that this build (and downstream app
-# builds and dev stages) depend on; the shell-less runtime variant is only for
-# per-app production stages (see the hardened-images RFC). Note that dhi.io
-# denies anonymous pulls, so building this image requires `docker login dhi.io`
-# first (any Docker account works; CI uses the dockerhub service credentials).
-#
 # Build:
-#   docker login dhi.io
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 # Multi-arch build (published for both amd64 and arm64/Apple Silicon; --push
 # is required since a multi-platform result can't be loaded into the local
@@ -24,7 +15,7 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 --push \
 #     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
-FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev
+FROM python:${PYTHON_VERSION}-slim
 
 LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
@@ -33,10 +24,6 @@ LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 # own Dockerfile / apt.txt.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      # adduser is absent from the DHI dev image's curated package set
-      # (python:X-slim shipped it implicitly); required by the mitodl user
-      # creation below.
-      adduser \
       build-essential \
       ca-certificates \
       curl \
@@ -51,13 +38,6 @@ RUN apt-get update && \
       zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# DHI's Python is Debian-packaged (`python3` in /usr/bin) rather than the
-# python.org /usr/local layout that python:X-slim used, and Debian packaging
-# ships no bare `python` binary. Provide one for downstream Dockerfiles and
-# scripts that expect it. Guarded so this stays a no-op if a future base adds
-# its own.
-RUN command -v python >/dev/null 2>&1 || ln -s "$(command -v python3)" /usr/local/bin/python
 
 # Install uv (pinned via the upstream tag; bump deliberately).
 COPY --from=ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 /uv /uvx /usr/local/bin/

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -11,21 +11,12 @@
 # near-zero-CVE, continuously rebuilt, signed provenance. The `-dev` variant is
 # deliberate — it keeps the shell and apt that this build (and downstream app
 # builds and dev stages) depend on; the shell-less runtime variant is only for
-# per-app production stages (see the hardened-images RFC).
-#
-# This pulls mitodl/dhi-python-mirror, NOT dhi.io directly. DHI's images carry
-# zstd-compressed layers; single-platform downstream builds (nearly every app
-# image built FROM this base) silently mislabel those as gzip when they push
-# through Docker's legacy manifest format, which has no field to declare
-# anything else — and Concourse's registry-image resource then fails trying
-# to gzip-decode the real zstd bytes. The ol-python-base Concourse pipeline
-# mirrors dhi.io into this repo with every layer forced to genuinely, not
-# just nominally, gzip before this Dockerfile ever builds — see
-# mirror_dhi_python_base_task in
-# src/ol_concourse/pipelines/container_images/ol_python_base.py for the full
-# mechanism and how this was confirmed.
+# per-app production stages (see the hardened-images RFC). Note that dhi.io
+# denies anonymous pulls, so building this image requires `docker login dhi.io`
+# first (any Docker account works; CI uses the dockerhub service credentials).
 #
 # Build:
+#   docker login dhi.io
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 # Multi-arch build (published for both amd64 and arm64/Apple Silicon; --push
 # is required since a multi-platform result can't be loaded into the local
@@ -33,7 +24,7 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 --push \
 #     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
-FROM mitodl/dhi-python-mirror:${PYTHON_VERSION}-debian13-dev
+FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev
 
 LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -33,49 +33,10 @@ ol_infrastructure_repo = git_repo(
 # Upstream Docker Hardened Images bases (see the hardened-images RFC). These
 # resources exist to trigger rebuilds whenever Docker ships a CVE-patched
 # rebuild of the base — without them the hardening silently decays between
-# Dockerfile edits.
-#
-# The build does NOT pull dhi.io directly. DHI's images carry zstd-compressed
-# layers for anything Docker built and we didn't modify; buildkit's OCI
-# exporter (which oci-build-task uses, with no documented option to
-# override — confirmed by reading its source: neither the Config struct nor
-# the buildctl invocation it shells out to expose a compression flag)
-# preserves that original compression for pass-through layers rather than
-# recompressing everything to match the new layers it adds.
-#
-# That alone is survivable — Concourse's registry-image resource genuinely
-# can decode OCI zstd-labeled layers (verified by reading its source,
-# commands/rootfs.go, at v1.18.0, the version bundled with our pinned
-# Concourse 8.3.0: it has an explicit case for the OCI zstd media type using
-# klauspost/compress/zstd). The actual break is one step further downstream.
-# oci-build-task only requests OCI-format output (which can *label* a zstd
-# layer correctly) when a build sets IMAGE_PLATFORM for multiple platforms;
-# any single-platform build — i.e. nearly every k8s_apps app image, unlike
-# this multi-arch ol-python-base build — defaults to Docker's legacy
-# manifest format instead (verified: oci-build-task's task.go hardcodes
-# `outputType := "docker"` unless multi-platform output forces OCI). That
-# legacy format's manifest.json has no per-layer media-type field at all —
-# there is no way to *declare* a layer zstd — so oci-build-task's loader for
-# that path (tarball.ImageFromPath, go-containerregistry's legacy reader)
-# pushes DHI's still-zstd-compressed bytes under the implicit legacy
-# "tar.gzip" label, silently mislabeling them rather than transcoding them.
-# Confirmed directly: `docker manifest inspect --verbose` on the exact
-# learn-ai-app digest that failed the canary showed every layer declared as
-# application/vnd.docker.image.rootfs.diff.tar.gzip — Docker's legacy gzip
-# media type — despite carrying DHI's genuinely zstd-compressed bytes
-# through unchanged. registry-image resource correctly trusts that label,
-# tries gzip.NewReader on real zstd bytes, and fails with exactly the
-# "gzip: invalid header" error that broke the canary build.
-#
-# mirror_dhi_python_base_task fixes this once, upstream of every consumer:
-# it mirrors dhi.io into mitodl/dhi-python-mirror using skopeo's
-# --dest-force-compress-format, which forces every layer — including ones
-# copied verbatim from the source — to genuinely, not just nominally, gzip.
-# Verified locally against the real dhi.io/python image: zstd layers came
-# out uniformly gzip after the copy. With no zstd bytes left anywhere in the
-# chain, there's nothing left for any downstream build's legacy-format
-# output to mislabel, regardless of whether that build is single- or
-# multi-platform.
+# Dockerfile edits. The build itself pulls the base straight from dhi.io
+# (authenticated via the docker config written by dhi_docker_config_task;
+# dhi.io denies anonymous pulls, and feeding the fetched image in via
+# IMAGE_ARG would collapse the multi-arch build to a single platform).
 dhi_python_base_resources = {
     version: registry_image(
         name=Identifier(f"dhi-python-{version.replace('.', '')}-image"),
@@ -87,62 +48,18 @@ dhi_python_base_resources = {
     for version in PYTHON_VERSIONS
 }
 
-DHI_MIRROR_REPOSITORY = "mitodl/dhi-python-mirror"
 
+def dhi_docker_config_task() -> TaskStep:
+    """Write a docker config authorizing pulls from dhi.io.
 
-def mirror_dhi_python_base_task(python_version: str) -> TaskStep:
-    """Mirror the DHI Python dev image with layers forced to gzip.
-
-    skopeo takes registry credentials directly as flags, so unlike the
-    docker-config dance below (needed because oci-build-task has no
-    credential flags of its own), this task needs no separate config file.
-    """
-    tag = f"{python_version}-debian13-dev"
-    return TaskStep(
-        task=Identifier(f"mirror-dhi-python-{python_version.replace('.', '')}"),
-        config=TaskConfig(
-            platform=Platform.linux,
-            image_resource=AnonymousResource(
-                type=REGISTRY_IMAGE,
-                source={"repository": "quay.io/skopeo/stable", "tag": "latest"},
-            ),
-            params={
-                "DHI_USERNAME": "((dockerhub.username))",
-                "DHI_PASSWORD": "((dockerhub.password))",
-            },
-            run=Command(
-                path="sh",
-                # -e only: -x would echo the credentials into the build log.
-                args=[
-                    "-ec",
-                    (
-                        "skopeo copy --all"
-                        ' --src-creds="$DHI_USERNAME:$DHI_PASSWORD"'
-                        ' --dest-creds="$DHI_USERNAME:$DHI_PASSWORD"'
-                        " --dest-compress-format=gzip"
-                        " --dest-force-compress-format"
-                        f" docker://dhi.io/python:{tag}"
-                        f" docker://{DHI_MIRROR_REPOSITORY}:{tag}"
-                    ),
-                ],
-            ),
-        ),
-    )
-
-
-def dockerhub_docker_config_task() -> TaskStep:
-    """Write a docker config authorizing pulls from Docker Hub.
-
-    Needed so the build's `FROM mitodl/dhi-python-mirror:...` pull is
-    authenticated regardless of that repo's default visibility — cheaper
-    than depending on a Docker Hub visibility setting staying put. oci-build-
-    task resolves FROM-image credentials through the standard docker config
-    machinery, honoring the DOCKER_CONFIG env var, so the build task consumes
-    this task's output directory via DOCKER_CONFIG=docker-config.
+    oci-build-task resolves FROM-image credentials through the standard
+    docker config machinery, honoring the DOCKER_CONFIG env var, so the
+    build task consumes this task's output directory via
+    DOCKER_CONFIG=docker-config.
     """
     docker_config = Output(name=Identifier("docker-config"))
     return TaskStep(
-        task=Identifier("write-dockerhub-docker-config"),
+        task=Identifier("write-dhi-docker-config"),
         config=TaskConfig(
             platform=Platform.linux,
             image_resource=AnonymousResource(
@@ -155,8 +72,8 @@ def dockerhub_docker_config_task() -> TaskStep:
             ),
             outputs=[docker_config],
             params={
-                "DOCKERHUB_USERNAME": "((dockerhub.username))",
-                "DOCKERHUB_PASSWORD": "((dockerhub.password))",
+                "DHI_USERNAME": "((dockerhub.username))",
+                "DHI_PASSWORD": "((dockerhub.password))",
             },
             run=Command(
                 path="sh",
@@ -164,11 +81,10 @@ def dockerhub_docker_config_task() -> TaskStep:
                 args=[
                     "-ec",
                     (
-                        'auth="$(printf \'%s:%s\' "$DOCKERHUB_USERNAME"'
-                        ' "$DOCKERHUB_PASSWORD" | base64 | tr -d \'\\n\')"\n'
-                        'printf \'{"auths": {"https://index.docker.io/v1/":'
-                        ' {"auth": "%s"}}}\' "$auth"'
-                        f" > {docker_config.name}/config.json\n"
+                        'auth="$(printf \'%s:%s\' "$DHI_USERNAME"'
+                        ' "$DHI_PASSWORD" | base64 | tr -d \'\\n\')"\n'
+                        'printf \'{"auths": {"dhi.io": {"auth": "%s"}}}\''
+                        f' "$auth" > {docker_config.name}/config.json\n'
                     ),
                 ],
             ),
@@ -209,8 +125,7 @@ def build_job(python_version: str) -> Job:
                 get=dhi_python_base_resources[python_version].name,
                 trigger=True,
             ),
-            mirror_dhi_python_base_task(python_version),
-            dockerhub_docker_config_task(),
+            dhi_docker_config_task(),
             container_build_task(
                 inputs=[
                     Input(name=ol_infrastructure_repo.name),

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -1,24 +1,17 @@
 import sys
 
-from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.pipeline import (
-    AnonymousResource,
-    Command,
     GetStep,
     Identifier,
     Input,
     Job,
-    Output,
     Pipeline,
-    Platform,
     PutStep,
-    TaskConfig,
-    TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
-from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+from ol_concourse.pipelines.constants import ECR_REGION
 from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 PYTHON_VERSIONS = ("3.11", "3.12", "3.13", "3.14")
@@ -29,68 +22,6 @@ ol_infrastructure_repo = git_repo(
     branch="main",
     paths=["dockerfiles/ol-python-base/Dockerfile"],
 )
-
-# Upstream Docker Hardened Images bases (see the hardened-images RFC). These
-# resources exist to trigger rebuilds whenever Docker ships a CVE-patched
-# rebuild of the base — without them the hardening silently decays between
-# Dockerfile edits. The build itself pulls the base straight from dhi.io
-# (authenticated via the docker config written by dhi_docker_config_task;
-# dhi.io denies anonymous pulls, and feeding the fetched image in via
-# IMAGE_ARG would collapse the multi-arch build to a single platform).
-dhi_python_base_resources = {
-    version: registry_image(
-        name=Identifier(f"dhi-python-{version.replace('.', '')}-image"),
-        image_repository="dhi.io/python",
-        image_tag=f"{version}-debian13-dev",
-        username="((dockerhub.username))",
-        password="((dockerhub.password))",  # noqa: S106
-    )
-    for version in PYTHON_VERSIONS
-}
-
-
-def dhi_docker_config_task() -> TaskStep:
-    """Write a docker config authorizing pulls from dhi.io.
-
-    oci-build-task resolves FROM-image credentials through the standard
-    docker config machinery, honoring the DOCKER_CONFIG env var, so the
-    build task consumes this task's output directory via
-    DOCKER_CONFIG=docker-config.
-    """
-    docker_config = Output(name=Identifier("docker-config"))
-    return TaskStep(
-        task=Identifier("write-dhi-docker-config"),
-        config=TaskConfig(
-            platform=Platform.linux,
-            image_resource=AnonymousResource(
-                type=REGISTRY_IMAGE,
-                source={
-                    "repository": dockerhub_ecr_image_uri("alpine"),
-                    "tag": "latest",
-                    "aws_region": ECR_REGION,
-                },
-            ),
-            outputs=[docker_config],
-            params={
-                "DHI_USERNAME": "((dockerhub.username))",
-                "DHI_PASSWORD": "((dockerhub.password))",
-            },
-            run=Command(
-                path="sh",
-                # -e only: -x would echo the credentials into the build log.
-                args=[
-                    "-ec",
-                    (
-                        'auth="$(printf \'%s:%s\' "$DHI_USERNAME"'
-                        ' "$DHI_PASSWORD" | base64 | tr -d \'\\n\')"\n'
-                        'printf \'{"auths": {"dhi.io": {"auth": "%s"}}}\''
-                        f' "$auth" > {docker_config.name}/config.json\n'
-                    ),
-                ],
-            ),
-        ),
-    )
-
 
 image_resources = {
     version: registry_image(
@@ -121,22 +52,11 @@ def build_job(python_version: str) -> Job:
         public=True,
         plan=[
             GetStep(get=ol_infrastructure_repo.name, trigger=True),
-            GetStep(
-                get=dhi_python_base_resources[python_version].name,
-                trigger=True,
-            ),
-            dhi_docker_config_task(),
             container_build_task(
-                inputs=[
-                    Input(name=ol_infrastructure_repo.name),
-                    Input(name=Identifier("docker-config")),
-                ],
+                inputs=[Input(name=ol_infrastructure_repo.name)],
                 build_parameters={
                     "CONTEXT": context,
                     "BUILD_ARG_PYTHON_VERSION": python_version,
-                    # Auth for the dhi.io FROM pull; written by
-                    # dhi_docker_config_task above.
-                    "DOCKER_CONFIG": "docker-config",
                     # Cross-build linux/arm64 via QEMU emulation (workers have
                     # qemu-user-static/binfmt-support installed) so Apple
                     # Silicon can pull a native image. Multiple platforms
@@ -164,7 +84,6 @@ def build_job(python_version: str) -> Job:
 ol_python_base_pipeline = Pipeline(
     resources=[
         ol_infrastructure_repo,
-        *dhi_python_base_resources.values(),
         *image_resources.values(),
         *ecr_image_resources.values(),
     ],


### PR DESCRIPTION
### What are the relevant tickets?
Urgent revert to unblock releases. Reverts [#5698](https://github.com/mitodl/ol-infrastructure/pull/5698) (Tier 1: rebase `ol-python-base` onto Docker Hardened Images) and [#5712](https://github.com/mitodl/ol-infrastructure/pull/5712) (mirror fix for the resulting compression bug). RFC: https://github.com/mitodl/hq/discussions/13121

### Description (What does it do?)
`ol-python-base` builds are currently broken in production, blocking app releases: the pipeline tries to mirror `dhi.io`'s base image into `mitodl/dhi-python-mirror` before building, and that push is denied —

```
FATA[0001] copying image 1/2 from manifest list: writing blob: initiating layer upload to /v2/mitodl/dhi-python-mirror/blobs/uploads/ in registry-1.docker.io: requested access to the resource is denied
```

— because the Docker Hub credentials used can push to existing repos (like `mitodl/ol-python-base` itself) but can't create a brand-new one. That's a Docker Hub permission/repo-creation issue outside this repo, not something a code change fixes.

This PR reverts **both** #5698 and #5712, using `git revert` on each merge commit (newest first, clean — no conflicts), restoring `dockerfiles/ol-python-base/Dockerfile`, `src/ol_concourse/pipelines/container_images/ol_python_base.py`, and `dockerfiles/README.md` to their exact pre-Tier-1 state. Verified byte-for-byte: `git diff fa104b2b1~1 HEAD -- <these 3 files>` is empty.

Reverting only #5712 (the mirror fix) and leaving #5698 in place was considered and rejected: #5698 alone is *also* broken — it's what caused the original mislabeled-zstd-layer failure that #5712 was written to fix (see #5712's description for the full mechanism). A partial revert would leave releases blocked in a different way, just with a different error. Going all the way back to `FROM python:${PYTHON_VERSION}-slim` is the only state confirmed working before any of this hardened-image work started.

### How can this be tested?
1. Pre-commit passes clean on all three reverted files (ruff, mypy, hadolint, detect-secrets).
2. Diff confirms an exact match against the pre-#5698 commit for every file this reverts.
3. After merge: re-trigger the `ol-python-base-docker` pipeline (or let the `container-images-meta` pipeline re-register it) and confirm a normal build/push succeeds, then re-trigger whatever app release(s) are currently blocked.

### Additional Context
Not a draft — this is blocking releases right now. The hardened-base-image effort isn't abandoned: the RFC and the underlying goal stand, but the path taken (mirror-then-build) hit a real infrastructure permission blocker that needs to be resolved outside of code before trying again. [Issue #5714](https://github.com/mitodl/ol-infrastructure/issues/5714) (switching to `OUTPUT_OCI` instead of mirroring) is also worth reconsidering once this is unblocked, since it avoids needing a new Docker Hub repo at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
