### PR TITLE
fix(concourse): apply ECR lifecycle policy to k8s_apps pipelines

### DIFF
--- a/src/ol_concourse/pipelines/container_images/dcind.py
+++ b/src/ol_concourse/pipelines/container_images/dcind.py
@@ -105,7 +105,7 @@ docker_pipeline = Pipeline(
                     },
                 ),
                 ensure_ecr_task("mitodl/dcind"),
-                configure_ecr_repository_task("mitodl/dcind"),
+                configure_ecr_repository_task("mitodl/dcind", keep_last_n_images=10),
                 PutStep(
                     put=dcind_release_image.name,
                     inputs="detect",

--- a/src/ol_concourse/pipelines/container_images/google_ads_optimization.py
+++ b/src/ol_concourse/pipelines/container_images/google_ads_optimization.py
@@ -55,7 +55,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=ad_opt_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/ad-opt"),
-                configure_ecr_repository_task("mitodl/ad-opt"),
+                configure_ecr_repository_task("mitodl/ad-opt", keep_last_n_images=10),
                 PutStep(
                     put=ad_opt_release_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/hashicorp_release_resource.py
+++ b/src/ol_concourse/pipelines/container_images/hashicorp_release_resource.py
@@ -59,7 +59,9 @@ docker_pipeline = Pipeline(
                 GetStep(get=hashicorp_release_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/hashicorp-release-resource"),
-                configure_ecr_repository_task("mitodl/hashicorp-release-resource"),
+                configure_ecr_repository_task(
+                    "mitodl/hashicorp-release-resource", keep_last_n_images=10
+                ),
                 PutStep(
                     put=hashicorp_release_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/mitodl_concourse_npm_resource.py
+++ b/src/ol_concourse/pipelines/container_images/mitodl_concourse_npm_resource.py
@@ -59,7 +59,9 @@ docker_pipeline = Pipeline(
                 GetStep(get=concourse_npm_resource_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/concourse-npm-resource"),
-                configure_ecr_repository_task("mitodl/concourse-npm-resource"),
+                configure_ecr_repository_task(
+                    "mitodl/concourse-npm-resource", keep_last_n_images=10
+                ),
                 PutStep(
                     put=concourse_npm_resource_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/ocw_course_publisher.py
+++ b/src/ol_concourse/pipelines/container_images/ocw_course_publisher.py
@@ -66,7 +66,9 @@ docker_pipeline = Pipeline(
                 GetStep(get=ocw_studio_repo.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/ocw-course-publisher"),
-                configure_ecr_repository_task("mitodl/ocw-course-publisher"),
+                configure_ecr_repository_task(
+                    "mitodl/ocw-course-publisher", keep_last_n_images=10
+                ),
                 PutStep(
                     put=ocw_course_publisher_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -66,7 +66,9 @@ def build_job(python_version: str) -> Job:
                 },
             ),
             ensure_ecr_task("mitodl/ol-python-base"),
-            configure_ecr_repository_task("mitodl/ol-python-base"),
+            configure_ecr_repository_task(
+                "mitodl/ol-python-base", keep_last_n_images=10
+            ),
             PutStep(
                 put=image_resources[python_version].name,
                 inputs="detect",

--- a/src/ol_concourse/pipelines/container_images/ol_superset.py
+++ b/src/ol_concourse/pipelines/container_images/ol_superset.py
@@ -61,7 +61,9 @@ docker_pipeline = Pipeline(
                     },
                 ),
                 ensure_ecr_task("mitodl/ol-superset"),
-                configure_ecr_repository_task("mitodl/ol-superset"),
+                configure_ecr_repository_task(
+                    "mitodl/ol-superset", keep_last_n_images=10
+                ),
                 PutStep(
                     put=ol_superset_image.name,
                     params={"image": "image/image.tar"},

--- a/src/ol_concourse/pipelines/container_images/openedx_tubular.py
+++ b/src/ol_concourse/pipelines/container_images/openedx_tubular.py
@@ -55,7 +55,9 @@ docker_pipeline = Pipeline(
                 GetStep(get=tubular_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/openedx-tubular"),
-                configure_ecr_repository_task("mitodl/openedx-tubular"),
+                configure_ecr_repository_task(
+                    "mitodl/openedx-tubular", keep_last_n_images=10
+                ),
                 PutStep(
                     put=tubular_image.name,
                     params={

--- a/src/ol_concourse/pipelines/ecr.py
+++ b/src/ol_concourse/pipelines/ecr.py
@@ -24,28 +24,58 @@ from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 
 def configure_ecr_repository_task(
-    repo_name: str, *, keep_last_n_images: int = 10
+    repo_name: str,
+    *,
+    keep_last_n_images: int | None = None,
+    expire_after_days: int | None = None,
 ) -> TaskStep:
-    """Return a TaskStep applying scan-on-push + an image-count lifecycle policy.
+    """Return a TaskStep applying scan-on-push + a lifecycle policy.
 
     Safe to run on every pipeline execution: both
     ``put-image-scanning-configuration`` and ``put-lifecycle-policy`` are
     idempotent -- each call just (re)applies the same configuration.
 
+    Exactly one of ``keep_last_n_images``/``expire_after_days`` must be set.
+    ``keep_last_n_images`` (count-based, ``tagStatus: any``) is only safe
+    for a repository written to by a single build job/branch. For a
+    repository shared by independent CI and release build jobs (this
+    module's own docstring already flags that pattern), a burst of CI
+    commits can push the still-deployed release image out of the "N most
+    recent" window and delete it -- breaking any future pod/node image
+    pull. Use ``expire_after_days`` there instead: CI churn volume no
+    longer matters, only genuine staleness does, so a release image
+    redeployed within any reasonable window is never at risk. Flagged by
+    Copilot review on PR #5728 against exactly this shared-repo case.
+
     :param repo_name: The ECR repository name, e.g. ``"witan"``.
     :param keep_last_n_images: Expire all but the most recent N images.
+    :param expire_after_days: Expire images not pushed within the last N days.
     """
+    if (keep_last_n_images is None) == (expire_after_days is None):
+        msg = "Exactly one of keep_last_n_images or expire_after_days must be set"
+        raise ValueError(msg)
+    if keep_last_n_images is not None:
+        selection = {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": keep_last_n_images,
+        }
+        description = f"Keep last {keep_last_n_images} images"
+    else:
+        selection = {
+            "tagStatus": "any",
+            "countType": "sinceImagePushed",
+            "countUnit": "days",
+            "countNumber": expire_after_days,
+        }
+        description = f"Expire images older than {expire_after_days} days"
     lifecycle_policy = json.dumps(
         {
             "rules": [
                 {
                     "rulePriority": 1,
-                    "description": f"Keep last {keep_last_n_images} images",
-                    "selection": {
-                        "tagStatus": "any",
-                        "countType": "imageCountMoreThan",
-                        "countNumber": keep_last_n_images,
-                    },
+                    "description": description,
+                    "selection": selection,
                     "action": {"type": "expire"},
                 }
             ]

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -363,7 +363,7 @@ def _ensure_ecr_repository_step(
         # recent" window and delete it. Age-based means CI volume can't
         # threaten a release image redeployed within any reasonable
         # window. Flagged by Copilot review on PR #5728.
-        configure_ecr_repository_task(repo_name, expire_after_days=180),
+        configure_ecr_repository_task(repo_name, expire_after_days=90),
     ]
 
 

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -49,6 +49,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
     dockerhub_ecr_image_uri,
 )
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_job, pulumi_jobs_chain
 from ol_concourse.pipelines.secrets_map import project_secrets_paths
 from ol_concourse.pipelines.versions_map import project_version_paths
@@ -311,33 +312,51 @@ def _fastly_purge_params(purge_scope: str) -> dict[str, str]:
     return {"mode": "surrogate_key", "surrogate_key": purge_scope}
 
 
-def _ensure_ecr_repository_step(ecr_registry_image_resource: Resource) -> TaskStep:
-    """Return the shared 'create the ECR repo if it does not exist yet' step."""
-    return TaskStep(
-        task=Identifier("ensure-ecr-repository"),
-        config=TaskConfig(
-            platform=Platform.linux,
-            image_resource=AnonymousResource(
-                type="registry-image",
-                source={
-                    "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
-                    "tag": "latest",
-                    "aws_region": ECR_REGION,
+def _ensure_ecr_repository_step(
+    ecr_registry_image_resource: Resource,
+) -> list[TaskStep]:
+    """Return steps to create the ECR repo if missing, then apply its
+    scan-on-push + lifecycle-policy configuration.
+
+    Without the second step, every build permanently accumulates as its own
+    image in ECR -- Inspector re-scans and re-reports the same CVEs against
+    every old, unused build forever. Other pipeline generators
+    (witan, omnigraph, superset, ...) already pair ensure_ecr_task with
+    configure_ecr_repository_task; this generator's apps (mit-learn,
+    mitxonline, xpro, odl-video-service, and others sharing this step) were
+    missing the second half of that pairing, confirmed live via
+    `aws ecr describe-images` -- mit-learn-app alone had 1,204 accumulated
+    images, each carrying its own full copy of the same ~1,900 CVEs.
+    """
+    repo_name = ecr_registry_image_resource.source["repository"]
+    return [
+        TaskStep(
+            task=Identifier("ensure-ecr-repository"),
+            config=TaskConfig(
+                platform=Platform.linux,
+                image_resource=AnonymousResource(
+                    type="registry-image",
+                    source={
+                        "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                        "tag": "latest",
+                        "aws_region": ECR_REGION,
+                    },
+                ),
+                params={
+                    "REPO_NAME": repo_name,
+                    "AWS_PAGER": "cat",
                 },
-            ),
-            params={
-                "REPO_NAME": ecr_registry_image_resource.source["repository"],
-                "AWS_PAGER": "cat",
-            },
-            run=Command(
-                path="sh",
-                args=[
-                    "-exc",
-                    "aws ecr describe-repositories --repository-names ${REPO_NAME} || aws ecr create-repository --repository-name ${REPO_NAME}",
-                ],
+                run=Command(
+                    path="sh",
+                    args=[
+                        "-exc",
+                        "aws ecr describe-repositories --repository-names ${REPO_NAME} || aws ecr create-repository --repository-name ${REPO_NAME}",
+                    ],
+                ),
             ),
         ),
-    )
+        configure_ecr_repository_task(repo_name),
+    ]
 
 
 # ============================================================================
@@ -605,7 +624,7 @@ def _build_image_job_legacy(
         put_params["version"] = f"((.:{version_var}))"
         put_params["bump_aliases"] = True
 
-    plan.append(_ensure_ecr_repository_step(ecr_registry_image_resource))
+    plan.extend(_ensure_ecr_repository_step(ecr_registry_image_resource))
     plan.append(PutStep(put=dockerhub_registry_image_resource.name, params=put_params))
     plan.append(PutStep(put=ecr_registry_image_resource.name, params=put_params))
 
@@ -1028,7 +1047,7 @@ def _build_image_job(
             },
             build_args=[],
         ),
-        _ensure_ecr_repository_step(ecr_registry_image_resource),
+        *_ensure_ecr_repository_step(ecr_registry_image_resource),
         PutStep(
             put=dockerhub_registry_image_resource.name,
             params={
@@ -1135,7 +1154,7 @@ def _build_release_image_job(
             },
             build_args=[],
         ),
-        _ensure_ecr_repository_step(ecr_registry_image_resource),
+        *_ensure_ecr_repository_step(ecr_registry_image_resource),
         PutStep(put=dockerhub_registry_image_resource.name, params=put_params),
         PutStep(put=ecr_registry_image_resource.name, params=put_params),
     ]

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -355,10 +355,15 @@ def _ensure_ecr_repository_step(
                 ),
             ),
         ),
-        # keep_last_n_images made explicit here rather than left as the
-        # function's default -- so the actual retention count is visible in
-        # a diff of this call site, not only inside ecr.py.
-        configure_ecr_repository_task(repo_name, keep_last_n_images=10),
+        # expire_after_days, not keep_last_n_images: this repo is shared by
+        # independent CI (every main-branch commit) and release build jobs
+        # (see the registry_image() calls above/below using the same
+        # image_repository) -- a count-based policy would let CI churn
+        # push the still-deployed release image out of the "N most
+        # recent" window and delete it. Age-based means CI volume can't
+        # threaten a release image redeployed within any reasonable
+        # window. Flagged by Copilot review on PR #5728.
+        configure_ecr_repository_task(repo_name, expire_after_days=180),
     ]
 
 

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -355,7 +355,10 @@ def _ensure_ecr_repository_step(
                 ),
             ),
         ),
-        configure_ecr_repository_task(repo_name),
+        # keep_last_n_images made explicit here rather than left as the
+        # function's default -- so the actual retention count is visible in
+        # a diff of this call site, not only inside ecr.py.
+        configure_ecr_repository_task(repo_name, keep_last_n_images=10),
     ]
 
 

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -115,7 +115,7 @@ def build_omnigraph_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
-            configure_ecr_repository_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME, keep_last_n_images=10),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -118,7 +118,7 @@ def build_witan_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
-            configure_ecr_repository_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME, keep_last_n_images=10),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
@@ -156,7 +156,7 @@ def grader_base_image_pipeline() -> Pipeline:
                 },
             ),
             ensure_ecr_task(_BASE_IMAGE_REPO),
-            configure_ecr_repository_task(_BASE_IMAGE_REPO),
+            configure_ecr_repository_task(_BASE_IMAGE_REPO, keep_last_n_images=10),
             _version_tag_task(str(xqwatcher_repo.name), python_version),
             # Push to DockerHub first — fail fast if credentials are wrong
             # before consuming the ECR push quota.

--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -181,7 +181,7 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
                 ),
             ),
             ensure_ecr_task(config.ecr_repo_name),
-            configure_ecr_repository_task(config.ecr_repo_name),
+            configure_ecr_repository_task(config.ecr_repo_name, keep_last_n_images=10),
             PutStep(
                 put=grader_ecr_image.name,
                 params={


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`_ensure_ecr_repository_step` in `k8s_apps/pipeline.py` only created the ECR repository if it was missing — it never applied scan-on-push or a lifecycle policy the way other pipeline generators in this repo (witan, omnigraph, superset, ...) already do via `configure_ecr_repository_task()`.

Because of this, every commit to any of the 9 apps built through this pipeline generator (`mit-learn`, `mitxonline`, `xpro`, `odl-video-service`, `mit-learn-nextjs`, `learn-ai`, `micromasters`, `ocw-studio`, `ol-analytics-api`) permanently accumulated as its own image in ECR, and Amazon Inspector re-scans and re-reports the same CVEs against every old, unused build forever.

This was found while triaging Security Hub's finding backlog: of ~15,000 sampled active Inspector findings account-wide, ~12,600 collapsed to just 17 distinct (repo, digest) images once deduplicated. `mit-learn-app`'s images alone accounted for 5,769 of those findings — confirmed via `aws ecr describe-images` to have over **1,200 accumulated images** in that one repository (and still growing), each carrying its own full copy of the same ~1,923 CVEs.

**Fix:** pair each `ensure-ecr-repository` step with `configure_ecr_repository_task(repo_name, expire_after_days=90)`, matching the existing established pattern used elsewhere in this codebase, with one important difference explained below.

```json
{
  "rules": [
    {
      "rulePriority": 1,
      "description": "Expire images older than 90 days",
      "selection": {
        "tagStatus": "any",
        "countType": "sinceImagePushed",
        "countUnit": "days",
        "countNumber": 90
      },
      "action": { "type": "expire" }
    }
  ]
}
```

**Age-based, not count-based — this is the result of review feedback.** The initial version of this PR used `keep_last_n_images=10` (count-based), matching every other existing caller. [@copilot-pull-request-reviewer](https://github.com/copilot-pull-request-reviewer) correctly flagged that this is unsafe for these specific repos: they're shared by independent main-branch CI, release-candidate, and release build jobs (confirmed at the `registry_image()` calls in `pipeline.py`), and a burst of CI commits could push the still-deployed QA/Production image out of the "10 most recent" window and delete it — breaking any future pod/node image pull.

`configure_ecr_repository_task()` now supports `expire_after_days` as an alternative to `keep_last_n_images` (exactly one must be set). With age-based expiry, CI commit *volume* can't accelerate deletion of the deployed image — only genuine *staleness* (no rebuild in 90+ days) can. All 12 other existing callers (witan, omnigraph, superset, ol-python-base, ...) now pass `keep_last_n_images=10` explicitly to preserve their exact prior behavior — those repos are each written to by a single build job, so the count-based policy was never unsafe for them.

**Residual risk, accepted as a reasonable tradeoff:** if a deployed image genuinely goes 90+ days without any rebuild, it becomes eligible for expiry like anything else, and the *next* node disruption requiring a fresh pull (node replacement, autoscaling, a rolling restart) would fail. A tag-pattern-based approach to protect release tags specifically was considered and rejected: the release-candidate image's `additional_tags` unconditionally includes a git-short-ref tag alongside its semver tag, so it can't be reliably distinguished from ordinary CI churn by tag shape alone, and ECR lifecycle rules can't have one rule "protect" an image that another rule's selection also matches. Given how frequently these apps are actually rebuilt in practice, 90 days is judged to comfortably outlast any realistic release cadence.

### How can this be tested?
- `uv run ruff check` / `uv run mypy` / `uv run pytest tests/ol_concourse/` all pass (385 tests).
- Verified by actually generating mit-learn's and witan's real pipeline definitions (`python pipeline.py mit-learn` / `witan`) and confirming: mit-learn's build jobs now include a `configure-ecr-repository` task with `REPO_NAME=mitodl/mit-learn-app` and the age-based policy shown above; witan is unchanged (still count-based, `keep_last_n_images=10`).
- After merge, each affected pipeline needs to be re-flown (or will pick this up automatically via its own self-updating meta-pipeline) and will apply the policy on its next build — this only prevents *future* accumulation. The existing backlog of images in these repos can be cleaned up separately via a one-time `aws ecr put-lifecycle-policy` call using the same policy, independent of this PR.

### Additional Context
This is a pure pipeline-generator change — no application code, no Pulumi infrastructure changes, no impact on currently-running deployments.