### PR TITLE
fix(mitxonline): redirect home page to MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1118,6 +1118,20 @@ catalog_redirect_vcl = (
     f"}}"
 )
 
+# Home page redirects to MIT Learn's unit catalog view too - per hq#12506,
+# matches only the exact site root, not any deeper path, so /cms and
+# /staff-dashboard (and everything else) are unaffected by construction.
+# Applies to all requests regardless of login state - there's no distinct
+# logged-in experience at bare "/" today for this to disrupt. Uses a
+# distinct error code (605) from the catalog (604), course/program (603),
+# and UAI B2C (602) redirects above so this is fully additive.
+home_redirect_vcl = (
+    f'if (req.url.path == "/") {{\n'
+    f'  set req.http.x-redir-location = "https://{learn_frontend_domain}/c/unit/mitx";\n'
+    f"  error 605;\n"
+    f"}}"
+)
+
 gzip_settings: dict[str, set[str]] = {"extensions": set(), "content_types": set()}
 for k, v in mimetypes.types_map.items():
     if k in (
@@ -1229,6 +1243,15 @@ mitxonline_service = fastly.ServiceVcl(
             type="recv",
         ),
         vcl_snippet(
+            content=home_redirect_vcl,
+            name="Redirect home page to MIT Learn",
+            # Exact match on "/" only, so it can't shadow /cms, /staff-dashboard,
+            # or any other path - ordering relative to the other recv snippets
+            # isn't load-bearing, placed after them for readability only.
+            priority=170,
+            type="recv",
+        ),
+        vcl_snippet(
             content=textwrap.dedent("""\
             if (obj.status == 602) {
               set obj.status = 301;
@@ -1282,6 +1305,25 @@ mitxonline_service = fastly.ServiceVcl(
               return(deliver);
             }"""),
             name="Handle catalog redirects to MIT Learn",
+            type="error",
+        ),
+        vcl_snippet(
+            content=textwrap.dedent("""\
+            if (obj.status == 605) {
+              set obj.status = 301;
+              set obj.response = "Moved Permanently";
+              set obj.http.Location = req.http.x-redir-location;
+              set obj.http.Cache-Control = "no-store";
+              if (req.url.qs != "") {
+                if (obj.http.Location !~ "\\?") {
+                  set obj.http.Location = obj.http.Location "?" req.url.qs;
+                } else {
+                  set obj.http.Location = obj.http.Location "&" req.url.qs;
+                }
+              }
+              return(deliver);
+            }"""),
+            name="Handle home page redirects to MIT Learn",
             type="error",
         ),
         vcl_snippet(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1315,11 +1315,9 @@ mitxonline_service = fastly.ServiceVcl(
               set obj.http.Location = req.http.x-redir-location;
               set obj.http.Cache-Control = "no-store";
               if (req.url.qs != "") {
-                if (obj.http.Location !~ "\\?") {
-                  set obj.http.Location = obj.http.Location "?" req.url.qs;
-                } else {
-                  set obj.http.Location = obj.http.Location "&" req.url.qs;
-                }
+                # 605's Location is a fixed URL with no query string, so a
+                # plain "?" append is always correct here.
+                set obj.http.Location = obj.http.Location "?" req.url.qs;
               }
               return(deliver);
             }"""),

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/pingdom_checks.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/pingdom_checks.py
@@ -343,7 +343,10 @@ _CHECKS: list[_SMCheck] = [
     _SMCheck(
         resource_name="mitxonline-production-http",
         job="MITx Online Production",
-        target="https://mitxonline.mit.edu/",
+        # Bare "/" is answered with a synthetic 301 to MIT Learn at the Fastly
+        # edge, so it no longer exercises the origin - probe a health endpoint
+        # served by the app instead.
+        target="https://mitxonline.mit.edu/health/readiness/",
         frequency=60000,
         alert_sensitivity="high",
         labels={"env": "production", "service": "mitxonline"},
@@ -351,7 +354,7 @@ _CHECKS: list[_SMCheck] = [
     _SMCheck(
         resource_name="mitxonline-rc-http",
         job="MITx Online RC",
-        target="https://rc.mitxonline.mit.edu/",
+        target="https://rc.mitxonline.mit.edu/health/readiness/",
         frequency=60000,
         alert_sensitivity="low",
         labels={"env": "rc", "service": "mitxonline"},


### PR DESCRIPTION
## What are the relevant tickets?

Fixes mitodl/hq#12506
Subissue of mitodl/hq#12027

## Description (What does it do?)

The bare `https://mitxonline.mit.edu/` currently serves the mitxonline home page. Per mitodl/hq#12506, this should redirect to MIT Learn's MITx channel page instead: `https://learn.mit.edu/c/unit/mitx`.

This PR adds a new Fastly VCL rule matching only the exact root path (`req.url.path == "/"`), so it can't shadow `/cms`, `/staff-dashboard`, or any other route. As noted in the issue thread, this applies to **all** users regardless of login state — investigation confirmed there's no distinct logged-in experience at the bare `/` today (the dashboard lives at a separate `/dashboard/` route), so there's nothing to disrupt.

This PR introduces a new error code (605), following the same pattern as the existing UAI B2C (602), course/program (603), and catalog (604) redirects.

## Screenshots

N/A — infra-level redirect, no UI change.

## How can this be tested?
These have already been used to test:
- `uv run pre-commit run --files src/ol_infrastructure/applications/mitxonline/__main__.py` — ruff format/check, mypy, secret detection all pass.
- `uv run pytest tests/ol_infrastructure/lib/test_fastly.py` — 17/17 pass, including the repo-wide scan that every VCL snippet is built through the validating helper.
- Manually verified the exact-match condition against realistic and edge-case paths in Python: matches only `/`; does not match `/cms`, `/cms/login`, `/staff-dashboard`, `/staff-dashboard/foo`, `/courses/`, `/programs/`, `/catalog`, `/dashboard/`, etc.
- Checked this repo's source for any other use of custom error code 605 — none found (602/603/604 are the only other codes in use, sequential with no gaps). **This only confirms no collision in source; it does not confirm live Fastly state.**

Needs to get done after deploy:
- After deploy, confirm with `curl -I https://mitxonline.mit.edu/` — expect `301` with `Location: https://learn.mit.edu/c/unit/mitx`. Also confirm `/cms/login` and `/staff-dashboard/` still resolve normally (not redirected).

This also still needs to get done, but by devops:
- `pulumi preview` not run against live state in this session — **devops should confirm no existing/manual use of custom error code 605 on this Fastly service as part of the preview**, in addition to the general plan review (same as mitodl/hq#13100 / ol-infrastructure#5693).

## Additional Context

This work is very similar to other subissues in the Redirect epic. Same pattern as the existing `/catalog/*` redirect (mitodl/hq#12504), course/program redirect (mitodl/hq#12449), and bare `/courses/`/`/programs/` redirect (mitodl/hq#13100) — this repo's Fastly VCL snippet approach in `src/ol_infrastructure/applications/mitxonline/__main__.py`.
