### PR TITLE
feat(mit-learn): wire StarRocks credentials so the certificate sync can run

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -154,6 +154,8 @@ config:
     SENTRY_TRACES_SAMPLE_RATE: "0.001"
     SESSION_COOKIE_NAME: "session_mitlearn"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
+    STARROCKS_HOST: "mysql.lakehouse.starrocks.ol.mit.edu"
+    STARROCKS_PORT: 9030
     TIKA_SERVER_ENDPOINT: "https://tika-production.ol.mit.edu"
     UWSGI_THREADS: 15
     UWSGI_WORKERS: 3

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -119,6 +119,16 @@ config:
     SESSION_COOKIE_NAME: "session_mitlearn_rc"
     SHOW_OCW_LECTURE_VIDEOS: "true"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
+    # STARROCKS_HOST/STARROCKS_PORT are deliberately unset here, even though
+    # QA has both a StarRocks cluster and the Vault mount behind it.
+    # SyncProgramCertificatesTask pins its view_name to the
+    # ol_data_lake_production catalog with no setting to override it, and QA's
+    # StarRocks registers that catalog too -- so setting the host here would
+    # not rehearse the sync against QA data, it would replicate production
+    # learner PII (gender, year of birth, country, city, street address,
+    # postal code) into the RC database. mit-learn declines to register the
+    # beat entry while these are unset, which is the behaviour we want.
+    # Set them once the view name is environment-aware.
     TIKA_SERVER_ENDPOINT: "https://tika-qa.ol.mit.edu"
     UWSGI_THREADS: 15
     UWSGI_WORKERS: 3

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -67,12 +67,14 @@ from ol_infrastructure.components.services.k8s import (
     OLApplicationK8sCeleryBeatConfig,
     OLApplicationK8sCeleryWorkerConfig,
     OLApplicationK8sConfig,
+    application_deployment_names,
 )
 from ol_infrastructure.components.services.vault import (
     OLVaultDatabaseBackend,
     OLVaultK8SResources,
     OLVaultK8SResourcesConfig,
     OLVaultPostgresDatabaseConfig,
+    OLVaultRestartTarget,
 )
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import (
@@ -1529,35 +1531,6 @@ redis_cache = OLAmazonCache(
     ),
 )
 
-# Dynamic StarRocks credentials for the warehouse-pull catalog ETL, minted per
-# environment from Vault's `database-starrocks` mount. The mount name is not
-# environment-qualified because QA and Production each run their own separate
-# Vault server, and that is what scopes the environment.
-#
-# STARROCKS_HOST is the single switch for the whole feature. Setting it in a
-# stack's `mitlearn:vars` is what makes mit-learn register the warehouse-pull
-# beat entries (it requires STARROCKS_HOST and STARROCKS_USER together), so
-# minting credentials for a stack that has no host would rotate a StarRocks
-# user on every refresh for nothing. Only CI lacks a StarRocks cluster
-# entirely; QA has one but is held back for the reason recorded in
-# Pulumi.QA.yaml.
-starrocks_vault_mount_path = (
-    "database-starrocks" if env_vars.get("STARROCKS_HOST") else None
-)
-
-# Create all Kubernetes secrets needed by the application
-secret_names, secret_resources = create_mitlearn_k8s_secrets(
-    stack_info=stack_info,
-    mitlearn_namespace=learn_namespace,
-    k8s_global_labels=k8s_app_labels,
-    vault_k8s_resources=vault_k8s_resources,
-    mitlearn_vault_mount=mitlearn_vault_mount,
-    db_config=mitlearn_vault_backend,  # Use the original DB config object
-    redis_password=redis_config.require("password"),
-    redis_cache=redis_cache,
-    starrocks_vault_mount_path=starrocks_vault_mount_path,
-)
-
 # KEDA webapp autoscaling: scale on APISIX request-rate + p95 latency
 # (CPU backstop) instead of CPU/memory alone, since search blocks on I/O.
 webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_trigger_auth(
@@ -1640,6 +1613,87 @@ celery_beat_resource_requests = _resource_config(
 )
 celery_beat_resource_limits = _resource_config(
     "celery_beat_resource_limits", {"memory": "1536Mi"}
+)
+
+# Celery topology is declared here rather than inline in the OLApplicationK8s
+# config below, because the secrets need the resulting Deployment names before
+# the component exists -- see the restart targets below.
+mitlearn_celery_worker_configs = [
+    OLApplicationK8sCeleryWorkerConfig(
+        queue_name="default",
+        max_replicas=20,
+        redis_host=redis_cache.address,
+        redis_password=redis_config.require("password"),
+        resource_requests=celery_default_resource_requests,
+        resource_limits=celery_default_resource_limits,
+    ),
+    OLApplicationK8sCeleryWorkerConfig(
+        queue_name="edx_content",
+        redis_host=redis_cache.address,
+        redis_password=redis_config.require("password"),
+        resource_requests=celery_edx_content_resource_requests,
+        resource_limits=celery_edx_content_resource_limits,
+    ),
+    OLApplicationK8sCeleryWorkerConfig(
+        queue_name="embeddings",
+        max_replicas=30,
+        redis_host=redis_cache.address,
+        redis_password=redis_config.require("password"),
+        resource_requests=celery_embeddings_resource_requests,
+        resource_limits=celery_embeddings_resource_limits,
+    ),
+]
+mitlearn_celery_beat_config = OLApplicationK8sCeleryBeatConfig(
+    resource_requests=celery_beat_resource_requests,
+    resource_limits=celery_beat_resource_limits,
+)
+
+# Dynamic StarRocks credentials for the warehouse-pull catalog ETL, minted per
+# environment from Vault's `database-starrocks` mount. The mount name is not
+# environment-qualified because QA and Production each run their own separate
+# Vault server, and that is what scopes the environment.
+#
+# STARROCKS_HOST is the single switch for the whole feature. Setting it in a
+# stack's `mitlearn:vars` is what makes mit-learn register the warehouse-pull
+# beat entries (it requires STARROCKS_HOST and STARROCKS_USER together), so
+# minting credentials for a stack that has no host would rotate a StarRocks
+# user on every refresh for nothing. Only CI lacks a StarRocks cluster
+# entirely; QA has one but is held back for the reason recorded in
+# Pulumi.QA.yaml.
+starrocks_vault_mount_path = (
+    "database-starrocks" if env_vars.get("STARROCKS_HOST") else None
+)
+
+# The StarRocks credential reaches the app through env_from_secret_names, i.e.
+# envFrom, so its values become pod environment variables fixed at pod start.
+# Re-rendering the Kubernetes Secret does not touch a running pod. Vault
+# rotates this lease on its own (the StarRocks role's max TTL is six months),
+# so without these restart targets the rotation lands in the Secret, Vault
+# revokes the old StarRocks user with DROP USER, and beat keeps authenticating
+# as a user that no longer exists -- the sync stops until something unrelated
+# rolls the pods. That failure is silent in exactly the way the missing
+# configuration this PR fixes was.
+starrocks_secret_restart_targets = [
+    OLVaultRestartTarget(kind="Deployment", name=deployment_name)
+    for deployment_name in application_deployment_names(
+        application_name="mitlearn",
+        celery_worker_configs=mitlearn_celery_worker_configs,
+        celery_beat_config=mitlearn_celery_beat_config,
+    )
+]
+
+# Create all Kubernetes secrets needed by the application
+secret_names, secret_resources = create_mitlearn_k8s_secrets(
+    stack_info=stack_info,
+    mitlearn_namespace=learn_namespace,
+    k8s_global_labels=k8s_app_labels,
+    vault_k8s_resources=vault_k8s_resources,
+    mitlearn_vault_mount=mitlearn_vault_mount,
+    db_config=mitlearn_vault_backend,  # Use the original DB config object
+    redis_password=redis_config.require("password"),
+    redis_cache=redis_cache,
+    starrocks_vault_mount_path=starrocks_vault_mount_path,
+    starrocks_restart_targets=starrocks_secret_restart_targets,
 )
 
 # Configure and deploy the mitlearn application using OLApplicationK8s
@@ -1739,35 +1793,8 @@ mitlearn_k8s_app = OLApplicationK8s(
         init_migrations=False,
         init_collectstatic=True,  # Assuming Django app needs collectstatic
         pre_deploy_commands=[("migrate", ["scripts/heroku-release-phase.sh"])],
-        celery_worker_configs=[
-            OLApplicationK8sCeleryWorkerConfig(
-                queue_name="default",
-                max_replicas=20,
-                redis_host=redis_cache.address,
-                redis_password=redis_config.require("password"),
-                resource_requests=celery_default_resource_requests,
-                resource_limits=celery_default_resource_limits,
-            ),
-            OLApplicationK8sCeleryWorkerConfig(
-                queue_name="edx_content",
-                redis_host=redis_cache.address,
-                redis_password=redis_config.require("password"),
-                resource_requests=celery_edx_content_resource_requests,
-                resource_limits=celery_edx_content_resource_limits,
-            ),
-            OLApplicationK8sCeleryWorkerConfig(
-                queue_name="embeddings",
-                max_replicas=30,
-                redis_host=redis_cache.address,
-                redis_password=redis_config.require("password"),
-                resource_requests=celery_embeddings_resource_requests,
-                resource_limits=celery_embeddings_resource_limits,
-            ),
-        ],
-        celery_beat_config=OLApplicationK8sCeleryBeatConfig(
-            resource_requests=celery_beat_resource_requests,
-            resource_limits=celery_beat_resource_limits,
-        ),
+        celery_worker_configs=mitlearn_celery_worker_configs,
+        celery_beat_config=mitlearn_celery_beat_config,
         resource_requests=webapp_resource_requests,
         resource_limits=webapp_resource_limits,
         # The component would default this floor to resource_requests["memory"],

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1529,6 +1529,22 @@ redis_cache = OLAmazonCache(
     ),
 )
 
+# Dynamic StarRocks credentials for the warehouse-pull catalog ETL, minted per
+# environment from Vault's `database-starrocks` mount. The mount name is not
+# environment-qualified because QA and Production each run their own separate
+# Vault server, and that is what scopes the environment.
+#
+# STARROCKS_HOST is the single switch for the whole feature. Setting it in a
+# stack's `mitlearn:vars` is what makes mit-learn register the warehouse-pull
+# beat entries (it requires STARROCKS_HOST and STARROCKS_USER together), so
+# minting credentials for a stack that has no host would rotate a StarRocks
+# user on every refresh for nothing. Only CI lacks a StarRocks cluster
+# entirely; QA has one but is held back for the reason recorded in
+# Pulumi.QA.yaml.
+starrocks_vault_mount_path = (
+    "database-starrocks" if env_vars.get("STARROCKS_HOST") else None
+)
+
 # Create all Kubernetes secrets needed by the application
 secret_names, secret_resources = create_mitlearn_k8s_secrets(
     stack_info=stack_info,
@@ -1539,6 +1555,7 @@ secret_names, secret_resources = create_mitlearn_k8s_secrets(
     db_config=mitlearn_vault_backend,  # Use the original DB config object
     redis_password=redis_config.require("password"),
     redis_cache=redis_cache,
+    starrocks_vault_mount_path=starrocks_vault_mount_path,
 )
 
 # KEDA webapp autoscaling: scale on APISIX request-rate + p95 latency

--- a/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
@@ -20,6 +20,7 @@ from ol_infrastructure.components.services.vault import (
     OLVaultK8SResources,
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
+    OLVaultRestartTarget,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -86,6 +87,7 @@ def _create_dynamic_secret(
     templates: dict[str, str | Output[str]],
     vaultauth: str,
     opts: ResourceOptions | None = None,
+    restart_targets: list[OLVaultRestartTarget] | None = None,
 ) -> tuple[str, OLVaultK8SSecret]:
     """
     Create an OLVaultK8SSecret resource for a dynamic Vault secret.
@@ -100,6 +102,9 @@ def _create_dynamic_secret(
         templates: Dictionary defining how Vault data maps to Kubernetes secret keys.
         vaultauth: Name of the Vault Kubernetes auth backend role.
         opts: Optional Pulumi resource options.
+        restart_targets: Deployments to rolling-restart when this secret's
+            contents change. Required for anything consumed via envFrom, whose
+            values are fixed at pod start.
 
     Returns:
         A tuple containing the generated Kubernetes secret name and the resource object.
@@ -119,6 +124,7 @@ def _create_dynamic_secret(
             exclude_raw=True,
             templates=templates,
             vaultauth=vaultauth,
+            restart_targets=restart_targets,
         ),
         opts=opts,
     )
@@ -135,6 +141,7 @@ def create_mitlearn_k8s_secrets(
     redis_password: str,
     redis_cache: OLAmazonCache,
     starrocks_vault_mount_path: str | None = None,
+    starrocks_restart_targets: list[OLVaultRestartTarget] | None = None,
 ) -> tuple[list[str], list[OLVaultK8SSecret | kubernetes.core.v1.Secret]]:
     """
     Create all Kubernetes secrets required by the mitlearn application.
@@ -152,6 +159,9 @@ def create_mitlearn_k8s_secrets(
         starrocks_vault_mount_path: Vault mount serving dynamic StarRocks
             credentials, or None to skip them. None for any stack that has no
             STARROCKS_HOST configured -- see the caller.
+        starrocks_restart_targets: Deployments to roll when Vault rotates the
+            StarRocks lease. Without these the rotated credential lands in the
+            Secret while running pods keep authenticating as the revoked user.
 
     Returns:
         A list of the names of the created Kubernetes secrets.
@@ -375,6 +385,7 @@ def create_mitlearn_k8s_secrets(
                 "STARROCKS_PASSWORD": '{{ get .Secrets "password" }}',
             },
             vaultauth=vault_k8s_resources.auth_name,
+            restart_targets=starrocks_restart_targets,
         )
         secret_names.append(starrocks_secret_name)
         secret_resources.append(starrocks_secret)

--- a/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
@@ -134,6 +134,7 @@ def create_mitlearn_k8s_secrets(
     db_config: OLVaultDatabaseBackend,
     redis_password: str,
     redis_cache: OLAmazonCache,
+    starrocks_vault_mount_path: str | None = None,
 ) -> tuple[list[str], list[OLVaultK8SSecret | kubernetes.core.v1.Secret]]:
     """
     Create all Kubernetes secrets required by the mitlearn application.
@@ -148,6 +149,9 @@ def create_mitlearn_k8s_secrets(
         vault_k8s_resources: Vault Kubernetes auth backend resources.
         mitlearn_vault_mount: The Vault mount resource for mitlearn secrets.
         db_config: Configuration for the Vault dynamic PostgreSQL database backend.
+        starrocks_vault_mount_path: Vault mount serving dynamic StarRocks
+            credentials, or None to skip them. None for any stack that has no
+            STARROCKS_HOST configured -- see the caller.
 
     Returns:
         A list of the names of the created Kubernetes secrets.
@@ -355,7 +359,27 @@ def create_mitlearn_k8s_secrets(
     secret_names.append(database_url_secret_name)
     secret_resources.append(database_url_secret)
 
-    # 7. A normal, k8s secret for redis credentials
+    # 7. Dynamic StarRocks credentials for the warehouse-pull catalog ETL
+    # Read by learning_resources.lib.warehouse to query the integrations__learn__*
+    # views. Skipped where the mount does not exist (CI).
+    if starrocks_vault_mount_path:
+        starrocks_secret_name, starrocks_secret = _create_dynamic_secret(
+            stack_info=stack_info,
+            secret_base_name="starrocks-secrets",  # StarRocks credentials  # pragma: allowlist secret  # noqa: S106
+            namespace=mitlearn_namespace,
+            labels=k8s_global_labels,
+            mount=starrocks_vault_mount_path,
+            path="creds/readonly",
+            templates={
+                "STARROCKS_USER": '{{ get .Secrets "username" }}',
+                "STARROCKS_PASSWORD": '{{ get .Secrets "password" }}',
+            },
+            vaultauth=vault_k8s_resources.auth_name,
+        )
+        secret_names.append(starrocks_secret_name)
+        secret_resources.append(starrocks_secret)
+
+    # 8. A normal, k8s secret for redis credentials
     # Vault is not needed for these.
     redis_creds_secret_name = "redis-creds"  # noqa: S105  # pragma: allowlist secret
     redis_creds = kubernetes.core.v1.Secret(

--- a/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
+++ b/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
@@ -56,6 +56,21 @@ path "secret-mitlearn/*" {
   capabilities = ["read"]
 }
 
+# Read-only StarRocks credentials for the warehouse-pull catalog ETL
+# (learning_resources.lib.warehouse). The `readonly` role holds SELECT on the
+# Iceberg catalog, which is what the integrations__learn__* views live in.
+#
+# Granted in every environment, including those not yet reading it: a policy
+# path pointing at a mount that does not exist, or that nothing reads, grants
+# no access on its own. Which stacks actually mint these credentials is decided
+# by STARROCKS_HOST in __main__.py, not here.
+path "database-starrocks/creds/readonly" {
+  capabilities = ["read"]
+}
+path "database-starrocks/creds/readonly/*" {
+  capabilities = ["read"]
+}
+
 # XPro HubSpot secret for CRM integration
 path "secret-xpro/hubspot" {
   capabilities = ["read"]
@@ -67,12 +82,12 @@ path "secret-xpro/hubspot" {
 path "sys/leases/renew" {
   capabilities = ["update"]
   allowed_parameters = {
-    lease_id = ["postgres-mitlearn/creds/app/*"]
+    lease_id = ["postgres-mitlearn/creds/app/*", "database-starrocks/creds/readonly/*"]
   }
 }
 path "sys/leases/revoke" {
   capabilities = ["update"]
   allowed_parameters = {
-    lease_id = ["postgres-mitlearn/creds/app/*"]
+    lease_id = ["postgres-mitlearn/creds/app/*", "database-starrocks/creds/readonly/*"]
   }
 }

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -1065,6 +1065,19 @@ starrocks_apisix_httproute = OLApisixHTTPRoute(
 # annotation below means it becomes the sole authority on the NLB's ingress, so
 # every legitimate caller must be listed here.
 FE_MYSQL_PORT = 9030
+
+# Stable name for the FE MySQL endpoint, published by external-dns from the
+# annotation on the Service below.  Consumers outside this stack need a name
+# they can put in configuration, and the NLB's own AWS hostname is not that:
+# it is regenerated whenever the Service is recreated, which would silently
+# cut off every client still holding the old one.
+#
+# A stack reference would be the usual way to share this, but it is not
+# available here -- this stack already references applications.mit_learn for
+# the security group above, so mit_learn referencing it back would close a
+# cycle.
+fe_mysql_domain = f"mysql.{starrocks_config.require('domain')}"
+
 fe_mysql_nlb_security_group = ec2.SecurityGroup(
     f"starrocks-{stack_info.env_suffix}-fe-mysql-nlb-security-group",
     name=f"starrocks-{stack_info.env_suffix}-fe-mysql-nlb",
@@ -1116,6 +1129,13 @@ fe_mysql_nlb_service = kubernetes.core.v1.Service(
             "service.beta.kubernetes.io/aws-load-balancer-security-groups": (
                 fe_mysql_nlb_security_group.id
             ),
+            # external-dns runs with sources including "service" and a domain
+            # filter covering ol.mit.edu on every cluster, so this annotation
+            # is all that is needed to publish the record.  The NLB is
+            # internal, so the record resolves to VPC-private addresses; it is
+            # reachable only from the peered VPCs the security group above
+            # admits.
+            "external-dns.alpha.kubernetes.io/hostname": fe_mysql_domain,
         },
     ),
     spec=kubernetes.core.v1.ServiceSpecArgs(
@@ -1137,6 +1157,8 @@ fe_mysql_nlb_service = kubernetes.core.v1.Service(
     ),
     opts=ResourceOptions(depends_on=[starrocks_release]),
 )
+
+export("fe_mysql_domain", fe_mysql_domain)
 
 export(
     "fe_mysql_host",


### PR DESCRIPTION
### What are the relevant tickets?

Makes https://github.com/mitodl/hq/issues/12954 actually true. That issue was closed on https://github.com/mitodl/mit-learn/pull/3808, which merged the replacement sync but could not run it.

Follows https://github.com/mitodl/ol-infrastructure/pull/5556 (opened the network path) and https://github.com/mitodl/ol-infrastructure/pull/5643 (narrowed the FE HTTP surface).

### Description (What does it do?)

The MicroMasters/MITx Online program certificate sync has never run. [`main/settings_celery.py`](https://github.com/mitodl/mit-learn/blob/main/main/settings_celery.py) registers its beat entry only when `STARROCKS_HOST` and `STARROCKS_USER` are both set, and nothing here set either for mit-learn — `grep -rniE 'STARROCKS_(HOST|USER|PASSWORD|PORT)' src/ol_infrastructure/applications/` returns exactly one hit, `superset/__main__.py:577`. An unregistered beat entry does not raise, so this failure mode produces no Sentry issue and no failed run; nothing surfaces it except reading the setting.

- `mitlearn_policy.hcl`: read on `database-starrocks/creds/readonly`, plus those lease ids in the existing `sys/leases/{renew,revoke}` allowlists. The `readonly` StarRocks role holds `SELECT ON ALL TABLES IN ALL DATABASES` in the Iceberg catalog (`substructure/starrocks/__main__.py`), which is where the `integrations__learn__*` views live.
- `k8s_secrets.py`: a `VaultDynamicSecret` templating `STARROCKS_USER` / `STARROCKS_PASSWORD`, following the `aws-mitx` and `postgres-mitlearn` dynamic secrets already in that file. It reaches the app through the existing `env_from_secret_names=secret_names`: `OLApplicationK8s` spreads that `envFrom` list into the celery worker and `celery-beat` containers as well as the webapp (`components/services/k8s.py`, the `application_deployment_envfrom` uses at ~2356 and ~2514). Beat is the process that registers the schedule, so that is the load-bearing one.
- `applications/starrocks/__main__.py`: an `external-dns.alpha.kubernetes.io/hostname` annotation on the FE MySQL NLB Service, publishing `mysql.<starrocks:domain>`, plus a `fe_mysql_domain` output.
- `Pulumi.Production.yaml`: `STARROCKS_HOST` / `STARROCKS_PORT`.

**Why a DNS record rather than a stack reference.** `applications.starrocks` already references `applications.mit_learn` for the FE MySQL NLB security group, so mit_learn referencing it back would close a cycle. The alternative — pasting the NLB's own AWS hostname into config — breaks silently: that name is regenerated whenever the Service is, and every client still holding the old one just stops connecting. external-dns already runs on the data clusters with `service` among its sources and a domain filter covering `ol.mit.edu`, so the annotation is the whole change. The NLB stays `internal`; the record resolves to VPC-private addresses reachable only from the peered VPCs its security group admits.

**Why QA is deliberately left unconfigured.** `SyncProgramCertificatesTask` pins `view_name` to the `ol_data_lake_production` catalog with no setting to override it, and QA's StarRocks registers that catalog too (`_DATA_LAKE_ENVS = ["qa", "production"]`, `substructure/starrocks/__main__.py:301`). Setting the host in QA would therefore not rehearse the sync against QA data — it would replicate production learner PII (gender, year of birth, country, city, street address, postal code, per `transform_program_certificate`) into the RC database. `STARROCKS_HOST` is the single switch: the Vault secret is minted only for stacks that set it, so QA rotates no StarRocks user for a feature it does not run. The reasoning is recorded in `Pulumi.QA.yaml`, where the next person will look.

### How can this be tested?

`pulumi preview` on all four affected stacks, run against live state:

| Stack | Result |
|---|---|
| `ol-application-mit-learn/Production` | `+3 / ~6 / +-1`: creates the `VaultDynamicSecret`, updates `ol-mitlearn-vault-policy-production`, rolls the webapp and all four celery deployments (`default`, `edx_content`, `embeddings`, `beat`), replaces the pre-deploy job |
| `ol-application-mit-learn/QA` | `~1`: the Vault policy only. No secret, no deployment churn — confirms the `STARROCKS_HOST` gate |
| `ol-application-starrocks/lakehouse.Production` | `~2`: `+ external-dns.alpha.kubernetes.io/hostname: "mysql.lakehouse.starrocks.ol.mit.edu"` on the Service, `+ fe_mysql_domain` output. The other is `pulumi:providers:kubernetes`, pre-existing kubeconfig key-ordering churn unrelated to this change |
| `ol-application-starrocks/lakehouse.QA` | `~2`: same shape, `mysql.lakehouse.qa.starrocks.ol.mit.edu` |

`pre-commit run` passes on all six files (ruff format, ruff check, mypy, yamllint, detect-secrets).

Not verified, because it needs the deploy: that Vault actually issues a `readonly` credential to the mitlearn k8s auth role, and that a pod resolves the new name and completes a TCP connection to 9030.

To validate after deploy, in order:

1. Apply `applications.starrocks` first — mit-learn cannot resolve the host until the record exists.
2. `dig +short mysql.lakehouse.starrocks.ol.mit.edu` returns the NLB's private addresses.
3. Apply `applications.mit_learn/Production`.
4. `kubectl -n mitlearn get secret starrocks-secrets-dynamic-secret` exists and carries both keys.
5. The `mitlearn-celery-beat-production` pod log names `warehouse-sync-program-certificates-every-1-days` as a due task. (`celery inspect` reports worker state, not beat's schedule, so it will not answer this.)
6. It runs at 09:00 UTC with `full_refresh: True`. Confirm `profiles_programcertificate` row counts move without Hightouch.

### Additional Context

- **Both writers stay live, and that is safe here.** Hightouch is external to mit-learn, so there is no legacy beat entry to retire and the two run in parallel. [`upsert_program_certificate`](https://github.com/mitodl/mit-learn/blob/main/profiles/etl.py) is `update_or_create` keyed on `record_hash` and never prunes — deliberately, since a certificate missing from one pull must not be read as "no longer earned". This is not the full-sync unpublish hazard that gates the catalog cohorts.
- **The connection is plaintext.** `_connect_starrocks` calls `pymysql.connect` with no `ssl` argument, and `starrocks:ssl_force_secure_transport` is `false`, so it will work — but Vault reaches the same port with `tls=skip-verify`. Worth a follow-up on the mit-learn side; not this PR.
- **Catalog names are hardcoded in application code.** The `ol_data_lake_production` pin in `view_name` is what forces the QA decision above. Making it environment-aware is the prerequisite for any QA rehearsal of warehouse-pull, and it will bind the five catalog-source tasks that follow this one, not just certificates.

### Checklist:
- [ ] Apply `applications.starrocks` (either stack) before `applications.mit_learn/Production`, so the DNS record exists first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLF4eWX5APDU6N7idHVFmg
