### PR TITLE
feat(omnigraph): deploy the council-health synthetic-probe CronJob

### DIFF
--- a/docs/witan-admin-break-glass-runbook.md
+++ b/docs/witan-admin-break-glass-runbook.md
@@ -217,6 +217,8 @@ pod start.
 
 ## Related
 
+- `witan-council-probe-runbook.md` — `svc-witan-probe`, the same opt-in shape,
+  for synthetic monitoring rather than maintenance.
 - `witan-token-sync-runbook.md` — per-user tokens, and the `actor-tokens` /
   `service-tokens` writer split this builds on.
 - `omnigraph-store-maintenance-runbook.md` — the *other* kind of maintenance

--- a/docs/witan-council-probe-runbook.md
+++ b/docs/witan-council-probe-runbook.md
@@ -1,0 +1,138 @@
+# `svc-witan-probe` — the council-health synthetic-monitoring account
+
+The fourth of witan's non-human principals, alongside `svc-witan-ci` (the
+code-graph pipeline), `svc-witan` (the MCP serving tier), and `svc-witan-admin`
+(break-glass maintenance).
+
+## What it is for
+
+Two alert rules already cover a lost `council` graph, from opposite
+directions, and a real window sits between them:
+
+- `WitanToolCallErrorRate` (`metric_rules/witan.py`) needs live MCP traffic to
+  say anything — with none in the window it is `0/0 = NaN` and never fires.
+- `WitanGraphQuarantined` (`log_rules/witan.py`) needs a pod restart — it reads
+  `graph_count` off omnigraph-server's own boot line.
+
+`council` lost during a quiet period with no restart is invisible to both
+until someone tries to use the service, which for a shared agent memory graph
+can be hours. Neither existing health check can be deepened to close that gap
+without breaking what it is *for*: omnigraph's `/healthz` is flat and
+unauthenticated by design, and witan's own probe deliberately answers from
+process state alone (deepening it converts backend slowness into frontend
+death — see `applications/witan/deployment.py`).
+
+So this is a separate, out-of-band, **authenticated** caller:
+`applications/omnigraph/council_probe.py` runs a CronJob
+(`check_council_health.py`) on its own schedule, in its own pod, carrying its
+own Cedar identity. It runs one trivial read against `council` and exits
+non-zero if that read did not come back — nothing more. See the script's own
+module docstring for the wire-level detail.
+
+**It needs no new alert rule.** A failing run *is* the signal:
+`WitanScheduledJobNeverSucceeded` and `eks_general.py`'s `WorkloadJobFailed*`
+already alert on a failing CronJob, and the CronJob's name is in
+`eks_general.py`'s fast staleness bucket for the "stopped running entirely"
+case those miss.
+
+## Why a fourth identity, not one of the other three
+
+`svc-witan-ci` is permanently excluded from the memory graph by design (it is
+a code-graph data pipeline with no role on the work graph — see
+`memory.policy.yaml`'s header). `svc-witan-admin` is break-glass and should
+not authenticate on a schedule. `svc-witan` is the serving tier's own
+credential, live in every real user request, not something a monitoring job
+should hold or rotate in lockstep with. `svc-witan-probe` costs nothing on any
+graph but `memory`, and there it holds `read` + `invoke_query` only — no
+`export`, no `change`, no `schema_apply`. See agent-kit
+`mcp/servers/witan/policy/README.md` § "Non-human actors".
+
+## Why it is optional, like `svc-witan-admin`
+
+Unlike `svc-witan` (required in every environment — see
+`witan-service-account-runbook.md`), an environment whose SOPS file has no
+`probe_token` simply has no council-health CronJob deployed. There is no
+crash-loop and no denied-but-authenticated state to reason about, because
+nothing authenticates as this identity at all until the token exists.
+
+## Provisioning it (per environment)
+
+1. **Mint a token and put it in SOPS.** Two keys, and they must match, and the
+   value must differ from `ci_token`, `admin_token`, and `service_token` — the
+   stack refuses the deploy otherwise, for the same reason as every other
+   identity here: Cedar tells these principals apart by actor id alone, so a
+   shared value collapses two principals into one holding the union of their
+   grants.
+
+   ```bash
+   tok="$(openssl rand -hex 32)"
+   f=src/bridge/secrets/omnigraph/secrets.<env>.yaml
+   sops set "$f" '["probe_token"]' "\"${tok}\""
+   sops set "$f" '["actor_tokens"]["svc-witan-probe"]' "\"${tok}\""
+   unset tok
+   ```
+
+2. **Deploy the omnigraph stack.** This writes
+   `secret-operations/witan/probe-token`, adds the actor to
+   `secret-operations/witan/service-tokens`, syncs a Kubernetes Secret from
+   the first path via the Vault Secrets Operator, and creates the
+   `witan-council-probe` CronJob in the `omnigraph` namespace — all in this
+   one stack; unlike `svc-witan`/`svc-witan-admin` there is no witan-stack
+   half to deploy separately, since the probe talks to omnigraph-server
+   directly rather than through the MCP tier.
+
+   The entry has to reach `actor-tokens` and then omnigraph-server before it
+   authenticates anywhere — the server hashes its token map once at boot and
+   never re-reads it. With token sync on (every environment, as of
+   2026-08-05), the stack's own bootstrap Job folds the service-tokens map
+   into its re-run trigger, so this lands within the same `pulumi up`. If you
+   want to confirm without waiting on the deploy log:
+
+   ```bash
+   kubectl -n omnigraph create job witan-token-sync-manual --from=cronjob/witan-token-sync
+   kubectl -n omnigraph logs job/witan-token-sync-manual
+   ```
+
+## Verifying
+
+```bash
+# The group is populated
+kubectl -n omnigraph logs deploy/omnigraph-server | grep render-policy-groups
+#   ... memory.policy.yaml [witan-users=33, witan-admin=1, witan-probe=1]
+
+# The CronJob exists and has succeeded at least once
+kubectl -n omnigraph get cronjob witan-council-probe
+kubectl -n omnigraph logs -l app.kubernetes.io/name=witan-council-probe --tail=20
+```
+
+Same caveat as every other identity here: the boot-log render line rotates
+out of the retained log within about ten minutes on a busy server. Read the
+token map instead once it has:
+
+```bash
+kubectl -n omnigraph get secret actor-tokens -o go-template='{{index .data "tokens.json"}}' \
+  | base64 -d | jq 'keys | map(select(startswith("act-") | not))'
+#   [ "svc-witan", "svc-witan-admin", "svc-witan-ci", "svc-witan-probe" ]
+```
+
+**End-to-end acceptance for this task specifically**: make the probe fail for
+a reason other than `council` actually being down (e.g. temporarily point
+`OMNIGRAPH_GRAPH_ID` at a graph id that does not exist), and confirm the
+CronJob-failure alert path fires — not by reading the manifest.
+
+## Rotating
+
+Same as minting: change both keys to a new value and deploy the omnigraph
+stack. Each CronJob run mounts the Secret fresh in a brand-new pod, so unlike
+the always-running data-tier Deployment there is nothing to restart — the very
+next scheduled run picks up the rotated token.
+
+## Related
+
+- `docs/witan-admin-break-glass-runbook.md` — `svc-witan-admin`, same
+  opt-in shape.
+- `docs/witan-service-account-runbook.md` — `svc-witan`, the required
+  counterpart, and the fullest write-up of the render-groups verification
+  trap that applies here too.
+- agent-kit `mcp/servers/witan/policy/` — the Cedar bundles (`witan-probe`
+  group in `memory.policy.yaml`) and the boot-time membership renderer.

--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -248,6 +248,8 @@ especially soon after a rotation.
 
 - `docs/witan-admin-break-glass-runbook.md` — `svc-witan-admin`, same shape,
   opt-in rather than required.
+- `docs/witan-council-probe-runbook.md` — `svc-witan-probe`, also opt-in,
+  for synthetic monitoring rather than maintenance.
 - `docs/witan-token-sync-runbook.md` — how service tokens reach `actor-tokens`.
 - agent-kit `mcp/servers/witan/policy/` — the Cedar bundles and the boot-time
   membership renderer.

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -58,6 +58,10 @@ from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.applications.omnigraph.cluster_config import (
     COUNCIL_GRAPH_ID,
 )
+from ol_infrastructure.applications.omnigraph.council_probe import (
+    DEFAULT_PROBE_SCHEDULE,
+    create_council_probe,
+)
 from ol_infrastructure.applications.omnigraph.data_tier import (
     CLUSTER_CONFIGMAP_NAME,
     DEFAULT_PER_ACTOR_BYTES_MAX,
@@ -223,6 +227,9 @@ OPTIMIZE_SCHEDULE = (
     omnigraph_config.get("optimize_schedule") or DEFAULT_OPTIMIZE_SCHEDULE
 )
 CLEANUP_SCHEDULE = omnigraph_config.get("cleanup_schedule") or DEFAULT_CLEANUP_SCHEDULE
+COUNCIL_PROBE_SCHEDULE = (
+    omnigraph_config.get("council_probe_schedule") or DEFAULT_PROBE_SCHEDULE
+)
 CLEANUP_OLDER_THAN = (
     omnigraph_config.get("cleanup_older_than") or DEFAULT_CLEANUP_OLDER_THAN
 )
@@ -390,6 +397,20 @@ WITAN_ADMIN_ACTOR_ID = "svc-witan-admin"
 WITAN_SERVICE_TOKEN_VAULT_PATH = "secret-operations/witan/service-token"  # noqa: S105  # pragma: allowlist secret
 WITAN_SERVICE_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 WITAN_SERVICE_ACTOR_ID = "svc-witan"
+
+# The synthetic-monitoring principal (agent-kit
+# mcp/servers/witan/policy/memory.policy.yaml `witan-probe` group). Same shape
+# as admin_token: a raw single-actor token on its own Vault path, plus the
+# matching entry in the actor-tokens map, both from the one SOPS record.
+#
+# Optional, the same way admin_token is: an environment whose SOPS file
+# predates this simply has no council-health CronJob deployed, rather than one
+# that crash-loops on a missing Secret. Separate from every other identity —
+# it is read-only on the memory graph and nothing else, so a leaked probe
+# token is worth exactly that much.
+WITAN_PROBE_TOKEN_VAULT_PATH = "secret-operations/witan/probe-token"  # noqa: S105  # pragma: allowlist secret
+WITAN_PROBE_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+WITAN_PROBE_ACTOR_ID = "svc-witan-probe"
 
 ##############################################
 #   Vault secret source (SOPS -> Vault)       #
@@ -564,11 +585,68 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
                 "shows them as separate groups."
             )
             raise ValueError(msg)
+
+    # svc-witan-probe, the council-health CronJob's identity. Optional and
+    # all-or-nothing, same shape as admin_token — see
+    # WITAN_PROBE_TOKEN_VAULT_PATH.
+    _witan_probe_token = _witan_secrets_source.get("probe_token")
+    _mapped_probe_token = _actor_tokens_map.get(WITAN_PROBE_ACTOR_ID)
+
+    for _label, _value in (
+        ("probe_token", _witan_probe_token),
+        (f"actor_tokens['{WITAN_PROBE_ACTOR_ID}']", _mapped_probe_token),
+    ):
+        if _value is not None and not str(_value).strip():
+            msg = (
+                f"omnigraph/secrets.{stack_info.env_suffix}.yaml: {_label} is "
+                "present but empty. Remove the key to leave this environment "
+                "with no council-health CronJob, or give it a real token — an "
+                "empty value is not the same as an absent one."
+            )
+            raise ValueError(msg)
+
+    if (_witan_probe_token is None) != (_mapped_probe_token is None):
+        msg = (
+            f"omnigraph/secrets.{stack_info.env_suffix}.yaml: 'probe_token' "
+            f"and actor_tokens['{WITAN_PROBE_ACTOR_ID}'] must be set together "
+            "or not at all — one without the other provisions a credential "
+            "that cannot authenticate."
+        )
+        raise ValueError(msg)
+    if _witan_probe_token is not None and _mapped_probe_token != _witan_probe_token:
+        msg = (
+            f"omnigraph/secrets.{stack_info.env_suffix}.yaml: probe_token must "
+            f"match actor_tokens['{WITAN_PROBE_ACTOR_ID}'] — they are the same "
+            "token exposed to two different consumers, exactly as ci_token and "
+            "admin_token are."
+        )
+        raise ValueError(msg)
+    for _other_label, _other_actor, _other in (
+        ("ci_token", WITAN_CI_ACTOR_ID, _witan_ci_token),
+        ("admin_token", WITAN_ADMIN_ACTOR_ID, _witan_admin_token),
+        ("service_token", WITAN_SERVICE_ACTOR_ID, _witan_service_token),
+    ):
+        if (
+            _witan_probe_token is not None
+            and _other is not None
+            and _witan_probe_token == _other
+        ):
+            msg = (
+                f"omnigraph/secrets.{stack_info.env_suffix}.yaml: probe_token "
+                f"must not equal {_other_label}. Cedar tells these principals "
+                f"apart by actor id alone, so a shared value makes "
+                f"{WITAN_PROBE_ACTOR_ID} and {_other_actor} one principal "
+                f"holding both sets of grants — the probe would gain "
+                f"everything {_other_actor} can do, while the bundle still "
+                "shows them as separate groups."
+            )
+            raise ValueError(msg)
 else:
     _actor_tokens_map = {}
     _witan_ci_token = None
     _witan_admin_token = None
     _witan_service_token = None
+    _witan_probe_token = None
 
 # A content fingerprint of the service-tokens map, independent of which of the
 # two writers below is active. Not secret — sha256 of the map's own JSON
@@ -682,6 +760,19 @@ if _witan_service_token is not None:
         path=WITAN_SERVICE_TOKEN_VAULT_PATH,
         data_json=Output.secret(
             json.dumps({WITAN_SERVICE_TOKEN_VAULT_KEY: _witan_service_token})
+        ),
+    )
+
+# The council-health probe's account. Consumed only by this stack's own
+# council-health CronJob below — unlike the other three, nothing outside this
+# program reads this path, so it needs no cross-stack StackReference.
+witan_probe_token_vault_secret = None
+if _witan_probe_token is not None:
+    witan_probe_token_vault_secret = vault.generic.Secret(
+        f"omnigraph-witan-probe-token-vault-secret-{stack_info.env_suffix}",
+        path=WITAN_PROBE_TOKEN_VAULT_PATH,
+        data_json=Output.secret(
+            json.dumps({WITAN_PROBE_TOKEN_VAULT_KEY: _witan_probe_token})
         ),
     )
 
@@ -924,8 +1015,71 @@ if MIGRATE_FROM_IMAGE:
     )
     export("storage_migration_job", storage_migration.job.metadata.name)
 
+##############################################
+#   Council-health synthetic probe            #
+##############################################
+# Entirely self-contained in this stack: unlike the admin/service tokens,
+# nothing outside this program consumes the probe's Vault path, so there is no
+# cross-stack StackReference to thread through — see WITAN_PROBE_TOKEN_VAULT_PATH.
+PROBE_TOKEN_SECRET_NAME = "witan-probe-token"  # noqa: S105  # pragma: allowlist secret
+PROBE_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+
+council_probe = None
+if witan_probe_token_vault_secret is not None:
+    probe_token_secret = OLVaultK8SSecret(
+        f"omnigraph-witan-probe-token-secret-{stack_info.env_suffix}",
+        resource_config=OLVaultK8SStaticSecretConfig(
+            name=PROBE_TOKEN_SECRET_NAME,
+            namespace=NAMESPACE,
+            labels=k8s_global_labels,
+            dest_secret_labels=k8s_global_labels,
+            dest_secret_name=PROBE_TOKEN_SECRET_NAME,
+            dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
+            mount="secret-operations",
+            mount_type="kv-v1",
+            path=WITAN_PROBE_TOKEN_VAULT_PATH,
+            exclude_raw=True,
+            excludes=[".*"],
+            templates={
+                PROBE_TOKEN_SECRET_KEY: (
+                    f'{{{{ get .Secrets "{WITAN_PROBE_TOKEN_VAULT_KEY}" }}}}'
+                )
+            },
+            refresh_after="1h",
+            # No restart target: each CronJob run is a brand-new pod that
+            # mounts the Secret fresh, unlike the always-running data-tier
+            # Deployment the actor-tokens sync has to bounce on a change.
+            vaultauth=omnigraph_auth_binding.vault_k8s_resources.auth_name,
+        ),
+        opts=ResourceOptions(
+            delete_before_replace=True,
+            depends_on=[
+                omnigraph_auth_binding.vault_k8s_resources,
+                witan_probe_token_vault_secret,
+            ],
+        ),
+    )
+    council_probe = create_council_probe(
+        stack_info=stack_info,
+        namespace=NAMESPACE,
+        k8s_global_labels=k8s_global_labels,
+        omnigraph_server_addr=omnigraph_server_addr(NAMESPACE),
+        graph_id=COUNCIL_GRAPH_ID,
+        schedule=COUNCIL_PROBE_SCHEDULE,
+        probe_token_secret_name=PROBE_TOKEN_SECRET_NAME,
+        probe_token_secret_key=PROBE_TOKEN_SECRET_KEY,
+        probe_token_secret=probe_token_secret,
+    )
+
 export("namespace", NAMESPACE)
 export("omnigraph_server_addr", omnigraph_server_addr(NAMESPACE))
+# Whether this environment has a council-health CronJob deployed — mint
+# `probe_token` in omnigraph/secrets.<env>.yaml to turn it on (see
+# WITAN_PROBE_TOKEN_VAULT_PATH). ol-infrastructure's eks_general.py staleness
+# rule lists this CronJob by name unconditionally, so an environment that
+# never provisions it just has a rule that permanently no-ops (no series,
+# no_data_state=OK), not a false alert.
+export("council_probe_provisioned", council_probe is not None)
 # The Layer-1 graph id consumers must address (`--graph <id>`). Exported
 # rather than left to each consumer's own default so the witan stack asks
 # for exactly the graph declared in cluster.yaml here.

--- a/src/ol_infrastructure/applications/omnigraph/council_probe.py
+++ b/src/ol_infrastructure/applications/omnigraph/council_probe.py
@@ -108,10 +108,13 @@ def create_council_probe(  # noqa: PLR0913
         ),
         spec=kubernetes.core.v1.PodSpecArgs(
             restart_policy="Never",
-            # No ServiceAccount token needed — see the module docstring. The
-            # default SA is left mounted at its usual read-only Kubernetes-API
-            # scope, which this pod never calls; explicitly disabling it would
-            # save nothing this pod can leak, since it makes zero K8s API calls.
+            # This pod makes zero Kubernetes API calls, but a mounted default
+            # SA token is a live credential regardless of whether the app
+            # ever uses it: a compromised container could exfiltrate it
+            # alongside the probe's own bearer token. Same posture as every
+            # other non-Kubernetes-API caller in this stack
+            # (view_reaper.py, ci_indexer.py).
+            automount_service_account_token=False,
             containers=[
                 kubernetes.core.v1.ContainerArgs(
                     name="check-council-health",

--- a/src/ol_infrastructure/applications/omnigraph/council_probe.py
+++ b/src/ol_infrastructure/applications/omnigraph/council_probe.py
@@ -1,0 +1,200 @@
+"""Deploy the council-health synthetic-probe CronJob.
+
+The probe itself is ``scripts/check_council_health.py``; its module docstring
+covers what it does and why. This module is the deployment half: schedule,
+image, and how the pod gets the one credential it needs.
+
+WHY NO IN-POD VAULT LOGIN, UNLIKE token_sync.py
+
+token_sync authenticates to Vault itself because it *writes* a Vault path at
+runtime. This job only *reads* one bearer token, and that credential already
+has a standard delivery path: the same Vault-secret-sync arrangement every
+other non-human witan token (`ci-token`, `admin-token`, `service-token`) uses
+— ``__main__.py`` writes the token to Vault from SOPS, an ``OLVaultK8SSecret``
+syncs it into a plain Kubernetes Secret, and this CronJob mounts it with an
+ordinary ``secretKeyRef``. No ServiceAccount, no Vault Kubernetes auth role,
+no ``automountServiceAccountToken`` — this pod carries no credential beyond
+the one env var.
+
+WHY A STOCK PYTHON IMAGE AND A CONFIGMAP
+
+Same reasoning as token_sync.py: the script is stdlib-only, so there is
+nothing to install and no image to build, publish, scan, or keep patched.
+Shipping it as a ConfigMap against ``python:3.12-slim`` means a change to the
+probe is a change to this stack and nothing else.
+
+OPTIONAL, THE SAME WAY THE ADMIN PRINCIPAL IS
+
+`svc-witan-probe` is opt-in per environment (see `__main__.py`): an
+environment whose operator has not yet minted a probe token gets no CronJob at
+all here, rather than one that crash-loops on a missing Secret.
+"""
+
+from pathlib import Path
+
+import pulumi_kubernetes as kubernetes
+from pulumi import Output, Resource, ResourceOptions
+
+from ol_infrastructure.lib.aws.eks_helper import cached_image_uri
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+PROBE_IMAGE = cached_image_uri("python:3.12-slim")
+
+CRONJOB_NAME = "witan-council-probe"
+SCRIPT_MOUNT_PATH = "/opt/witan-council-probe"
+SCRIPT_FILENAME = "check_council_health.py"
+
+# Every 15 minutes. The window this closes is bounded by cadence, not by the
+# request itself (one query, ~15s ceiling below) — 15m keeps the worst-case
+# "council is down and nobody has restarted a pod or made a call" detection
+# window well inside the existing staleness rule's 6h fast-bucket threshold
+# (eks_general.py), so a genuinely stuck CronJob controller is caught by that
+# rule long before a single missed run would be.
+DEFAULT_PROBE_SCHEDULE = "*/15 * * * *"
+
+# One HTTP call with its own 15s client-side timeout (script module docstring).
+# A run that has not finished in a minute is wedged on something the client
+# timeout should already have caught.
+PROBE_ACTIVE_DEADLINE_SECONDS = 60
+
+# The script is a single idempotent read; a retry is always safe, and two of
+# them ride out one dropped connection without waiting for the next tick.
+PROBE_BACKOFF_LIMIT = 1
+
+
+def create_council_probe(  # noqa: PLR0913
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    omnigraph_server_addr: str | Output[str],
+    graph_id: str,
+    schedule: str,
+    probe_token_secret_name: str,
+    probe_token_secret_key: str,
+    probe_token_secret: Resource,
+) -> kubernetes.batch.v1.CronJob:
+    """Provision the CronJob that runs the council-health probe on a schedule.
+
+    Callers gate this on the probe token actually being provisioned (see
+    ``__main__.py``) — there is no internal check here, because an
+    unconditional call with no token would either crash-loop or (worse) run
+    unauthenticated and prove nothing about the identity path being tested.
+    """
+    script_body = (Path(__file__).parent / "scripts" / SCRIPT_FILENAME).read_text()
+
+    # Same replace-on-change shape as token_sync.py's script ConfigMap: a
+    # mutated ConfigMap propagates to already-scheduled pods on the kubelet's
+    # own schedule, so a script edit has to roll a NEW ConfigMap rather than
+    # risk a run picking up half-updated content mid-propagation.
+    script_config_map = kubernetes.core.v1.ConfigMap(
+        f"witan-council-probe-script-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        data={SCRIPT_FILENAME: script_body},
+        opts=ResourceOptions(
+            replace_on_changes=["data"],
+            delete_before_replace=False,
+        ),
+    )
+
+    pod_template = kubernetes.core.v1.PodTemplateSpecArgs(
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            labels={
+                **k8s_global_labels,
+                "app.kubernetes.io/name": CRONJOB_NAME,
+            },
+        ),
+        spec=kubernetes.core.v1.PodSpecArgs(
+            restart_policy="Never",
+            # No ServiceAccount token needed — see the module docstring. The
+            # default SA is left mounted at its usual read-only Kubernetes-API
+            # scope, which this pod never calls; explicitly disabling it would
+            # save nothing this pod can leak, since it makes zero K8s API calls.
+            containers=[
+                kubernetes.core.v1.ContainerArgs(
+                    name="check-council-health",
+                    image=PROBE_IMAGE,
+                    command=["python", f"{SCRIPT_MOUNT_PATH}/{SCRIPT_FILENAME}"],
+                    env=[
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="OMNIGRAPH_SERVER_ADDR", value=omnigraph_server_addr
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="OMNIGRAPH_GRAPH_ID", value=graph_id
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="OMNIGRAPH_BEARER_TOKEN",
+                            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                                secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                                    name=probe_token_secret_name,
+                                    key=probe_token_secret_key,
+                                )
+                            ),
+                        ),
+                    ],
+                    volume_mounts=[
+                        kubernetes.core.v1.VolumeMountArgs(
+                            name="script",
+                            mount_path=SCRIPT_MOUNT_PATH,
+                            read_only=True,
+                        )
+                    ],
+                    security_context=kubernetes.core.v1.SecurityContextArgs(
+                        run_as_non_root=True,
+                        run_as_user=1000,
+                        run_as_group=1000,
+                    ),
+                    # One HTTP call. The limits are here to make it
+                    # evictable-last rather than because it is anywhere near
+                    # them.
+                    resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                        requests={"cpu": "25m", "memory": "32Mi"},
+                        limits={"cpu": "250m", "memory": "128Mi"},
+                    ),
+                )
+            ],
+            volumes=[
+                kubernetes.core.v1.VolumeArgs(
+                    name="script",
+                    config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                        name=script_config_map.metadata.name,
+                        default_mode=0o555,
+                    ),
+                )
+            ],
+        ),
+    )
+
+    return kubernetes.batch.v1.CronJob(
+        f"witan-council-probe-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=CRONJOB_NAME,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.CronJobSpecArgs(
+            schedule=schedule,
+            # A run overlapping the previous one would just mean two identical
+            # reads in flight; Forbid keeps the job history and the failure
+            # signal legible rather than piling up concurrent runs if the
+            # server is genuinely slow to answer.
+            concurrency_policy="Forbid",
+            starting_deadline_seconds=300,
+            successful_jobs_history_limit=1,
+            # A failed run is the one whose logs somebody needs, and the
+            # failure IS the alert signal this whole probe exists to produce
+            # (see the module docstring) — keep more than the successes.
+            failed_jobs_history_limit=5,
+            job_template=kubernetes.batch.v1.JobTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+                spec=kubernetes.batch.v1.JobSpecArgs(
+                    backoff_limit=PROBE_BACKOFF_LIMIT,
+                    active_deadline_seconds=PROBE_ACTIVE_DEADLINE_SECONDS,
+                    template=pod_template,
+                ),
+            ),
+        ),
+        opts=ResourceOptions(depends_on=[script_config_map, probe_token_secret]),
+    )

--- a/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
@@ -1,0 +1,175 @@
+"""Authenticated synthetic probe: prove `council` answers a real query.
+
+Carved out of tk-observability-for-shared-witan-service-ad3dba item 1
+(tk-an-authenticated-synthetic-probe-for-council-to--e89d8f). Two alert rules
+already cover a lost `council` graph from opposite directions —
+`WitanToolCallErrorRate` (needs live traffic) and `WitanGraphQuarantined`
+(needs a pod restart) — and a real window sits between them: `council` lost
+during a quiet period with no restart goes unreported until someone tries to
+use the service, which for a shared agent memory graph can be hours.
+
+Neither existing health check can close that window, and both should stay as
+they are:
+  - omnigraph's `/healthz` is flat and never auth-gated by design.
+  - witan's own probe answers from process state alone — a probe that checks
+    the data tier converts backend SLOWNESS into frontend DEATH, which is
+    exactly what took the service down on 2026-08-12.
+
+So this is a deliberately separate, out-of-band, AUTHENTICATED caller: it runs
+as its own CronJob, in its own pod, with its own narrowly-scoped Cedar
+identity (`svc-witan-probe` — read + invoke_query on the memory graph only,
+nothing else), and does the one thing neither existing check can: run a real
+query against `council` and see whether it comes back.
+
+WHY THIS NEEDS NO NEW ALERT RULE
+
+A failing run IS the signal. `WitanScheduledJobNeverSucceeded` and
+`eks_general.py`'s `WorkloadJobFailed*` already alert on a CronJob whose Job
+fails — this script just needs to exit non-zero for a real failure and exit 0
+for a real success, cleanly, so those existing rules have something honest to
+key off. The CronJob's own name is added to `eks_general.py`'s fast staleness
+bucket, for the "stopped running entirely" case those Job-failure rules
+cannot see.
+
+WHY STDLIB-ONLY
+
+Same reason as `sync_actor_tokens.py`: one HTTP call needs nothing installed,
+so this ships as a ConfigMap against `python:3.12-slim` rather than a built
+image — a change here is a change to this stack and nothing else.
+
+WHY A RAW HTTP CALL RATHER THAN THE `witan_core` CLIENT
+
+The whole point is to exercise the same wire contract every real caller uses
+(`POST /graphs/<id>/query`, `witan_core.omnigraph_http.PooledTransport.query`)
+without depending on `witan_core` being installed — installing it here would
+turn this ConfigMap back into an image-build problem. The query text below is
+deliberately trivial and read-only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, cast
+
+LOG = logging.getLogger("check-council-health")
+
+# One bounded read against a node type every environment's memory graph
+# schema declares. No parameters, so there is nothing for a caller to get
+# wrong — the whole point is to fail on the SERVER'S answer, not on this
+# script's own input.
+PROBE_QUERY = """
+query council_probe() {
+    match { $m: Memory }
+    return { $m.slug }
+    limit 1
+}
+"""
+
+HTTP_TIMEOUT_SECONDS = 15
+
+
+class ProbeError(Exception):
+    """A condition that must exit the run non-zero."""
+
+
+def run_probe(server_addr: str, graph_id: str, token: str) -> dict[str, Any]:
+    """POST the probe query and return the decoded JSON body on success.
+
+    Raises :class:`ProbeError` for anything that means `council` did not
+    answer: an unreachable server, a non-2xx response, or a 2xx body that
+    is not the JSON shape a query response actually takes. That last case
+    matters as much as the network failures — a 200 from a misconfigured
+    proxy in front of the real server would otherwise read as success.
+    """
+    url = f"{server_addr.rstrip('/')}/graphs/{graph_id}/query"
+    payload = json.dumps({"query": PROBE_QUERY, "params": {}}).encode()
+    request = urllib.request.Request(  # noqa: S310 - server_addr is our own config
+        url,
+        method="POST",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - server_addr is our own config
+            request, timeout=HTTP_TIMEOUT_SECONDS
+        ) as response:
+            status = response.status
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        msg = f"POST {url} failed: HTTP {exc.code} {detail}"
+        raise ProbeError(msg) from exc
+    except urllib.error.URLError as exc:
+        msg = f"POST {url} failed: {exc.reason}"
+        raise ProbeError(msg) from exc
+    except TimeoutError as exc:
+        msg = f"POST {url} timed out after {HTTP_TIMEOUT_SECONDS}s"
+        raise ProbeError(msg) from exc
+
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as exc:
+        msg = (
+            f"POST {url} returned HTTP {status} with a non-JSON body "
+            f"({body[:200]!r}): {exc}"
+        )
+        raise ProbeError(msg) from exc
+    if not isinstance(parsed, dict) or "rows" not in parsed:
+        msg = (
+            f"POST {url} returned HTTP {status} with an unexpected body shape "
+            f"(no 'rows' key): {parsed!r}"
+        )
+        raise ProbeError(msg)
+    return parsed
+
+
+def main() -> int:
+    """Run the probe once and exit non-zero on any failure to answer."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    server_addr = os.environ.get("OMNIGRAPH_SERVER_ADDR")
+    graph_id = os.environ.get("OMNIGRAPH_GRAPH_ID", "council")
+    token = os.environ.get("OMNIGRAPH_BEARER_TOKEN")
+    missing = [
+        name
+        for name, value in (
+            ("OMNIGRAPH_SERVER_ADDR", server_addr),
+            ("OMNIGRAPH_BEARER_TOKEN", token),
+        )
+        if not value
+    ]
+    if missing:
+        LOG.error("missing required env var(s): %s", ", ".join(missing))
+        return 1
+
+    try:
+        # `missing` being empty is what guarantees these are str, not None;
+        # cast rather than assert since this is not a runtime invariant worth
+        # enforcing twice, just a fact the type checker cannot see through
+        # the comprehension above.
+        result = run_probe(cast(str, server_addr), graph_id, cast(str, token))
+    except ProbeError as exc:
+        # Not `.exception()`: `exc` is already a fully-formatted, known
+        # failure message (a classified HTTP/JSON condition), not an
+        # unexpected exception whose traceback would add anything here.
+        LOG.error("council-health probe failed: %s", exc)  # noqa: TRY400
+        return 1
+
+    LOG.info(
+        "council-health probe OK: graph=%s row_count=%s",
+        graph_id,
+        result.get("row_count", len(result.get("rows", []))),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
@@ -122,10 +122,10 @@ def run_probe(server_addr: str, graph_id: str, token: str) -> dict[str, Any]:
             f"({body[:200]!r}): {exc}"
         )
         raise ProbeError(msg) from exc
-    if not isinstance(parsed, dict) or "rows" not in parsed:
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("rows"), list):
         msg = (
             f"POST {url} returned HTTP {status} with an unexpected body shape "
-            f"(no 'rows' key): {parsed!r}"
+            f"('rows' missing or not a list): {parsed!r}"
         )
         raise ProbeError(msg)
     return parsed

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -538,6 +538,7 @@ def create(
             # adding it. Current inventory:
             #   0/5 * * * *  cron-deploy-pipelines, cron-reindex   -> fast
             #   17 * * * *   witan-token-sync                      -> fast
+            #   */15 * * * * witan-council-probe                   -> fast
             #   20 3 * * *   omnigraph-optimize                    -> slow
             #
             # omnigraph-optimize is NIGHTLY and the slow bucket is 15 days, so
@@ -550,6 +551,14 @@ def create(
             # there.
             #   20 4 * * 0   omnigraph-cleanup                     -> slow
             #   30 7 * * 0   cms-edxapp-reindex-courses            -> slow
+            #
+            # witan-council-probe is not deployed in every environment (it
+            # needs a minted svc-witan-probe token, applications/omnigraph
+            # __main__.py) -- membership here is unconditional anyway, since a
+            # CronJob that never exists in an environment just means no
+            # kube_cronjob_status_last_successful_time series there, which is
+            # NoData and stays silent under no_data_state=OK, same as any
+            # other unmanaged member of this list would.
             #
             # Two CronJobs are deliberately absent from both buckets:
             #
@@ -591,7 +600,7 @@ def create(
                 datas=rd(
                     "max by (cluster, namespace, cronjob) (time() - "
                     "(kube_cronjob_status_last_successful_time"
-                    '{cluster=~".*-(ci|qa)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync"} > 0)) > 21600'
+                    '{cluster=~".*-(ci|qa)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-council-probe"} > 0)) > 21600'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -607,7 +616,7 @@ def create(
                 datas=rd(
                     "max by (cluster, namespace, cronjob) (time() - "
                     "(kube_cronjob_status_last_successful_time"
-                    '{cluster=~".*-(production)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync"} > 0)) > 21600'
+                    '{cluster=~".*-(production)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-council-probe"} > 0)) > 21600'
                 ),
             ),
             alerting.RuleGroupRuleArgs(

--- a/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
@@ -124,6 +124,26 @@ def test_run_probe_rejects_a_2xx_body_missing_rows(stub_server):
         run_probe(base, "council", "t")  # pragma: allowlist secret
 
 
+@pytest.mark.parametrize(
+    "malformed_rows",
+    [
+        None,  # {"rows": null, ...} — a present-but-empty key
+        "ok",  # {"rows": "ok", ...} — present, wrong type
+    ],
+)
+def test_run_probe_rejects_rows_that_is_not_a_list(stub_server, malformed_rows):
+    """`rows` present but the wrong shape must fail the same as a missing
+    key — a presence-only check would let a proxy-shaped 2xx through.
+    """
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/graphs/council/query": (200, {"rows": malformed_rows, "row_count": 1})
+    }
+
+    with pytest.raises(ProbeError, match="unexpected body shape"):
+        run_probe(base, "council", "t")  # pragma: allowlist secret
+
+
 def test_run_probe_raises_when_the_server_is_unreachable():
     with pytest.raises(ProbeError, match="failed"):
         run_probe(

--- a/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
@@ -1,0 +1,163 @@
+"""Tests for the council-health synthetic probe.
+
+The property worth pinning is what "the probe worked" actually means: a 2xx
+response is not enough on its own (a misconfigured proxy can return one), the
+request has to carry the bearer token, and a genuine server error or an
+unreachable server both have to come back as a non-zero exit — that exit code
+is the only signal the CronJob-failure alert rules ever see.
+"""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from typing import Any, ClassVar
+
+import pytest
+
+from ol_infrastructure.applications.omnigraph.scripts.check_council_health import (
+    ProbeError,
+    main,
+    run_probe,
+)
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Serves whatever ``routes`` maps the path to: (status, body)."""
+
+    routes: ClassVar[dict[str, Any]] = {}
+    #: Every request this handler has served, for tests that assert on how the
+    #: probe called out rather than only on what came back.
+    requests: ClassVar[list[dict[str, Any]]] = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw_body = self.rfile.read(length) if length else b""
+        self.__class__.requests.append(
+            {
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+                "body": json.loads(raw_body) if raw_body else None,
+            }
+        )
+        status, body = self.routes.get(self.path, (404, {"error": "not found"}))
+        payload = body.encode() if isinstance(body, str) else json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def stub_server():
+    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _StubHandler.routes = {}
+    _StubHandler.requests = []
+    yield server, f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+
+
+def test_run_probe_sends_the_bearer_token_and_query_path(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/graphs/council/query": (200, {"rows": [{"m.slug": "x"}], "row_count": 1})
+    }
+
+    result = run_probe(base, "council", "t")  # pragma: allowlist secret
+
+    assert result["row_count"] == 1
+    [seen] = _StubHandler.requests
+    assert seen["path"] == "/graphs/council/query"
+    assert seen["authorization"] == "Bearer t"
+    assert seen["body"]["params"] == {}
+    assert "match" in seen["body"]["query"]
+
+
+def test_run_probe_targets_the_graph_id_it_is_given(stub_server):
+    """The acceptance test this task names: point it at a graph id that does
+    not exist and confirm the probe fails for that reason.
+    """
+    _, base = stub_server
+    _StubHandler.routes = {"/graphs/council/query": (200, {"rows": [], "row_count": 0})}
+
+    with pytest.raises(ProbeError, match="HTTP 404"):
+        run_probe(base, "does-not-exist", "t")  # pragma: allowlist secret
+
+
+def test_run_probe_raises_on_a_server_error(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/graphs/council/query": (
+            500,
+            {"error": "policy denied action 'read'", "code": "denied"},
+        )
+    }
+
+    with pytest.raises(ProbeError, match="policy denied action"):
+        run_probe(base, "council", "t")  # pragma: allowlist secret
+
+
+def test_run_probe_rejects_a_non_json_2xx_body(stub_server):
+    """A 200 with the wrong shape is a misrouted request, not a working probe —
+    e.g. an HTML page from a proxy in front of the real server.
+    """
+    _, base = stub_server
+    _StubHandler.routes = {"/graphs/council/query": (200, "<html>not json</html>")}
+
+    with pytest.raises(ProbeError, match="non-JSON body"):
+        run_probe(base, "council", "t")  # pragma: allowlist secret
+
+
+def test_run_probe_rejects_a_2xx_body_missing_rows(stub_server):
+    """A 200 whose body is JSON but not a query response — same failure mode
+    as the non-JSON case, one layer further in.
+    """
+    _, base = stub_server
+    _StubHandler.routes = {"/graphs/council/query": (200, {"ok": True})}
+
+    with pytest.raises(ProbeError, match="unexpected body shape"):
+        run_probe(base, "council", "t")  # pragma: allowlist secret
+
+
+def test_run_probe_raises_when_the_server_is_unreachable():
+    with pytest.raises(ProbeError, match="failed"):
+        run_probe(
+            "http://127.0.0.1:1",  # nothing listens on port 1
+            "council",
+            "t",  # pragma: allowlist secret
+        )
+
+
+def test_main_fails_closed_on_missing_env(monkeypatch):
+    monkeypatch.delenv("OMNIGRAPH_SERVER_ADDR", raising=False)
+    monkeypatch.delenv("OMNIGRAPH_BEARER_TOKEN", raising=False)
+
+    assert main() == 1
+
+
+def test_main_succeeds_end_to_end(stub_server, monkeypatch):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/graphs/council/query": (200, {"rows": [{"m.slug": "x"}], "row_count": 1})
+    }
+    monkeypatch.setenv("OMNIGRAPH_SERVER_ADDR", base)
+    monkeypatch.setenv("OMNIGRAPH_BEARER_TOKEN", "t")  # pragma: allowlist secret
+    monkeypatch.delenv("OMNIGRAPH_GRAPH_ID", raising=False)
+
+    assert main() == 0
+    [seen] = _StubHandler.requests
+    assert seen["path"] == "/graphs/council/query"
+
+
+def test_main_fails_on_a_probe_failure(stub_server, monkeypatch):
+    _, base = stub_server
+    _StubHandler.routes = {"/graphs/council/query": (500, {"error": "boom"})}
+    monkeypatch.setenv("OMNIGRAPH_SERVER_ADDR", base)
+    monkeypatch.setenv("OMNIGRAPH_BEARER_TOKEN", "t")  # pragma: allowlist secret
+
+    assert main() == 1


### PR DESCRIPTION
### What are the relevant tickets?
`tk-an-authenticated-synthetic-probe-for-council-to--e89d8f` (witan project tracker, workflow project `wp-witan-multi-user-service-deployment-dcf6ee`)

### Description (What does it do?)
Two alert rules already cover a lost `council` graph, from opposite directions, and a real window sits between them: `WitanToolCallErrorRate` needs live MCP traffic (0/0 = NaN with none), and `WitanGraphQuarantined` needs a pod restart to have anything to compare. `council` lost during a quiet period with no restart is invisible to both until someone tries to use the service — which for a shared agent memory graph can be hours.

Neither existing health check can be deepened to close that gap without breaking what it's for: omnigraph's `/healthz` is flat and unauthenticated by design, and witan's own probe deliberately answers from process state alone (deepening it converts backend slowness into frontend death — this is what took the service down on 2026-08-12).

So this adds a deliberately separate, out-of-band, **authenticated** caller:

- `check_council_health.py` — a stdlib-only script (same reasoning as `sync_actor_tokens.py`: nothing to install, ships as a ConfigMap against `python:3.12-slim`) that POSTs one trivial, parameter-free read against `council` (`POST /graphs/<id>/query`, the same wire contract every real caller uses) and exits non-zero on anything that means the graph did not answer — unreachable server, non-2xx, or a 2xx body that isn't a real query response.
- `council_probe.py` — the CronJob deployment: every 15 minutes, authenticating with a bearer token mounted from a plain `secretKeyRef` (no in-pod Vault login — this pod only reads a credential, it doesn't mint or write one).
- The credential is `svc-witan-probe`, a new dedicated Cedar identity landing in agent-kit#323 — read + `invoke_query` on the memory graph only. Neither existing service identity fit: `svc-witan-ci` is permanently excluded from the memory graph by design, `svc-witan-admin` is break-glass and shouldn't authenticate on a schedule.
- **No new alert rule needed.** A failing run *is* the signal: `WitanScheduledJobNeverSucceeded` and `eks_general.py`'s `WorkloadJobFailed*` already alert on a failing CronJob. The CronJob's name is added to `eks_general.py`'s fast staleness bucket, for the "stopped running entirely" case those miss.
- **Opt-in**, the same shape as `svc-witan-admin`: an environment with no minted `probe_token` in its SOPS file just has no CronJob deployed — no crash-loop, no partially-authenticated state.

Full identity/provisioning writeup: `docs/witan-council-probe-runbook.md`.

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/applications/omnigraph/` — 112 passed, including 9 new tests in `test_check_council_health.py` against a real `http.server` stub (bearer token delivery, the graph-id-in-path acceptance case from this task's own acceptance criteria, a genuine server error, a non-JSON 2xx body, an unreachable server, and `main()`'s exit codes end to end).
- `uv run mypy` on both new source files — clean.
- `uv run ruff check` / `ruff format --check` on all changed/new files — clean.
- `pre-commit run --files <changed files>` — every hook passes (ruff, mypy, detect-secrets, etc.).
- Not yet run against a live cluster: that needs `probe_token` minted in a real environment's SOPS file first (see runbook), which is the remaining manual step before this task's own acceptance criteria (point the probe at a nonexistent graph id, confirm the alert path fires end to end) can be exercised for real.

### Additional Context
This depends on agent-kit#323 (the Cedar grant) merging first — without it, a deployed probe would authenticate and then get `policy denied action 'read' for unknown actor 'svc-witan-probe'` on every run, which is itself a clean, loud failure (not silent), but not the intended one.

Provisioning `probe_token` per environment is a manual SOPS step I can't do from here (no KMS/decrypt access) — the runbook documents it precisely (`sops set ... probe_token`, `sops set ... actor_tokens.svc-witan-probe`). Until that's done in an environment, `pulumi up` there creates no CronJob and no Secret — nothing crash-loops.