### PR TITLE
Enable Typesense forum search for master/verawood CI+QA environments

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -139,7 +139,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitx-staging
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -140,7 +140,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitx-staging
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -150,7 +150,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitx
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -151,7 +151,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitx
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -158,7 +158,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitxonline
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -160,7 +160,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: mitxonline
     mfe_apps:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -119,7 +119,7 @@ config:
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
-  typesense:forum_search_enabled: "false"
+  typesense:forum_search_enabled: "true"
   edxapp:site_project:
     deployment: xpro
     mfe_apps:


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Sets `typesense:forum_search_enabled: "true"` on the seven CI/QA edxapp stacks whose release line ships the fixed forum package. One line per file, no code changes.

- [mitodl/lehrer#208](https://github.com/mitodl/lehrer/pull/208) merged, so `deployments/mit-ol/build_manifest.yaml` now installs forum from the branch behind [openedx/forum#289](https://github.com/openedx/forum/pull/289) on six of its seven cells: `master × {mitxonline, mitx, mitx-staging}` and `verawood × {mitx, mitx-staging, xpro}`.
- Before that, this toggle could not be turned on anywhere. The released backend is non-functional as shipped, with two independent defects: `per_page=1000` against Typesense's hard cap of 250 (HTTP 422 on *every* search), and a topic filter naming `commentable_ids` where the collection schema declares `commentable_id` (HTTP 400 on topic-scoped searches).
- That is the likely explanation for what happened in April 2026. `87fcc0559` ([#4501](https://github.com/mitodl/ol-infrastructure/pull/4501), 2026-04-21 11:04) enabled Typesense and set this key to `"true"` on mitxonline CI; `d6c2824ee` set it back to `"false"` 48 minutes later with no reason recorded; `386057f69` then rolled Typesense out to more environments at 13:48 the same day, deliberately keeping the forum key `"false"`. It has stayed off everywhere since.
- Flipped: `mitx.CI`, `mitx.QA`, `mitx-staging.CI`, `mitx-staging.QA`, `mitxonline.CI`, `mitxonline.QA`, `xpro.CI`. Derived by cross-referencing the env→release map in [`version_matrix.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/openedx/version_matrix.py#L12-L47) against the manifest cells.
- **Not flipped: `xpro.QA`.** It runs `ulmo`, and that cell still pins `openedx-forum==0.4.1` in its overrides: the manifest's `release_python` is `ulmo: '3.11'` against `master`/`verawood` at `'3.12'`, and forum master dropped 3.11. Turning this on would put xpro QA on the unfixed backend. It stays on Elasticsearch.
- Production is untouched in all four deployments.

All seven already had `typesense:enabled: "true"`, so the new value is reached at [`k8s_configmaps.py#L292-L293`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py#L292-L293), which sets `FORUM_SEARCH_BACKEND` to `forum.search.typesense.TypesenseBackend`.

### How can this be tested?

Nothing has been applied and no search has been run. The only verification so far is a preview.

`pulumi preview --stack mitxonline.CI --diff` renders the expected change in the interpolated configmap:

```
+ FORUM_SEARCH_BACKEND : "forum.search.typesense.TypesenseBackend"
  TYPESENSE_ENABLED    : true
```

The preview then aborts on an unset `EDXAPP_DOCKER_IMAGE_DIGEST`, which is supplied by the pipeline and unrelated to this change.

To validate:

1. Apply an edxapp CI stack and confirm the pods restarted and the new value is live in the running process, not just merged.
2. Run `rebuild_forum_indices` for that environment.
3. Search in the LMS discussions UI. The failure mode is total rather than partial (HTTP 422 on every query), so a broken environment is obvious on the first search.
4. Repeat per environment. Do not promote to Production until CI and QA have been observed working.

### Additional Context

- `xpro.QA` staying on Elasticsearch is deliberate, not an oversight. Worth confirming that is the reviewer's read too, since it is the one asymmetry in the diff.
- Known gaps in the Typesense backend even once working, per its own source comments: `get_suggested_text()` returns `None`, so there is no "did you mean" spelling correction that the Elasticsearch backend provides via phrase suggesters; `group_ids` and `sort_criteria` are unsupported. These need product sign-off before Production, not before this PR.
- Once openedx/forum#289 merges and releases, the git override in lehrer must be removed so edx-platform's pin carries the dependency. A git direct reference wins silently over a pin, so a stale override would hold us on a dead branch with nothing flagging it.
