### PR TITLE
feat(keycloak): onboard American Robert College of Istanbul (RobCol) as a SAML IdP

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -1191,6 +1191,37 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         )
         onboard_saml_org(
             SamlIdpConfig(
+                idp_alias="RobCol",
+                idp_display_name="American Robert College of Istanbul",
+                org_saml_metadata_url="https://login.microsoftonline.com/d4bc61be-6893-44c0-8f85-a6e62e5bebee/federationmetadata/2007-06/federationmetadata.xml?appid=90601514-0347-4331-99cc-e2947959d287",
+                principal_type="SUBJECT",
+                principal_attribute="user.mail",
+                login_hint=False,
+                name_id_format=NameIdFormat.email,
+                keycloak_url=keycloak_url,
+                realm_id=ol_apps_realm.id,
+                first_login_flow=ol_first_login_flow,
+                resource_options=resource_options,
+                attribute_name_map={
+                    "email": "user.mail",
+                    "firstName": "user.givenname",
+                    "lastName": "user.surname",
+                    "fullName": "user.displayname",
+                },
+                want_assertions_encrypted=False,
+                want_assertions_signed=False,
+            ),
+            org=OrgConfig(
+                org_domains=["robcol.k12.tr"],
+                org_name="American Robert College of Istanbul",
+                org_alias="RobCol",
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                resource_options=resource_options,
+            ),
+        )
+        onboard_saml_org(
+            SamlIdpConfig(
                 idp_alias="UCV",
                 idp_display_name="Universidad Cesar Vallejo",
                 org_saml_metadata_xml=Path(__file__)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Onboards American Robert College of Istanbul (alias `RobCol`, domain `robcol.k12.tr`) as a new SAML identity provider on the `olapps` (MIT Learn) Keycloak realm, using the existing `onboard_saml_org`/`SamlIdpConfig`/`OrgConfig` helpers in `org_sso_helpers.py`.

This follows the same Azure AD federation-metadata pattern already used for University Of Dubai, Istanbul Aydin University, and Cyprus Aydin University elsewhere in this file:
- `org_saml_metadata_url` pointed at their Azure AD tenant's federation metadata endpoint.
- `principal_type="SUBJECT"` / `principal_attribute="user.mail"`, `name_id_format=NameIdFormat.email`.
- `attribute_name_map` using the short-form Azure claim names (`user.mail`, `user.givenname`, `user.surname`, `user.displayname`) — these are exactly the attribute names RobCol's intake form specified, and match the same short-form convention already used for University Of Dubai (as opposed to the full XML-namespace claim URIs used for the Aydin orgs — Azure AD tenants can be configured either way).
- `want_assertions_encrypted=False`, `want_assertions_signed=False` — matching University Of Dubai and the Aydin student IdPs (3 of 4 existing Azure AD orgs in this file use this). This wasn't specified in the intake form; if their tenant does sign/encrypt assertions and Keycloak rejects them for validation reasons, this may need to flip to `True`.
- Domain-based routing via `org_domains=["robcol.k12.tr"]` (`login_hint` is `False`, matching the other Azure AD orgs, since they route by domain rather than a direct hint link).

### Screenshots (if appropriate):
N/A — backend Keycloak config only.

### How can this be tested?
- `ruff format`, `ruff check`, and `mypy` all pass via `pre-commit`.
- Verified the federation metadata URL is reachable (`curl` returns `200`).
- After merge/apply, verify in the Keycloak admin console that the `RobCol` identity provider appears under the `olapps` realm, and that logging in with a `@robcol.k12.tr` email routes to their Azure AD login page and completes the SAML flow with a test account, populating email/first name/last name correctly.

### Additional Context
Intake form also linked a Google Drive folder (`MIT Learn.docx`) with additional integration details I wasn't able to read (Drive access isn't connected in this session, and reading it wasn't a blocker for this PR per the requester). Worth a quick check of that doc before merging in case it specifies something not captured in the spreadsheet row (e.g. required signing/encryption settings, a specific NameID format, or additional attributes).