### PR TITLE
Add more courses

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -162,21 +162,14 @@ courses = [
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.15-1T2026.git",
         image_name="uai_source-uai.15",
     ),
-    CourseImageInfo(
-        course_name="mitxt-6.3710.3x",
-        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.3x-2T2026.git",
-        image_name="mitxt-6.3710.3x",
-    ),
-    CourseImageInfo(
-        course_name="mitxt-6.3710.4x",
-        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.4x-2T2026.git",
-        image_name="mitxt-6.3710.4x",
-    ),
-    CourseImageInfo(
-        course_name="mitxt-6.3710.5x",
-        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.5x-2T2026.git",
-        image_name="mitxt-6.3710.5x",
-    ),
+    *[
+        CourseImageInfo(
+            course_name=f"mitxt-6.3710.{module_num}x",
+            repo_uri=f"git@github.mit.edu:ol-notebooks/MITxT-6.3710.{module_num}x-2T2026.git",
+            image_name=f"mitxt-6.3710.{module_num}x",
+        )
+        for module_num in range(3, 6)
+    ],
     CourseImageInfo(
         course_name="uai_source-uai.scm1",
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.SCM.1-1T2026.git",
@@ -187,6 +180,19 @@ courses = [
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.SCM.2-1T2026.git",
         image_name="uai_source-uai.scm2",
     ),
+    CourseImageInfo(
+        course_name="uai_source-uai.cls1",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.CLS.1-1T2026.git",
+        image_name="uai_source-uai.cls1",
+    ),
+    *[
+        CourseImageInfo(
+            course_name=f"mitxt-6.7960.{module_num}x",
+            repo_uri=f"git@github.mit.edu:ol-notebooks/MITxT-6.7960.{module_num}x-2T2026.git",
+            image_name=f"mitxt-6.7960.{module_num}x",
+        )
+        for module_num in range(1, 6)
+    ],
 ]
 
 # This infers the ECR url from the AWS account,

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -190,9 +190,8 @@ COURSE_NAMES = [
     "supervised_learning_fundamentals",
     "introduction_to_data_analytics_and_machine_learning",
     "base_authoring_image",
-    "mitxt-6.3710.3x",
-    "mitxt-6.3710.4x",
-    "mitxt-6.3710.5x",
+    *[f"mitxt-6.3710.{module_num}x" for module_num in range(3, 6)],
+    *[f"mitxt-6.7960.{module_num}x" for module_num in range(1, 6)],
 ]
 COURSE_NAMES.extend(
     [

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -221,6 +221,7 @@ COURSE_NAMES.extend(
             "edm1",
             "scm1",
             "scm2",
+            "cls1",
         ]
     ]
 )

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -20,9 +20,8 @@ KNOWN_COURSES = [
     "supervised_learning_fundamentals",
     "introduction_to_data_analytics_and_machine_learning",
     "base_authoring_image",
-    "mitxt-6.3710.3x",
-    "mitxt-6.3710.4x",
-    "mitxt-6.3710.5x",
+    *[f"mitxt-6.3710.{module_num}x" for module_num in range(3, 6)],
+    *[f"mitxt-6.7960.{module_num}x" for module_num in range(1, 6)],
 ]
 # We have notebooks in UAI courses 6-13, excluding 10
 KNOWN_COURSES.extend(
@@ -53,6 +52,7 @@ KNOWN_COURSES.extend(
             "edm1",
             "scm1",
             "scm2",
+            "cls1",
         ]
     ]
 )


### PR DESCRIPTION
### What are the relevant tickets?
mitxt course requests covered at https://github.com/mitodl/hq/issues/11190 

### Description (What does it do?)
Adds 5 course repos for deep learning, one for AI and Complex Systems notebooks. Slightly rewrote one existing set of course identifiers to reduce a bit of boilerplate.

### How can this be tested?
`uv run python src/ol_concourse/pipelines/container_images/jupyter_courses.py` should show the new course pipelines. Pulumi should reflect new courses in the extra images block for the prepuller, and some code changes to the list of courses we track in the dynamic image config file for any `pulumi up` in CI/QA/Production
<img width="1102" height="811" alt="Screenshot 2026-09-02 at 3 15 56 PM" src="https://github.com/user-attachments/assets/ea7afb94-fee9-4274-8b60-46e2e14fb872" />