### PR TITLE
fix(starrocks): grant the read-only governance roles SELECT on materialized views

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -469,21 +469,32 @@ GRANT ALL ON ALL DATABASES TO ROLE ol_data_engineer;
 -- database naming is confirmed, at which point these grants will be narrowed to
 -- the named databases.  Until then all four roles see the same read surface.
 --
+-- Each also needs SELECT ON ALL MATERIALIZED VIEWS.  MATERIALIZED VIEW is its
+-- own privilege object type in StarRocks, so an ALL TABLES grant does not reach
+-- an MV -- which is why readonly and app above carry the same pair.  Without it
+-- these roles cannot read b2b_analytics.mv_b2b_*, the whole B2B analytics
+-- surface.  admin, ol_platform_admin and ol_data_engineer need no equivalent:
+-- db_admin already covers every MV.
+--
 -- ol_data_analyst: target scope Silver_Analytics + Gold (read-only)
 GRANT USAGE ON CATALOG default_catalog TO ROLE ol_data_analyst;
 GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE ol_data_analyst;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE ol_data_analyst;
 
 -- ol_researcher: target scope Silver_Analytics + Gold_Analytics (read-only)
 GRANT USAGE ON CATALOG default_catalog TO ROLE ol_researcher;
 GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE ol_researcher;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE ol_researcher;
 
 -- ol_instructor: target scope Gold_Analytics + Gold_Operations (read-only)
 GRANT USAGE ON CATALOG default_catalog TO ROLE ol_instructor;
 GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE ol_instructor;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE ol_instructor;
 
 -- ol_business_analyst: target scope Silver_Operations + Gold (read-only)
 GRANT USAGE ON CATALOG default_catalog TO ROLE ol_business_analyst;
-GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE ol_business_analyst;"""
+GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE ol_business_analyst;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE ol_business_analyst;"""
 
 _roles_sql = _base_roles_sql + _iceberg_roles_sql
 _role_deps: list[pulumi.Resource] = [starrocks_db_connection, *catalog_setups]


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Grants `SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES` to the four read-only governance roles: `ol_data_analyst`, `ol_researcher`, `ol_instructor`, `ol_business_analyst`.

- Those roles held `SELECT ON ALL TABLES` and nothing covering materialized views, so a human in any of them could not read `b2b_analytics.mv_b2b_*` — which is the entire B2B analytics read surface.
- `readonly` and `app` already carry the MV grant. It was added for them when `ol-analytics-api` hit exactly this; the governance roles were missed.
- `admin`, `ol_platform_admin` and `ol_data_engineer` are deliberately unchanged — all three hold `db_admin`, which already covers materialized views.
- The Iceberg catalog grant block is untouched: an external Iceberg catalog cannot hold StarRocks materialized views.

<details>
<summary><b>Implementation details</b></summary>
<br>

`MATERIALIZED VIEW` is a distinct privilege object type in StarRocks, alongside `TABLE` and `VIEW`. A `GRANT SELECT ON ALL TABLES IN ALL DATABASES` does not reach an MV, so every role that needs to read one needs a second, explicit grant.

This is not theoretical — it is the failure `ol-analytics-api` returned in production before the `app` role got its MV grant:

```
(5203, 'Access denied; you need (at least one of) the SELECT privilege(s) on
MATERIALIZED VIEW mv_b2b_program_funnel for this operation. Please ask the admin
to grant permission(s) or try activating existing roles using <set [default] role>.
Current role(s): [app]. Inactivated role(s): NONE.')
```

That user held `SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN ALL DATABASES` at the time. The existing comment above `_b2b_analytics_db_sql` records the same conclusion.

No other grant path masks the gap for the governance roles:

- OIDC users receive exactly one role, via `GRANT <role> TO EXTERNAL GROUP <role>` in the group-provider setup — there is no implicit `readonly`.
- The Vault database roles (`readonly` / `app` / `admin`) each assign only their own role in `starrocks_role_statements`.

The three roles left alone hold `db_admin`, which the StarRocks docs describe as carrying "the privileges to perform all operations on catalog, database, table, view, materialized view, function, global function, resource group, and plug-ins" — so an explicit grant would be redundant. See [Overview of privileges](https://docs.starrocks.io/docs/administration/user_privs/authorization/user_privs/).

The new statements land in `_base_roles_sql`, which `roles_setup_cmd` re-applies on both create and update. Its `triggers` is a SHA-256 of `_roles_sql`, so changing the string is what causes the command to re-run.

</details>

### How can this be tested?

**What has been run:** `uv run pre-commit run --files src/ol_infrastructure/substructure/starrocks/__main__.py` — ruff format, ruff check, mypy and detect-secrets all pass. That is the only validation performed.

**What has not:** `pulumi preview` has not been run, and these grants are not applied in any environment. A reviewer should run preview against the starrocks substructure stack before merging. Expect exactly one diff — `starrocks-<env>-roles-setup` updating, because its trigger hash covers `_roles_sql`.

**Validating after apply,** connected as an admin (`bin/starrocks-auth --env <env> --mode vault --vault-role admin --port-forward --output mysql` from `ol-data-platform`):

```sql
SHOW GRANTS FOR ROLE ol_data_analyst;
-- expect a MATERIALIZED VIEW row alongside the existing TABLE row
```

Then functionally, as a user holding only `ol_data_analyst`:

```sql
SELECT COUNT(*) FROM b2b_analytics.mv_b2b_contract_utilization;
-- before: 5203 Access denied ... SELECT privilege(s) on MATERIALIZED VIEW
-- after:  a row count
```

### Additional Context

- `GRANT` re-application is a no-op for privileges already held — the existing comment block above the roles setup states this, and it is why the whole SQL block is safe to re-apply on every `pulumi up`.
- Related gap, not addressed here: `app` has `CREATE MATERIALIZED VIEW ON DATABASE b2b_analytics` but no `DROP`, `ALTER` or `REFRESH` on MVs. Nothing hits it today because the Dagster `StarRocksResource` defaults to `vault_role="admin"`, but a `dbt build --full-refresh` run as `app` would fail on the drop.
