### PR TITLE
feat(keycloak): grant IdP management to the mitxonline-b2b-client service account

### DIFF
--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -548,11 +548,17 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         client_id="realm-management",
         opts=InvokeOptions(provider=keycloak_provider),
     )
+    # Keep this list in step with the deployed grants in
+    # substructure/keycloak/olapps.py — local MITx Online exercises the same B2B
+    # provisioning code paths, and a role missing here surfaces as a 403 that
+    # does not reproduce in QA.
     for resource_name, role in [
         ("b2b-view-realm", "view-realm"),
         ("b2b-view-users", "view-users"),
         ("b2b-query-users", "query-users"),
         ("b2b-manage-realm", "manage-realm"),
+        ("b2b-view-identity-providers", "view-identity-providers"),
+        ("b2b-manage-identity-providers", "manage-identity-providers"),
     ]:
         keycloak.openid.ClientServiceAccountRole(
             f"olapps-mitxonline-{resource_name}",

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -557,6 +557,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         ("b2b-view-users", "view-users"),
         ("b2b-query-users", "query-users"),
         ("b2b-manage-realm", "manage-realm"),
+        ("b2b-manage-users", "manage-users"),
         ("b2b-view-identity-providers", "view-identity-providers"),
         ("b2b-manage-identity-providers", "manage-identity-providers"),
     ]:

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -655,7 +655,8 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # MITXONLINE B2B [START]
     # This client is used by MITx Online for B2B operations via the Keycloak
     # Admin API. It requires service account roles to view realms, users, and
-    # organizations.
+    # organizations, and to manage the identity providers organizations are
+    # linked to.
     olapps_mitxonline_b2b_client = keycloak.openid.Client(
         "olapps-mitxonline-b2b-client",
         name="mitxonline-b2b-client",
@@ -681,11 +682,26 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # Assign required service account roles for Keycloak Admin API access
     # These roles allow the client to list/view realms, users, and organizations
     # Refactored repetitive role assignments into a loop for maintainability
+    #
+    # manage-realm covers Organizations but NOT identity providers. IdP
+    # create/update/delete, identity-provider/import-config, and org<->IdP linking
+    # all route through requireManageIdentityProviders(), which RealmPermissions
+    # resolves to the manage-identity-providers role alone; manage-realm is a
+    # distinct, non-composite role and does not satisfy it. Without these two the
+    # client cannot even list an organization's IdPs.
     for resource_name, role in [
         ("olapps-mitxonline-b2b-client-view-realm-role", "view-realm"),
         ("olapps-mitxonline-b2b-client-view-users-role", "view-users"),
         ("olapps-mitxonline-b2b-client-query-users-role", "query-users"),
         ("olapps-mitxonline-b2b-client-manage-realm-role", "manage-realm"),
+        (
+            "olapps-mitxonline-b2b-client-view-identity-providers-role",
+            "view-identity-providers",
+        ),
+        (
+            "olapps-mitxonline-b2b-client-manage-identity-providers-role",
+            "manage-identity-providers",
+        ),
     ]:
         keycloak.openid.ClientServiceAccountRole(
             resource_name,

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -687,8 +687,11 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # create/update/delete, identity-provider/import-config, and org<->IdP linking
     # all route through requireManageIdentityProviders(), which RealmPermissions
     # resolves to the manage-identity-providers role alone; manage-realm is a
-    # distinct, non-composite role and does not satisfy it. Without these two the
-    # client cannot even list an organization's IdPs.
+    # distinct, non-composite role and does not satisfy it. Reads go through
+    # requireViewIdentityProviders(), which accepts EITHER identity-provider role,
+    # so view-identity-providers is redundant with manage granted -- it is listed
+    # anyway so the account's read scope is visible here rather than inferred,
+    # matching how view-realm is listed alongside manage-realm above.
     for resource_name, role in [
         ("olapps-mitxonline-b2b-client-view-realm-role", "view-realm"),
         ("olapps-mitxonline-b2b-client-view-users-role", "view-users"),

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -655,8 +655,8 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # MITXONLINE B2B [START]
     # This client is used by MITx Online for B2B operations via the Keycloak
     # Admin API. It requires service account roles to view realms, users, and
-    # organizations, and to manage the identity providers organizations are
-    # linked to.
+    # organizations, to manage organization membership, and to manage the
+    # identity providers organizations are linked to.
     olapps_mitxonline_b2b_client = keycloak.openid.Client(
         "olapps-mitxonline-b2b-client",
         name="mitxonline-b2b-client",
@@ -692,11 +692,27 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # so view-identity-providers is redundant with manage granted -- it is listed
     # anyway so the account's read scope is visible here rather than inferred,
     # matching how view-realm is listed alongside manage-realm above.
+    #
+    # manage-users is required for the same reason, on a different endpoint:
+    # OrganizationMemberResource.addMember() requires BOTH
+    # auth.orgs().requireManage(organization) (satisfied by manage-realm) AND
+    # auth.users().requireManage(user), which only accepts the manage-users role
+    # (UserPermissions.canManage() checks AdminRoles.MANAGE_USERS specifically --
+    # manage-realm is not in its role list, unlike OrganizationPermissions.canManage()
+    # which explicitly accepts manage-realm as an alternative to manage-organizations).
+    # Without it, adding a user to an organization 403s even though the client can
+    # already view/manage the organization itself. This realm does not run Fine-Grained
+    # Admin Permissions (no `features` set on the Keycloak CR), so there is no way to
+    # scope this to just organization members; UserPermissions.canManageByGroup() only
+    # applies when FGAP's AuthorizationProvider is wired up, which it is not here --
+    # the grant is realm-wide, matching the existing mitlearn-admin-client precedent
+    # above.
     for resource_name, role in [
         ("olapps-mitxonline-b2b-client-view-realm-role", "view-realm"),
         ("olapps-mitxonline-b2b-client-view-users-role", "view-users"),
         ("olapps-mitxonline-b2b-client-query-users-role", "query-users"),
         ("olapps-mitxonline-b2b-client-manage-realm-role", "manage-realm"),
+        ("olapps-mitxonline-b2b-client-manage-users-role", "manage-users"),
         (
             "olapps-mitxonline-b2b-client-view-identity-providers-role",
             "view-identity-providers",


### PR DESCRIPTION
### What are the relevant tickets?

Hard prerequisite for phase 1 of the B2B onboarding provisioning design,
https://github.com/mitodl/hq/discussions/12784.

### Description (What does it do?)

Adds `manage-identity-providers`, `view-identity-providers`, and `manage-users` to the
realm-management roles granted to the `mitxonline-b2b-client` service account.

The account held `view-realm`, `view-users`, `query-users` and `manage-realm`. Keycloak's
`OrganizationPermissions` accepts `MANAGE_REALM` for org CRUD, domains and invitations, so
most of the organization half of B2B provisioning already works. Identity providers are a
separate permission: `IdentityProvidersResource` gates create/update/delete and
`identity-provider/import-config` on `requireManageIdentityProviders()` and reads on
`requireViewIdentityProviders()`, and `RealmPermissions` resolves those to
`MANAGE_IDENTITY_PROVIDERS` / `MANAGE_IDENTITY_PROVIDERS`-or-`VIEW_IDENTITY_PROVIDERS`.
`manage-realm` is a distinct, non-composite role and satisfies neither, so today the client
cannot list an organization's IdPs at all.

`OrganizationIdentityProvidersResource.addIdentityProvider()` and `delete()` require *both*
org manage and `manage-identity-providers`, so linking an IdP to an organization needs this
too.

**Adding an org member also needs a second, separate permission — `manage-realm` alone
isn't enough for that specific operation.** `OrganizationMemberResource.addMember()` calls
both `auth.orgs().requireManage(organization)` (satisfied by `manage-realm`, already held)
and `auth.users().requireManage(user)`. That second check only accepts `AdminRoles.
MANAGE_USERS` — `UserPermissions.canManage()` does not treat `manage-realm` as an
alternative the way `OrganizationPermissions.canManage()` does. Reproduced live: the client
could already view/manage an organization, but `POST /organizations/{id}/members` 403'd
until `manage-users` was granted. `manage-users` is realm-wide (this realm doesn't run
Fine-Grained Admin Permissions, so `UserPermissions.canManageByGroup()`'s scoped fallback
never applies — `AuthorizationProvider` is null); matches the existing precedent set by
`mitlearn-admin-client`'s `manage-users` grant earlier in the same file.

Checked against Keycloak 26.7.2, the `KEYCLOAK_VERSION` in `src/bridge/lib/versions.py`.
FGAP does not change any of it: `RealmPermissionsV2` overrides only
`canManage`/`canViewAuthorizationDefault` and leaves the IdP methods alone, and we do not
run FGAP regardless — the Keycloak CR sets no `features`, and the ol-keycloak image builds
with `--features=update-email` only. (Scoping `manage-users` to just organization members
via FGAP is being tracked separately, not part of this PR.)

This grant is what lets MITx Online provision a partner's SSO integration through the
Admin API at runtime, instead of a Pulumi PR per customer, and what lets it actually add
users to an organization at all.

### How can this be tested?

`pulumi preview` on `substructure.keycloak`:
- CI: 3 `keycloak:openid/clientServiceAccountRole` creates (`manage-identity-providers`,
  `view-identity-providers`, `manage-users`) and nothing else. Verified.
- QA: same 3 creates, plus one pre-existing unrelated `olapps` realm update
  (`accountTheme`/`adminTheme` drift, not touched by this change). Verified.
- Production: the 3 creates appear correctly; the stack also shows pre-existing drift from
  `main` outpacing Production's last deploy (RobCol SAML IdP mappers, a toolhive client
  change) — unrelated to this PR. Verified.

**Post-deploy verification, not yet done** — it needs the change live and I have no Vault
session from here. Against the QA realm, using the `mitxonline-b2b-client` credentials from
`secret-mitxonline/keycloak-admin-b2b`:

1. `POST /admin/realms/olapps/identity-provider/import-config` with a `fromUrl` returns the
   parsed config rather than 403.
2. `GET /admin/realms/olapps/organizations/{id}/identity-providers` returns a list rather
   than 403.
3. `POST /admin/realms/olapps/organizations/{id}/members` with a valid user ID returns
   `201 Created` rather than 403.

The C1 provisioning API spec should not assume these endpoints until all three come back
clean.

### Additional Context

`view-identity-providers` is strictly redundant — `requireViewIdentityProviders()` accepts
`MANAGE_IDENTITY_PROVIDERS` as well. It is granted explicitly anyway, matching how the loop
already pairs `view-realm` with `manage-realm`, so the account's read and write scope both
read off the role list directly.

`manage-users` found and added while manually reconciling non-SSO B2B organizations into
Keycloak for a separate project (mitxonline PR
https://github.com/mitodl/mitxonline/pull/3923 fixed a `Content-Type` bug blocking the same
`addMember` call; this permission gap was the next blocker after that fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAnN1EyrzDAMLojPQEMdhM
https://claude.ai/code/session_01BodaQnigJ9J5jJcTR3cquS
