### PR TITLE
feat(bin): check which repos ol-release-bot is actually installed on

### DIFF
--- a/bin/release-bot-installation-check
+++ b/bin/release-bot-installation-check
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Report which repos the ol-release-bot GitHub App is actually installed on.
+
+A ruleset bypass actor entry and an App installation are independent facts:
+GitHub stores an Integration bypass actor for an App that has no access to the
+repo at all. `release_workflow_repos()` grants the bypass on every registered
+app ahead of the rollout, so the bypass list says nothing about installation.
+
+This matters at exactly one moment. Flipping an app to
+`use_release_resource_workflow=True` on a repo the App is not installed on
+fails in `action: finish` at *authentication* -- the installation token mint or
+the git push credential -- not on rules. That failure looks nothing like the
+GH013 ruleset rejection everyone will be expecting, and will be misdiagnosed.
+
+Why this needs its own script: the installed-repo list is unreachable from a
+`gh auth` token. `GET /repos/{owner}/{repo}/installation` needs an App JWT;
+`GET /user/installations/{id}/repositories` needs a token authorized to
+*ol-release-bot itself*, which the GitHub CLI's user-to-server token is not,
+regardless of scopes. Only the App's own credentials answer the question, so
+this mints a short-lived App JWT from the sops-encrypted PEM.
+
+The JWT is App-level and read-only here: it authenticates as the App to ask
+"are you installed on this repo", and is never exchanged for an installation
+token, so this cannot write anything.
+
+Usage:
+    uv run bin/release-bot-installation-check
+    uv run bin/release-bot-installation-check --json
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+import requests
+from github import Auth
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bridge.secrets.sops import read_yaml_secrets
+from bridge.settings.apps import APPS
+from bridge.settings.apps import github_repo as app_github_repo
+
+app = cyclopts.App(
+    help="Check which repos the ol-release-bot GitHub App is installed on."
+)
+
+_SECRETS_PATH = Path("concourse/operations.production.yaml")
+_API = "https://api.github.com"
+_TIMEOUT = 30
+
+
+def _app_jwt() -> str:
+    secrets = read_yaml_secrets(_SECRETS_PATH)["pipelines"]["shared/github_app"]
+    return Auth.AppAuth(
+        int(secrets["release_bot_app_id"]), secrets["release_bot_app_pem"]
+    ).create_jwt()
+
+
+def _installation_id(repo: str, jwt: str) -> int | None:
+    """Return the installation id on *repo*, or None if the App is not installed."""
+    response = requests.get(
+        f"{_API}/repos/{repo}/installation",
+        headers={
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=_TIMEOUT,
+    )
+    if response.status_code == requests.codes.not_found:
+        return None
+    response.raise_for_status()
+    return response.json()["id"]
+
+
+@app.default
+def check(
+    *,
+    as_json: Annotated[
+        bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
+    ] = False,
+) -> int:
+    """Report installation status for every repo in the app registry."""
+    jwt = _app_jwt()
+    # Two app entries can share one repo (mit-learn / mit-learn-nextjs), and the
+    # answer is a property of the repo, so ask once per repo.
+    repos = sorted({app_github_repo(name) for name in APPS})
+    results = {repo: _installation_id(repo, jwt) for repo in repos}
+
+    if as_json:
+        print(json.dumps(results, indent=2))
+    else:
+        for repo, installation_id in results.items():
+            mark = "installed" if installation_id else "NOT INSTALLED"
+            suffix = f" (installation {installation_id})" if installation_id else ""
+            print(f"{mark:>14}  {repo}{suffix}")
+
+    missing = [repo for repo, installation_id in results.items() if not installation_id]
+    if missing:
+        print(
+            f"\n{len(missing)} repo(s) missing. Add them at "
+            "https://github.com/organizations/mitodl/settings/installations/150138801"
+            " before flipping their pipeline.",
+            file=sys.stderr,
+        )
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/release-bot-installation-check
+++ b/bin/release-bot-installation-check
@@ -81,7 +81,7 @@ def check(
     as_json: Annotated[
         bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
     ] = False,
-) -> int:
+) -> None:
     """Report installation status for every repo in the app registry."""
     jwt = _app_jwt()
     # Two app entries can share one repo (mit-learn / mit-learn-nextjs), and the
@@ -99,13 +99,16 @@ def check(
 
     missing = [repo for repo, installation_id in results.items() if not installation_id]
     if missing:
+        # sys.exit rather than `return 1`: cyclopts discards a handler's return
+        # value, so returning a status here would exit 0 and a CI gate built on
+        # this script would pass while reporting missing repos.
         print(
             f"\n{len(missing)} repo(s) missing. Add them at "
             "https://github.com/organizations/mitodl/settings/installations/150138801"
             " before flipping their pipeline.",
             file=sys.stderr,
         )
-    return 1 if missing else 0
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A ruleset bypass actor entry and a GitHub App installation are independent facts, and the release-workflow rollout has been treating the first as evidence of the second. `release_workflow_repos()` deliberately grants the bypass on every registered app ahead of the rollout, so the bypass list says nothing at all about installation.

**Running this found a live instance.** `mitodl/ocw-studio` has Integration `4437866` (ol-release-bot) as a `bypass_mode: always` actor on its `baseline-default-branch` ruleset — and the App is not installed on the repo:

```
     installed  mitodl/learn-ai (installation 150138801)
     installed  mitodl/micromasters (installation 150138801)
     installed  mitodl/mit-learn (installation 150138801)
     installed  mitodl/mitxonline (installation 150138801)
     installed  mitodl/mitxpro (installation 150138801)
 NOT INSTALLED  mitodl/ocw-studio
     installed  mitodl/odl-video-service (installation 150138801)
     installed  mitodl/ol-analytics-api (installation 150138801)
```

Flipping ocw-studio to `use_release_resource_workflow=True` would have failed in `action: finish` at *authentication* — the installation token mint or the git push credential — not on rules. That failure looks nothing like the GH013 ruleset rejection anyone would be expecting, and would have been misdiagnosed as a bypass problem that was in fact already correct.

## Why a script rather than a `gh` one-liner

No `gh auth` token can answer this:

- `GET /repos/{owner}/{repo}/installation` → 401, needs an App JWT
- `GET /user/installations` and `/user/installations/{id}/repositories` → 403 "must authenticate with an access token authorized to a GitHub App". This means authorized to **ol-release-bot itself**; the GitHub CLI's user-to-server token is authorized to the GitHub CLI app, so it fails at any scope. `read:user` does not help, despite what gh's hint says.
- `GET /orgs/mitodl/installations` returns the installation, but its `repositories_url` is the generic `https://api.github.com/installation/repositories`, which only resolves under an installation token.

So the script mints an App-level JWT from the sops-encrypted PEM (`concourse/operations.production.yaml`, `pipelines.shared/github_app`). The JWT is only ever used to ask "are you installed on this repo" and is never exchanged for an installation token, so the script cannot write anything. It iterates the distinct repos in `bridge.settings.apps.APPS` (8 repos for 9 app entries — mit-learn and mit-learn-nextjs share one repo) and exits non-zero naming any that are missing.

The second commit is a bug the claim audit on this PR body caught: cyclopts discards a handler's return value, so the original `return 1 if missing else 0` exited 0. Verified directly against cyclopts, not assumed. A CI gate built on the first commit would have passed while printing that repos were missing.

## Follow-up, not in this PR

Adding ocw-studio to the installation is an org-owner action: https://github.com/organizations/mitodl/settings/installations/150138801 → Repository access. (I did not attempt the REST route for it, since it is a privileged write; whether a user token can drive it is untested.)

Also worth recording from the installation metadata: the App holds `contents: write, deployments: write, issues: write, metadata: read, **pull_requests: read**`. Read-only PRs are fine for today's bypass-based `finish`, but they foreclose any fallback where the App opens or merges its own PR on the default branch.

Part of https://github.com/mitodl/hq/issues/7185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4BxeTCBQLTb2KJrWqzXon
