### PR TITLE
feat(dagster): OTel auto-instrumentation for the control plane, not run workers

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -78,6 +78,11 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
+from ol_infrastructure.lib.otel import (
+    DEFAULT_TRACE_SAMPLING_RATE,
+    OTLP_ENDPOINT,
+    ships_telemetry,
+)
 from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
     parse_stack,
@@ -2128,6 +2133,132 @@ edxorg_gcp_secret = OLVaultK8SSecret(
     opts=ResourceOptions(depends_on=[dagster_auth_binding]),
 )
 
+# ── OpenTelemetry auto-instrumentation, control plane only ──
+#
+# ol-data-platform bakes the auto-instrumentation agent into every Dagster image
+# and symlinks it to the stable path below (dg_deployments/Dockerfile.dagster-k8s
+# and dg_projects/*/Dockerfile). Putting that path on PYTHONPATH imports its
+# sitecustomize.py, which is the whole of what `opentelemetry-instrument` does:
+# the console script prepends the same directory and execs the command
+# (opentelemetry/instrumentation/auto_instrumentation/__init__.py). PYTHONPATH is
+# the lever rather than an ENTRYPOINT because the Dagster chart hardcodes
+# `command: ["/bin/bash", "-c", ...]` for both the webserver and the daemon, so
+# an ENTRYPOINT would never run for either.
+#
+# WHAT IT BUYS: opentelemetry-instrumentation-sqlalchemy wraps Engine.connect and
+# emits a CLIENT span named "connect" (its engine.py) alongside the per-statement
+# span. Stock dagster_postgres builds every engine as create_engine(url,
+# isolation_level="AUTOCOMMIT", poolclass=NullPool), where that span would price a
+# TCP+SCRAM handshake per query -- but dagster_instance.yaml replaces all three
+# storages with ol_orchestrate's QueuePool-backed classes, so here the same span
+# times a pool CHECKOUT: near-zero on a hit, a real handshake on a miss. That
+# distribution is the client-side half this project has never had. Every pool
+# number in this stack was set against PgBouncer's view alone, and
+# pool_size/max_overflow (15/15, and EVENT_LOG_POOL_SIZE) were never validated
+# against how often a checkout actually falls through. The gRPC spans separately
+# put a distribution behind DAGSTER_GRPC_TIMEOUT_SECONDS and
+# DAGSTER_CODE_SERVER_TIMEOUT_SECONDS, both of which are currently guesses.
+#
+# RUN WORKERS ARE DELIBERATELY EXCLUDED, and excluding them takes explicit work.
+# They live 7-9 seconds, so an 8s process would depend entirely on
+# BatchSpanProcessor's at-exit flush -- a SIGKILL loses the spans -- and the
+# volume needs a sampling decision of its own first. But the user-deployments
+# chart copies each deployment's whole `env` list into
+# DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT, and K8sRunLauncher applies that to
+# every run worker pod, so PYTHONPATH set here reaches them by default.
+# dagster_instance.yaml overrides it back to "" under
+# run_launcher.config.run_k8s_config.container_config.env; an empty PYTHONPATH
+# contributes no sys.path entries, so the agent is never imported there. The
+# remaining OTEL_* variables ride along to run workers and are inert without it.
+OTEL_AGENT_PYTHONPATH = "/opt/otel/auto_instrumentation"
+
+
+def dagster_otel_env(service_name: str, image_version: str) -> list[dict[str, str]]:
+    """Build the OTEL_* + PYTHONPATH block for one long-lived Dagster process.
+
+    Empty where there is no collector to export to, which leaves PYTHONPATH
+    unset and the agent inert -- operations-ci runs no Alloy, so setting the
+    endpoint there would buy a connection failure per batch forever in the one
+    environment nobody is watching.
+
+    :param service_name: unprefixed, e.g. ``"dagster-daemon"``; the environment
+        is prepended to match the ``<env>-<service>`` convention edxapp,
+        mit_learn and witan already use.
+    :param image_version: the tag or digest this workload runs, so a span can be
+        attributed to the image it came from.
+    """
+    if not ships_telemetry(stack_info):
+        return []
+    return [
+        {"name": "PYTHONPATH", "value": OTEL_AGENT_PYTHONPATH},
+        {
+            "name": "OTEL_SERVICE_NAME",
+            "value": f"{stack_info.env_suffix}-{service_name}",
+        },
+        {"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": OTLP_ENDPOINT},
+        {"name": "OTEL_EXPORTER_OTLP_PROTOCOL", "value": "http/protobuf"},
+        # dagster-azure pulls in azure-monitor-opentelemetry, which registers a
+        # second `opentelemetry_distro` and `opentelemetry_configurator` entry
+        # point in the dagster-k8s image. _load_distro/_load_configurator take
+        # "the first to come up" when nothing is pinned, so without these two the
+        # agent could configure Azure Monitor exporters instead of ours,
+        # depending on entry-point iteration order. `distro` and `configurator`
+        # are the names opentelemetry-distro registers.
+        {"name": "OTEL_PYTHON_DISTRO", "value": "distro"},
+        {"name": "OTEL_PYTHON_CONFIGURATOR", "value": "configurator"},
+        # Only the HTTP OTLP exporter is installed in the images; the SDK default
+        # "otlp" resolves to the gRPC exporter, which is absent. An unresolvable
+        # exporter aborts SDK initialisation outright -- traces included -- which
+        # is why metrics and logs are named off rather than left at their
+        # defaults. Same reasoning as edxapp/k8s_resources.py's _OTEL_SDK_ENV.
+        {"name": "OTEL_TRACES_EXPORTER", "value": "otlp_proto_http"},
+        {"name": "OTEL_METRICS_EXPORTER", "value": "none"},
+        {"name": "OTEL_LOGS_EXPORTER", "value": "none"},
+        # The mit_learn/learn_ai ratio, so a trace crossing from one of those
+        # services is sampled once rather than decided twice. Alloy's
+        # tailSampling filters again on top.
+        {"name": "OTEL_TRACES_SAMPLER", "value": "parentbased_traceidratio"},
+        {"name": "OTEL_TRACES_SAMPLER_ARG", "value": DEFAULT_TRACE_SAMPLING_RATE},
+        {"name": "OTEL_PROPAGATORS", "value": "tracecontext,baggage"},
+        {
+            "name": "OTEL_RESOURCE_ATTRIBUTES",
+            "value": ",".join(
+                [
+                    f"deployment.environment={stack_info.env_suffix}",
+                    "service.namespace=dagster",
+                    f"service.version={image_version}",
+                ]
+            ),
+        },
+        # A guard, not a live setting: the images install an explicit
+        # instrumentation list that omits psycopg2. If that ever moves to
+        # opentelemetry-bootstrap, bootstrap selects psycopg2 alongside
+        # sqlalchemy and every query gets two spans for the one statement.
+        {"name": "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS", "value": "psycopg2"},
+    ]
+
+
+def grpc_health_check_command(port: int) -> list[str]:
+    """Build the chart's code-location probe command, minus the OTel agent.
+
+    Exec probes inherit the container environment, so PYTHONPATH would make each
+    one pay a full SDK initialisation and emit a span for its own health check --
+    five extra interpreter startups a minute per pod, on top of a `dagster api
+    grpc-health-check` that already costs ~1.5s. ``env -u`` drops the variable
+    for the probe process alone, and is a no-op where it was never set.
+    """
+    return [
+        "env",
+        "-u",
+        "PYTHONPATH",
+        "dagster",
+        "api",
+        "grpc-health-check",
+        "-p",
+        str(port),
+    ]
+
+
 # Define the user code deployments before the main helm chart so they can be referenced
 # Define all code locations based on ol-data-platform structure
 code_locations: list[dict[str, str | int]] = [
@@ -2196,8 +2327,13 @@ for location in code_locations:
             module,
         ],
         "port": port,
+        # Each probe states the exec command the chart would otherwise generate
+        # for it, so that grpc_health_check_command can strip the OTel agent off
+        # the probe process. Supplying `exec` also makes the chart emit the probe
+        # dict verbatim rather than assembling it key by key.
         "startupProbe": {
             "enabled": True,
+            "exec": {"command": grpc_health_check_command(port)},
             "periodSeconds": 10,
             "timeoutSeconds": 10,
             "failureThreshold": 60,
@@ -2206,6 +2342,7 @@ for location in code_locations:
         },
         "readinessProbe": {
             "enabled": True,
+            "exec": {"command": grpc_health_check_command(port)},
             "periodSeconds": 20,
             "timeoutSeconds": 10,
             "failureThreshold": 3,
@@ -2213,6 +2350,7 @@ for location in code_locations:
         },
         "livenessProbe": {
             "enabled": True,
+            "exec": {"command": grpc_health_check_command(port)},
             "periodSeconds": 30,
             "timeoutSeconds": 10,
             "failureThreshold": 3,
@@ -2262,6 +2400,9 @@ for location in code_locations:
             # Ties each Sentry issue to the image it came from. Same git
             # short-ref the Concourse pipeline tagged the image with.
             {"name": "SENTRY_RELEASE", "value": image_tag_or_digest},
+            *dagster_otel_env(
+                f"dagster-code-{name.replace('_', '-')}", image_tag_or_digest
+            ),
         ],
         "envSecrets": [
             {"name": "dagster-static-secrets"},
@@ -2307,6 +2448,7 @@ for location in code_locations:
         # to connect before the code location has finished initializing.
         deployment["startupProbe"] = {
             "enabled": True,
+            "exec": {"command": grpc_health_check_command(port)},
             "periodSeconds": 10,
             # Allow longer timeout for health check response
             "timeoutSeconds": 10,
@@ -2317,6 +2459,7 @@ for location in code_locations:
         }
         deployment["readinessProbe"] = {
             "enabled": True,
+            "exec": {"command": grpc_health_check_command(port)},
             # Less aggressive after startup
             "periodSeconds": 20,
             "timeoutSeconds": 10,
@@ -2614,6 +2757,7 @@ dagster_helm_values = {
                 "value": "120",
             },
             {"name": "AWS_DEFAULT_REGION", "value": "us-east-1"},
+            *dagster_otel_env("dagster-webserver", dagster_k8s_image_tag_or_digest),
         ],
         "envSecrets": [
             {"name": "dagster-static-secrets"},
@@ -2684,6 +2828,7 @@ dagster_helm_values = {
                 "value": "25",
             },
             {"name": "AWS_DEFAULT_REGION", "value": "us-east-1"},
+            *dagster_otel_env("dagster-daemon", dagster_k8s_image_tag_or_digest),
         ],
         "envSecrets": [
             {"name": "dagster-static-secrets"},

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2160,9 +2160,11 @@ edxorg_gcp_secret = OLVaultK8SSecret(
 # DAGSTER_CODE_SERVER_TIMEOUT_SECONDS, both of which are currently guesses.
 #
 # RUN WORKERS ARE DELIBERATELY EXCLUDED, and excluding them takes explicit work.
-# They live 7-9 seconds, so an 8s process would depend entirely on
-# BatchSpanProcessor's at-exit flush -- a SIGKILL loses the spans -- and the
-# volume needs a sampling decision of its own first. But the user-deployments
+# Not because their data is uninteresting -- it is the most interesting part, and
+# tk-extend-otel-auto-instrumentation-to-dagster-run--378bda tracks turning them
+# on. The open question is the span-flush policy: they are preemptible by design,
+# so a SIGKILL drops whatever BatchSpanProcessor has not flushed, biased towards
+# the runs killed during a capacity event. But the user-deployments
 # chart copies each deployment's whole `env` list into
 # DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT, and K8sRunLauncher applies that to
 # every run worker pod, so PYTHONPATH set here reaches them by default -- and it

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2165,11 +2165,13 @@ edxorg_gcp_secret = OLVaultK8SSecret(
 # volume needs a sampling decision of its own first. But the user-deployments
 # chart copies each deployment's whole `env` list into
 # DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT, and K8sRunLauncher applies that to
-# every run worker pod, so PYTHONPATH set here reaches them by default.
-# dagster_instance.yaml overrides it back to "" under
-# run_launcher.config.run_k8s_config.container_config.env; an empty PYTHONPATH
-# contributes no sys.path entries, so the agent is never imported there. The
-# remaining OTEL_* variables ride along to run workers and are inert without it.
+# every run worker pod, so PYTHONPATH set here reaches them by default -- and it
+# cannot be taken back by naming PYTHONPATH again on the run launcher, because
+# both values land in the same merged list with the code location's last and
+# kubelet resolves duplicates by last assignment. dagster_instance.yaml strips it
+# with a container `command` of `env -u PYTHONPATH` instead, which the merge does
+# not touch; see the comment there. The remaining OTEL_* variables ride along to
+# run workers and are inert once the agent is off the path.
 OTEL_AGENT_PYTHONPATH = "/opt/otel/auto_instrumentation"
 
 

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -145,6 +145,32 @@ run_launcher:
   class: K8sRunLauncher
   config:
     run_k8s_config:
+      container_config:
+        env:
+        # Keep the OpenTelemetry auto-instrumentation agent off run workers.
+        #
+        # The user-deployments chart copies each code location's whole `env`
+        # list into DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT, and K8sRunLauncher
+        # applies that context to every run worker pod -- so the PYTHONPATH that
+        # switches the agent on for the ten code servers (see dagster_otel_env
+        # in __main__.py) would otherwise reach the run workers too. There is no
+        # chart lever that grants a code location container env a run worker
+        # does not inherit; `env_config_maps` and `env_secrets` propagate the
+        # same way.
+        #
+        # Empty is the off switch, not a placeholder: CPython contributes no
+        # sys.path entries for an empty PYTHONPATH, so site never finds the
+        # agent's sitecustomize.py and the SDK is never initialised. This entry
+        # is last in the container's env list (dagster_k8s/job.py builds it as
+        # [*env, *job_config.env, *user_defined_env_vars], and run_k8s_config
+        # supplies the third), and kubelet resolves duplicate names by last
+        # assignment (kubelet_pods.go, makeEnvironmentVariables).
+        #
+        # Run workers stay excluded until their span volume has a sampling
+        # decision: they live 7-9 seconds, so an 8s process depends entirely on
+        # BatchSpanProcessor's at-exit flush, and a SIGKILL loses the spans.
+        - name: PYTHONPATH
+          value: ""
       pod_template_spec_metadata:
         annotations:
           karpenter.sh/do-not-disrupt: "true"

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -146,31 +146,42 @@ run_launcher:
   config:
     run_k8s_config:
       container_config:
-        env:
         # Keep the OpenTelemetry auto-instrumentation agent off run workers.
         #
         # The user-deployments chart copies each code location's whole `env`
         # list into DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT, and K8sRunLauncher
         # applies that context to every run worker pod -- so the PYTHONPATH that
         # switches the agent on for the ten code servers (see dagster_otel_env
-        # in __main__.py) would otherwise reach the run workers too. There is no
-        # chart lever that grants a code location container env a run worker
-        # does not inherit; `env_config_maps` and `env_secrets` propagate the
-        # same way.
+        # in __main__.py) reaches run workers too. There is no chart lever that
+        # grants a code location container env a run worker does not inherit;
+        # `env_config_maps` and `env_secrets` propagate the same way.
         #
-        # Empty is the off switch, not a placeholder: CPython contributes no
-        # sys.path entries for an empty PYTHONPATH, so site never finds the
-        # agent's sitecustomize.py and the SDK is never initialised. This entry
-        # is last in the container's env list (dagster_k8s/job.py builds it as
-        # [*env, *job_config.env, *user_defined_env_vars], and run_k8s_config
-        # supplies the third), and kubelet resolves duplicate names by last
-        # assignment (kubelet_pods.go, makeEnvironmentVariables).
+        # THIS CANNOT BE FIXED BY SETTING PYTHONPATH BACK TO "" HERE, which is
+        # what the first version of this file did. K8sContainerContext.__new__
+        # folds a context's top-level `env` into its own run_k8s_config, and
+        # get_k8s_job_config carries no env at all, so BOTH values end up in
+        # job.py's `user_defined_env_vars` -- and create_for_run ends with
+        # `context.merge(user_defined_container_context)`, whose list merge is
+        # [*run_launcher, *code_location]. That puts the agent path last, and
+        # kubelet resolves duplicate names by last assignment, so the override
+        # loses. Caught in review on PR #5733 and reproduced in the image.
+        #
+        # `command` works where `env` cannot: the merge only copies keys the
+        # code-location context actually sets, and it sets no command, so this
+        # one survives. Kubernetes prepends it to the launcher's args, giving
+        # `env -u PYTHONPATH dagster api execute_run ...`. Unsetting rather than
+        # emptying means site never finds the agent's sitecustomize.py, so
+        # nothing is imported and no library is patched -- OTEL_SDK_DISABLED
+        # would not do this, it only makes TracerProvider hand out NoOp tracers
+        # (sdk/trace/__init__.py) after the agent has already loaded.
         #
         # Run workers stay excluded until their span volume has a sampling
         # decision: they live 7-9 seconds, so an 8s process depends entirely on
         # BatchSpanProcessor's at-exit flush, and a SIGKILL loses the spans.
-        - name: PYTHONPATH
-          value: ""
+        command:
+        - env
+        - -u
+        - PYTHONPATH
       pod_template_spec_metadata:
         annotations:
           karpenter.sh/do-not-disrupt: "true"

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -175,9 +175,20 @@ run_launcher:
         # would not do this, it only makes TracerProvider hand out NoOp tracers
         # (sdk/trace/__init__.py) after the agent has already loaded.
         #
-        # Run workers stay excluded until their span volume has a sampling
-        # decision: they live 7-9 seconds, so an 8s process depends entirely on
-        # BatchSpanProcessor's at-exit flush, and a SIGKILL loses the spans.
+        # Run workers stay excluded until the span-flush policy is decided, not
+        # because the data is uninteresting -- it is the most interesting, since
+        # 2026-08-10 was 178 run workers holding connections and their per-worker
+        # footprint is still unmeasured. The blocker is that they are preemptible
+        # by design (priority_class_name below), so a SIGKILL drops whatever
+        # BatchSpanProcessor has not flushed, and it drops it with a bias: the
+        # preempted runs are the ones from a capacity event. Measured
+        # 2026-09-03 on data-production, run duration is p50 17s / p90 32s -- three
+        # BSP cycles at the 5s default, not zero -- and arrivals are bursty
+        # (~2.2/s inside a burst against ~0.006/s outside), so the flush and
+        # sampling settings have to be sized against the burst rather than any
+        # runs/day average. Tracked in
+        # tk-extend-otel-auto-instrumentation-to-dagster-run--378bda; deleting
+        # this command block is the whole toggle.
         command:
         - env
         - -u


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-otel-auto-instrumentation-for-the-dagster-contro-142adc`, under the "Dagster + PgBouncer observability and pool tuning" project. Pairs with mitodl/ol-data-platform#2637, which puts the agent in the images; merge order between the two does not matter.

### Description (What does it do?)

Turns on OpenTelemetry auto-instrumentation for the Dagster webserver, the daemon and the ten code locations, and keeps it off run workers.

- `dagster_otel_env()` builds the `OTEL_*` + `PYTHONPATH` block for one long-lived process; empty on CI, which runs no Alloy.
- `dagster_instance.yaml` strips `PYTHONPATH` from run worker pods with a container `command` of `env -u PYTHONPATH`.
- The code-location probes now state `env -u PYTHONPATH` ahead of the `grpc-health-check` command the chart would otherwise generate.

Every pool number in this stack was set against PgBouncer's view of the connection alone. The sqlalchemy `connect` span is the client-side half we have never had, and the gRPC spans put a distribution behind `DAGSTER_GRPC_TIMEOUT_SECONDS` and `DAGSTER_CODE_SERVER_TIMEOUT_SECONDS`, both currently guesses.

<details>
<summary><b>Implementation details</b></summary>
<br>

**What the `connect` span actually measures here.** `opentelemetry-instrumentation-sqlalchemy` wraps `Engine.connect` and emits a CLIENT span named `connect` alongside the per-statement span. Stock `dagster_postgres` builds every engine as `create_engine(url, isolation_level="AUTOCOMMIT", poolclass=NullPool)`, where that span would price a TCP+SCRAM handshake per query — but `dagster_instance.yaml` replaces all three storages with `ol_orchestrate`'s QueuePool-backed classes, so here it times a pool **checkout**: near-zero on a hit, a real handshake on a miss. `pool_size`/`max_overflow` (15/15, and `EVENT_LOG_POOL_SIZE`) have never been validated against how often a checkout falls through.

**Why `PYTHONPATH` and not `opentelemetry-instrument`.** The Dagster chart hardcodes `command: ["/bin/bash", "-c", "{{ template \"dagster.webserver.dagsterWebserverCommand\" . }}"]` for the webserver and the equivalent for the daemon, so an image `ENTRYPOINT` would never run for either. The agent directory holds a `sitecustomize.py`, and prepending it is the whole of what the console script does.

**Excluding run workers took two extra changes, not zero.**

1. `dagsterUserDeployments.k8sContainerContext` copies each deployment's whole `env` list into `DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT`, and `K8sRunLauncher` applies that context to every run worker pod — so `PYTHONPATH` set for the code servers reaches run workers by default. There is no chart lever that grants a code-location container env a run worker does not inherit; `envConfigMaps` and `envSecrets` propagate the same way.

   **Naming `PYTHONPATH` again on the run launcher does not take it back** — the first version of this PR did that, and Copilot caught it. `K8sContainerContext.__new__` folds a context's top-level `env` into its own `run_k8s_config`, and `get_k8s_job_config` carries no env at all, so both values land in `job.py`'s `user_defined_env_vars` rather than in separate slots. `create_for_run` ends with `context.merge(user_defined_container_context)`, whose list merge is `[*run_launcher, *code_location]`, putting the agent path last — and kubelet resolves duplicates by last assignment (`kubelet_pods.go`, `makeEnvironmentVariables`), so the override loses.

   The fix is a container `command` of `env -u PYTHONPATH`. `_merge_k8s_config` only copies keys the code-location context actually sets, and it sets no `command`, so this one survives; Kubernetes prepends it to the launcher's args. Unsetting rather than emptying also means nothing is imported and no library is patched. `OTEL_SDK_DISABLED=true` was considered and rejected: measured in the image it still yields a real `TracerProvider` with sqlalchemy patched, because the SDK only reads it inside `TracerProvider` to hand out NoOp tracers (`sdk/trace/__init__.py:1341`) after the agent has loaded. The cost run workers are being spared is the import and the patching on a 7-9s process, not just the spans.

2. Exec probes inherit the container environment. Without `env -u`, each `dagster api grpc-health-check` would pay a full SDK initialisation and emit a span for its own health check — five interpreter startups a minute per pod across thirteen pods. Supplying `exec` also makes the chart emit the probe dict verbatim rather than assembling it key by key, which is why each probe now states the command explicitly.

**Why the distro/configurator pins.** `dagster-azure` pulls in `azure-monitor-opentelemetry`, which registers a second `opentelemetry_distro` and `opentelemetry_configurator` entry point in the `dagster-k8s` image. `_load_distro`/`_load_configurators` take "the first to come up" when nothing is named, so without `OTEL_PYTHON_DISTRO=distro` and `OTEL_PYTHON_CONFIGURATOR=configurator` the agent could configure Azure Monitor exporters depending on entry-point iteration order.

**Sampling** follows the mit_learn/learn_ai house ratio (`parentbased_traceidratio` @ `DEFAULT_TRACE_SAMPLING_RATE`), so a trace crossing from one of those services is sampled once rather than decided twice; Alloy's `tailSampling` filters again on top.

</details>

### How can this be tested?

`pulumi preview --stack Production` from `src/ol_infrastructure/applications/dagster`: **2 to update, 93 unchanged** — the two Helm releases and nothing else. The diff shows the new env entries on `dagsterDaemon` and `dagsterWebserver`, the `exec` key added to all three probes on each of the ten code locations, and the daemon's `checksum/ol-dagster-instance` annotation moving (the `dagster_instance.yaml` edit, which is what makes the daemon restart and pick up the new run launcher config).

Behaviour was checked against images built from mitodl/ol-data-platform#2637 rather than asserted:

- With this env block applied, `trace.get_tracer_provider()` is a real `TracerProvider`, the exporter is `OTLPSpanExporter` at `http://…alloy-receiver…:4318/v1/traces`, the sampler is `ParentBasedTraceIdRatio`, the resource carries `service.name=production-dagster-daemon` / `deployment.environment` / `service.namespace=dagster` / `service.version`, and sqlalchemy and grpc are both instrumented.
- Under `env -u PYTHONPATH` — which is both the probe path and, after the review fix, the run worker path — the same checks return `ProxyTracerProvider` with nothing instrumented. The pre-fix run-worker shape (agent on `PYTHONPATH` plus the full inherited OTEL_* set) was also run, and it *does* come back instrumented: that is the bug the `command` change fixes, reproduced rather than reasoned about.
- `env -u PYTHONPATH dagster api grpc-health-check -p 4006` still runs.

After merge, the checks worth doing on the cluster: a `service.name=production-dagster-*` trace arriving in Tempo, and `kubectl get pod -l dagster/job -o jsonpath='{.items[0].spec.containers[0].command}'` on a live run worker showing the `env -u PYTHONPATH` prefix.

### Additional Context

Not in scope, but the obvious next thing: `opentelemetry-instrumentation-sqlalchemy` also emits a `db.client.connections.usage` metric, which is client-side pool utilisation — the other number this project lacks. `OTEL_METRICS_EXPORTER` is `none` here because turning it on is a separate Alloy ingestion decision.

Run workers stay excluded, but the reason is narrower than the task this came from claimed, and the follow-up is filed rather than open-ended. Measured on data-production 2026-09-03 from the run-worker Jobs in their 1h TTL window: p50 **17s**, p90 32s, max 191s (n=2375) — not the "7-9 seconds" I originally wrote here, and 17s is three `BatchSpanProcessor` cycles at the 5s default rather than zero. Arrivals are bursty rather than steady (2582 runs in 20 minutes against 23 in the 40 before, almost all one partitioned `ASSET_JOB` from the `openedx` code location), so no runs/day average describes the workload and the "~53k/day → ~400 spans/s" volume chain isn't a usable basis either.

What does justify holding them back is the flush policy: run workers are preemptible by design (`priority_class_name: dagster-run`, which is how the daemon got unstuck on 2026-08-10), so a SIGKILL drops unflushed spans — biased towards the runs killed during a capacity event, which are the ones worth seeing. That's a decision to make, not a reason the data is uninteresting: run workers are where the 178 connections of 2026-08-10 were, and `dagster_instance.yaml` records their per-worker footprint as unmeasured. Deleting the `command` block is the whole toggle once the flush policy is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmBR31urv7W1hZe8cGpBzn

