### PR TITLE
fix(ol-python-base): re-rebase onto DHI via OUTPUT_OCI, not mirroring

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -9,10 +9,17 @@ This directory contains Dockerfiles for MIT Open Learning services.
 Published as `mitodl/ol-python-base:{3.11,3.12,3.13}` via the Concourse pipeline at
 [`pipelines/infrastructure/ol_python_base_docker.yaml`](../pipelines/infrastructure/ol_python_base_docker.yaml).
 
-Bakes the substrate every app Dockerfile previously duplicated: Python slim, common-core
-apt packages, the `uv` binary, non-root `mitodl` user, `/opt/venv` + `UV_CACHE_DIR`
-env vars. App Dockerfiles do `FROM mitodl/ol-python-base:<python-version>` and add only
-app-specific layers.
+Bakes the substrate every app Dockerfile previously duplicated: hardened Python
+(Docker Hardened Images `-dev` variant, Debian 13; pulls require `docker login dhi.io`),
+common-core apt packages, the `uv` binary, non-root `mitodl` user, `/opt/venv` +
+`UV_CACHE_DIR` env vars. App Dockerfiles do `FROM mitodl/ol-python-base:<python-version>`
+and add only app-specific layers.
+
+App image builds that consume this base must set `OUTPUT_OCI: "true"` (see
+`src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py`) so DHI's zstd-compressed
+layers stay correctly labeled through single-platform builds — see
+[mitodl/ol-infrastructure#5714](https://github.com/mitodl/ol-infrastructure/issues/5714)
+for why.
 
 **Registering the pipeline** (one-time, requires Concourse access):
 ```

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -2,12 +2,34 @@
 # Shared Python base image for MIT Open Learning services.
 #
 # Bakes the substrate that every Python app Dockerfile previously duplicated:
-# slim Python, the common-core apt packages, the uv binary, a non-root `mitodl`
-# user, and the /opt/venv environment configuration. App images do
+# hardened Python, the common-core apt packages, the uv binary, a non-root
+# `mitodl` user, and the /opt/venv environment configuration. App images do
 # `FROM mitodl/ol-python-base:<python-version>` and add only their app-specific
 # layers (extra apt, node build stages, project source, run command).
 #
+# The base is Docker Hardened Images' Python `-dev` variant (Debian 13/trixie):
+# near-zero-CVE, continuously rebuilt, signed provenance. The `-dev` variant is
+# deliberate — it keeps the shell and apt this build (and downstream app
+# builds and dev stages) depend on; the shell-less runtime variant is only for
+# per-app production stages (see the hardened-images RFC). Pulls require
+# `docker login dhi.io` (any Docker account; CI uses the dockerhub service
+# credentials).
+#
+# DHI's layers are zstd-compressed. Earlier attempts at this rebase tried
+# mirroring the base with forced gzip recompression (mitodl/ol-infrastructure
+# #5712) to work around that, but the mirror needed a brand-new Docker Hub
+# repo whose push permissions were never verified before merging — which
+# broke production. The actual, permanent fix is OUTPUT_OCI=true on any
+# single-platform build consuming this base (see
+# src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py and
+# mitodl/ol-infrastructure#5714): it preserves DHI's original zstd layers
+# and their correct labeling end-to-end, with no mirroring, no new registry
+# artifact, and no new permission surface. This build itself needs no such
+# flag — it's already multi-arch, which oci-build-task treats as requiring
+# OCI output regardless.
+#
 # Build:
+#   docker login dhi.io
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 # Multi-arch build (published for both amd64 and arm64/Apple Silicon; --push
 # is required since a multi-platform result can't be loaded into the local
@@ -15,7 +37,7 @@
 #   docker buildx build --platform linux/amd64,linux/arm64 --push \
 #     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
-FROM python:${PYTHON_VERSION}-slim
+FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev
 
 LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
@@ -24,6 +46,10 @@ LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 # own Dockerfile / apt.txt.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+      # adduser is absent from the DHI dev image's curated package set
+      # (python:X-slim shipped it implicitly); required by the mitodl user
+      # creation below.
+      adduser \
       build-essential \
       ca-certificates \
       curl \
@@ -38,6 +64,13 @@ RUN apt-get update && \
       zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# DHI's Python is Debian-packaged (`python3` in /usr/bin) rather than the
+# python.org /usr/local layout that python:X-slim used, and Debian packaging
+# ships no bare `python` binary. Provide one for downstream Dockerfiles and
+# scripts that expect it. Guarded so this stays a no-op if a future base adds
+# its own.
+RUN command -v python >/dev/null 2>&1 || ln -s "$(command -v python3)" /usr/local/bin/python
 
 # Install uv (pinned via the upstream tag; bump deliberately).
 COPY --from=ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 /uv /uvx /usr/local/bin/

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -50,6 +50,12 @@ RUN apt-get update && \
       # (python:X-slim shipped it implicitly); required by the mitodl user
       # creation below.
       adduser \
+      # bsdutils provides `logger`, also absent from the curated set.
+      # adduser (and other Debian maintainer scripts) call it optionally to
+      # notify syslog and degrade gracefully without it -- confirmed
+      # harmless in practice -- but installing it removes the warning noise
+      # and any theoretical dependency on that graceful-degradation path.
+      bsdutils \
       build-essential \
       ca-certificates \
       curl \

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -1,17 +1,24 @@
 import sys
 
+from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
     GetStep,
     Identifier,
     Input,
     Job,
+    Output,
     Pipeline,
+    Platform,
     PutStep,
+    TaskConfig,
+    TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
-from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 PYTHON_VERSIONS = ("3.11", "3.12", "3.13", "3.14")
@@ -22,6 +29,77 @@ ol_infrastructure_repo = git_repo(
     branch="main",
     paths=["dockerfiles/ol-python-base/Dockerfile"],
 )
+
+# Upstream Docker Hardened Images bases (see the hardened-images RFC). These
+# resources exist to trigger rebuilds whenever Docker ships a CVE-patched
+# rebuild of the base -- without them the hardening silently decays between
+# Dockerfile edits. dhi.io denies anonymous pulls, so the build authenticates
+# via dhi_docker_config_task below.
+#
+# This build itself never mislabels DHI's zstd layers: it's multi-arch
+# (IMAGE_PLATFORM below), and oci-build-task treats any multi-platform build
+# as requiring OCI output regardless of any other setting, which can
+# correctly declare a zstd layer. The mislabeling only happens in
+# *downstream* single-platform builds (every app image) that don't request
+# OCI output explicitly -- see OUTPUT_OCI in
+# src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py and
+# mitodl/ol-infrastructure#5714 for the full mechanism and why an earlier
+# attempt at this (mirroring the base with forced recompression, #5712)
+# was reverted (#5715) instead of fixed forward.
+dhi_python_base_resources = {
+    version: registry_image(
+        name=Identifier(f"dhi-python-{version.replace('.', '')}-image"),
+        image_repository="dhi.io/python",
+        image_tag=f"{version}-debian13-dev",
+        username="((dockerhub.username))",
+        password="((dockerhub.password))",  # noqa: S106
+    )
+    for version in PYTHON_VERSIONS
+}
+
+
+def dhi_docker_config_task() -> TaskStep:
+    """Write a docker config authorizing pulls from dhi.io.
+
+    oci-build-task resolves FROM-image credentials through the standard
+    docker config machinery, honoring the DOCKER_CONFIG env var, so the
+    build task consumes this task's output directory via
+    DOCKER_CONFIG=docker-config.
+    """
+    docker_config = Output(name=Identifier("docker-config"))
+    return TaskStep(
+        task=Identifier("write-dhi-docker-config"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type=REGISTRY_IMAGE,
+                source={
+                    "repository": dockerhub_ecr_image_uri("alpine"),
+                    "tag": "latest",
+                    "aws_region": ECR_REGION,
+                },
+            ),
+            outputs=[docker_config],
+            params={
+                "DHI_USERNAME": "((dockerhub.username))",
+                "DHI_PASSWORD": "((dockerhub.password))",
+            },
+            run=Command(
+                path="sh",
+                # -e only: -x would echo the credentials into the build log.
+                args=[
+                    "-ec",
+                    (
+                        'auth="$(printf \'%s:%s\' "$DHI_USERNAME"'
+                        ' "$DHI_PASSWORD" | base64 | tr -d \'\\n\')"\n'
+                        'printf \'{"auths": {"dhi.io": {"auth": "%s"}}}\''
+                        f' "$auth" > {docker_config.name}/config.json\n'
+                    ),
+                ],
+            ),
+        ),
+    )
+
 
 image_resources = {
     version: registry_image(
@@ -52,16 +130,30 @@ def build_job(python_version: str) -> Job:
         public=True,
         plan=[
             GetStep(get=ol_infrastructure_repo.name, trigger=True),
+            GetStep(
+                get=dhi_python_base_resources[python_version].name,
+                trigger=True,
+            ),
+            dhi_docker_config_task(),
             container_build_task(
-                inputs=[Input(name=ol_infrastructure_repo.name)],
+                inputs=[
+                    Input(name=ol_infrastructure_repo.name),
+                    Input(name=Identifier("docker-config")),
+                ],
                 build_parameters={
                     "CONTEXT": context,
                     "BUILD_ARG_PYTHON_VERSION": python_version,
+                    # Auth for the dhi.io FROM pull; written by
+                    # dhi_docker_config_task above.
+                    "DOCKER_CONFIG": "docker-config",
                     # Cross-build linux/arm64 via QEMU emulation (workers have
                     # qemu-user-static/binfmt-support installed) so Apple
                     # Silicon can pull a native image. Multiple platforms
                     # makes oci-build-task emit an OCI layout directory
-                    # (image/image) instead of a tarball.
+                    # (image/image) instead of a tarball, and treats the
+                    # build as requiring OCI output regardless of any other
+                    # setting -- so this build never mislabels DHI's zstd
+                    # layers even without an explicit OUTPUT_OCI.
                     "IMAGE_PLATFORM": "linux/amd64,linux/arm64",
                 },
             ),
@@ -84,6 +176,7 @@ def build_job(python_version: str) -> Job:
 ol_python_base_pipeline = Pipeline(
     resources=[
         ol_infrastructure_repo,
+        *dhi_python_base_resources.values(),
         *image_resources.values(),
         *ecr_image_resources.values(),
     ],

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -519,9 +519,21 @@ def _build_image_job_legacy(
     version_args = {}
     additional_build_params = {}
     if build_target:
-        additional_build_params = {
-            "TARGET": build_target,
-        }
+        additional_build_params["TARGET"] = build_target
+    # OUTPUT_OCI preserves the DHI-hardened base's zstd layer labeling
+    # end-to-end (mitodl/ol-infrastructure#5714). oci-build-task's default
+    # (Docker-legacy) output format has no field to declare a layer as
+    # anything but gzip, so a layer carried through unchanged from a
+    # zstd-compressed base gets silently mislabeled as gzip -- which is what
+    # broke the original learn-ai canary build. Skipped when
+    # sentry_sourcemaps is set (mit-learn-nextjs only): oci-build-task's
+    # OCI-output loader (loadOciImages) never checks UNPACK_ROOTFS, unlike
+    # the legacy loader the sourcemap upload step depends on -- and
+    # mit-learn-nextjs doesn't build FROM mitodl/ol-python-base anyway
+    # (it's a Node/Next.js image), so it was never at risk from DHI's zstd
+    # layers in the first place.
+    if sentry_sourcemaps is None:
+        additional_build_params["OUTPUT_OCI"] = "true"
     if branch_type == "release_candidate":
         plan.extend(
             [
@@ -598,7 +610,9 @@ def _build_image_job_legacy(
     )
 
     put_params: dict[str, Any] = {
-        "image": "image/image.tar",
+        # Directory, not image.tar, whenever OUTPUT_OCI was set above --
+        # matches oci-build-task's documented output shape for that flag.
+        "image": "image/image" if sentry_sourcemaps is None else "image/image.tar",
         "additional_tags": f"./{git_repo_resource.name}/.git/short_ref",
     }
     if branch_type != "main":


### PR DESCRIPTION
### What are the relevant tickets?
Closes [mitodl/ol-infrastructure#5714](https://github.com/mitodl/ol-infrastructure/issues/5714). Re-applies the hardened-base-image rebase ([#5698](https://github.com/mitodl/ol-infrastructure/pull/5698)) that was reverted ([#5715](https://github.com/mitodl/ol-infrastructure/pull/5715)) after its mirror-based fix ([#5712](https://github.com/mitodl/ol-infrastructure/pull/5712)) broke production — this time via `OUTPUT_OCI`, not mirroring. RFC: https://github.com/mitodl/hq/discussions/13121

### Description (What does it do?)

**Background, briefly:** `ol-python-base` was rebased onto a Docker Hardened Images base with zstd-compressed layers. Single-platform builds (every app image) export via `oci-build-task`'s default Docker-legacy manifest format, whose schema has no field to declare a layer as anything but gzip — so DHI's real zstd layers got silently mislabeled as gzip, and Concourse's `registry-image` resource failed decoding them (`gzip: invalid header`). A first attempt fixed this by mirroring the base with forced recompression, but that introduced a new Docker Hub repo whose push permissions were never verified before merging, which broke every release pipeline depending on `ol-python-base`. Both changes were reverted.

**This fix:** `OUTPUT_OCI: "true"` forces `oci-build-task` to emit the OCI manifest format instead, which *can* correctly declare a zstd layer — no mirroring, no new registry artifact, no new permission surface. `ol-python-base`'s own build never needed this (it's multi-arch, which `oci-build-task` already treats as requiring OCI output regardless), so this only touches app builds:

- `dockerfiles/ol-python-base/Dockerfile` — `FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev` directly (same as the original #5698 attempt). Also installs `adduser` (absent from DHI's curated package set; needed for the `mitodl` user creation) and `bsdutils` (provides `logger`; `adduser`'s optional syslog notification calls it and degrades gracefully without it, but installing it removes the warning noise and the dependency on that degradation path holding universally).
- `src/ol_concourse/pipelines/container_images/ol_python_base.py` — the `dhi.io` trigger resource and docker-config auth task from #5698, with no mirror task.
- `src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py` — adds `OUTPUT_OCI: "true"` (and switches the corresponding `PutStep`'s image path from `image/image.tar` to the `image/image` directory `OUTPUT_OCI` produces) to `_build_image_job_legacy`, covering every app **except** `mit-learn-nextjs`. That app is deliberately excluded: `oci-build-task`'s OCI-output loader (`loadOciImages`) never checks `UNPACK_ROOTFS` (needed for its Sentry sourcemap upload step), unlike the legacy loader — and `mit-learn-nextjs` doesn't build `FROM mitodl/ol-python-base` anyway (it's a Node/Next.js image), so it was never at risk from DHI's zstd layers. `ol-analytics-api`'s separate release-resource build path is untouched for the same reason: it builds from `python:3.12-slim-bookworm` directly, never touching `ol-python-base`.

### How can this be tested?

Given the history here, this was fully verified end-to-end against real Concourse infrastructure before this PR was opened, using throwaway pipelines and tags with zero risk to production (full detail in [#5714](https://github.com/mitodl/ol-infrastructure/issues/5714)):

1. Built `ol-python-base` from this exact branch (real `dhi.io` pull, multi-arch) → pushed to a throwaway tag. **Succeeded.**
2. Built learn-ai's *real* Dockerfile (via a throwaway branch pointing its `FROM` at that test tag) using the real, fixed `_build_image_job_legacy` with `OUTPUT_OCI=true` → pushed to a throwaway tag. **Succeeded.**
3. **The literal reproduction of the original incident**: a downstream job doing a `get` gated on that build having passed — the exact step that failed with `gzip: invalid header` last time. **Succeeded.**
4. Pulled the resulting image locally: Django, Celery, and the interpreter all import correctly; app source and collected static files are present and correct. (One `granian` import segfault turned up under local QEMU emulation — isolated and confirmed to be a pre-existing incompatibility between that exact `granian` release and QEMU's amd64-on-arm64 emulation, unrelated to this fix: it reproduces identically on a completely stock, unmodified `python:3.14-slim` base.)
5. Verified `mit-learn-nextjs`'s build renders unchanged (`image/image.tar`, `UNPACK_ROOTFS` intact on its release-candidate build) and every other app's build picks up `OUTPUT_OCI: true` correctly, by rendering `build_app_pipeline()` for each and inspecting the output directly.
6. Confirmed via source (`oci-build-task`'s `commands/rootfs.go`/`out.go` at the exact bundled version, not assumed) that both the pull and push sides of `registry-image` resource correctly handle OCI-labeled zstd layers, and that `ol-analytics-api`/`mit-learn-nextjs` genuinely don't build from `ol-python-base` (verified against their actual Dockerfiles, not assumed).
7. **ECR, checked separately** — every real build pushes to both Docker Hub and ECR, and the above only exercised Docker Hub directly, so this needed its own check rather than assuming parity between two different registry implementations. Confirmed directly against the pushed ECR image (`aws ecr batch-get-image`): the stored manifest is `application/vnd.oci.image.index.v1+json` (not silently downgraded to Docker's legacy schema), and its layer media types are an exact match to what was pushed — 5 layers correctly `tar+zstd` (DHI's originals), the rest correctly `tar+gzip` (the app's own) — so ECR stored it honestly rather than rewriting anything. Authenticated and pulled the image straight from ECR (`610119931565.dkr.ecr.us-east-1.amazonaws.com/mitodl/learn-ai-app:output-oci-test`); all layers decoded cleanly. Also confirmed AWS documents OCI 1.1 + zstd-layer support in ECR directly (they promote it for Fargate startup-time gains), so this isn't riding on an undocumented capability. Short of what wasn't done: no live Concourse `get` was run against the ECR `registry_image` resource specifically (the way `verify-fetch-back` did for Docker Hub) — but `registry-image` resource's decode logic is registry-agnostic (it branches purely on the media-type string, which is now confirmed identical on both registries), so the same code path that already passed against Docker Hub has nothing registry-specific left to trip on.

Test pipelines have been torn down. The two throwaway tags (`mitodl/ol-python-base:3.14-output-oci-test`, `mitodl/learn-ai-app:output-oci-test`) still exist on Docker Hub and ECR — harmless leftover clutter, not deleted since doing so needs registry credentials beyond what's available in this session; safe to remove from either console whenever convenient.

**After merge:** the `container-images-meta` pipeline's `create-ol-python-base-docker` job needs to run to re-register `ol-python-base-docker` with the new job definition (or trigger it manually) before the fix takes effect; the same applies to each app's `k8s_apps` pipeline registration.

### Additional Context

Not a draft. Given the history on this base image, I'd suggest a careful rollout: let `ol-python-base` rebuild first, confirm it publishes cleanly, then re-trigger one small app (learn-ai) and confirm it builds *and* deploys before letting the rest of the fleet rebuild on its normal cadence — this is the canary step the original plan called for and is worth actually following through on this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

