### PR TITLE
fix(edxapp): raise mitxonline Meilisearch volume throughput to 500 MB/s

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
+++ b/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
@@ -12,6 +12,7 @@
   meilisearch:memory_request: "4Gi"
   meilisearch:memory_limit: "4Gi"
   meilisearch:max_indexing_memory: "2Gi" # optional, see Sizing below
+  meilisearch:volume_attributes_class: "" # optional, see Volume throughput below
 ```
 
 The difference between `deploy` and `enabled`. Deploy means "deploy the helm chart" whereas enabled means "enable meilisearch integration in the Open edX platform". You can deploy the chart but not enable it in Open edX if you want to test things out first.
@@ -44,6 +45,44 @@ the OS, so rewriting documents in place inflates `indexSize` permanently. Only a
 rebuild through the temp-index-and-swap path (a non-incremental
 `./manage.py cms reindex_studio`) reclaims it — `--incremental` writes in place
 and does not.
+
+## Volume throughput
+
+Whatever cannot be held in page cache is re-read from EBS, so once the index
+outgrows the pod's cgroup the volume's throughput becomes the real ceiling on
+indexing. `ebs-gp3-sc` provisions gp3 at the AWS default of 125 MB/s, and a
+starved instance will sit against that number indefinitely. Over fifteen
+consecutive minutes on 2026-09-03, mitxonline production averaged 110 MB/s and
+peaked at 122 MB/s — 98% of the ceiling — while peak IOPS reached 1,904/s, only
+38% of the 5,000 already provisioned. It read 91.8 GiB in that window against a
+12.02 GiB index, so it re-read the whole thing 7.6 times over. Throughput bound
+it; IOPS did not. Check both before assuming which one is short.
+
+StorageClass parameters apply at provisioning time only, so raising them does
+nothing for a volume that already exists. `volume_attributes_class` names a
+`VolumeAttributesClass` instead, which drives `ec2:ModifyVolume` against the live
+volume: online, no pod restart, and no rebind — which matters because this PVC
+is zone-locked and its pod is pinned to a core node, so anything that forces a
+reschedule risks leaving `meilisearch-0` `Pending`.
+
+`ebs-gp3-throughput-500` is declared for every cluster in
+`infrastructure/aws/eks/__main__.py` and costs nothing until a PVC names it. The
+EKS stack has to be applied before the stack that references it, or the PVC will
+name a class that does not exist yet.
+
+EBS allows one modification per volume per six hours, so a mistake here is slow
+to walk back. Confirm the result against the volume rather than the PVC:
+
+```bash
+kubectl get pvc meilisearch -n <namespace> \
+  -o jsonpath='{.status.currentVolumeAttributesClassName}{"\n"}'
+aws ec2 describe-volumes --volume-ids <vol-id> \
+  --query 'Volumes[0].[Iops,Throughput]' --output text
+```
+
+This raises a ceiling; it does not reduce the amount of re-reading. Sizing the
+memory limit so the working set fits is the durable fix, and the two are
+complementary rather than alternatives.
 
 ## SOPS secrets
 

--- a/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
+++ b/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
@@ -65,10 +65,28 @@ volume: online, no pod restart, and no rebind — which matters because this PVC
 is zone-locked and its pod is pinned to a core node, so anything that forces a
 reschedule risks leaving `meilisearch-0` `Pending`.
 
-`ebs-gp3-throughput-500` is declared for every cluster in
-`infrastructure/aws/eks/__main__.py` and costs nothing until a PVC names it. The
-EKS stack has to be applied before the stack that references it, or the PVC will
-name a class that does not exist yet.
+`ebs-gp3-throughput-500` and its rollback counterpart `ebs-gp3-throughput-125`
+are declared for every cluster in `infrastructure/aws/eks/__main__.py` and cost
+nothing until a PVC names one. Apply the EKS stack before the stack that
+references a class: a PVC naming a class that does not exist yet is held in
+`Pending` under `status.modifyVolumeStatus` until it appears. The claim stays
+bound and the pod keeps running throughout — it is the modification that waits,
+not the volume.
+
+### Rolling back
+
+Do not roll back by reverting the config key. Clearing
+`volumeAttributesClassName` means "no class applies"; it does not call
+`ec2:ModifyVolume`, so the volume keeps whatever geometry it was last given and
+the revert silently leaves it at 500 MB/s. Point the claim at the baseline class
+instead, let the modification finish, and only then drop the reference:
+
+```yaml
+meilisearch:volume_attributes_class: ebs-gp3-throughput-125
+```
+
+Confirm `Throughput` reads `125` on the volume before removing the key, using
+the commands below.
 
 EBS allows one modification per volume per six hours, so a mistake here is slow
 to walk back. Confirm the result against the volume rather than the PVC:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -187,6 +187,7 @@ config:
   meilisearch:memory_request: "1Gi"
   meilisearch:memory_limit: "4Gi"
   meilisearch:max_indexing_memory: "2Gi"
+  meilisearch:volume_attributes_class: ebs-gp3-throughput-500
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -164,7 +164,7 @@ def create_meilisearch_resources(
             max_indexing_memory
         )
 
-    return kubernetes.helm.v3.Release(
+    meilisearch_release = kubernetes.helm.v3.Release(
         f"ol-{stack_info.env_prefix}-edxapp-meilisearch-helm-release-{stack_info.env_suffix}",
         kubernetes.helm.v3.ReleaseArgs(
             name="meilisearch",
@@ -180,3 +180,31 @@ def create_meilisearch_resources(
         ),
         opts=ResourceOptions(delete_before_replace=True),
     )
+
+    # Raise the throughput of an already-provisioned volume. The storageclass sets
+    # gp3 throughput at provisioning time and cannot revise it afterwards, so a
+    # volume whose index has outgrown the pod's page cache stays pinned at whatever
+    # ceiling it was born with. Pointing the PVC at a VolumeAttributesClass drives
+    # ec2:ModifyVolume against the live volume instead -- online, no pod restart, no
+    # rebind, so it does not disturb the zone-locked PVC.
+    #
+    # The chart's PVC template has no field for this (meilisearch-kubernetes 0.38.0),
+    # hence a patch against the Helm-created claim rather than a values entry.
+    # Emitted only where configured, so the stacks that have not been sized for it
+    # render unchanged.
+    if volume_attributes_class := meilisearch_config.get("volume_attributes_class"):
+        kubernetes.core.v1.PersistentVolumeClaimPatch(
+            f"ol-{stack_info.env_prefix}-edxapp-meilisearch-pvc-attributes-{stack_info.env_suffix}",
+            metadata=kubernetes.meta.v1.ObjectMetaPatchArgs(
+                name="meilisearch",
+                namespace=namespace,
+                labels=k8s_global_labels,
+                annotations={"pulumi.com/patchForce": "true"},
+            ),
+            spec=kubernetes.core.v1.PersistentVolumeClaimSpecPatchArgs(
+                volume_attributes_class_name=volume_attributes_class,
+            ),
+            opts=ResourceOptions(depends_on=[meilisearch_release]),
+        )
+
+    return meilisearch_release

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -842,6 +842,41 @@ if eks_config.get_bool("ebs_csi_provisioner"):
             depends_on=[ebs_csi_driver_role, *node_groups],
         ),
     )
+    # gp3 volumes provisioned by the storageclass above get 125 MB/s, the AWS
+    # default. That is a throughput ceiling, not a starting point: a volume whose
+    # working set does not fit in its consumer's page cache re-reads from EBS
+    # continuously and saturates it. Over fifteen consecutive minutes on 2026-09-03,
+    # mitxonline production Meilisearch averaged 110 MB/s against that ceiling and
+    # peaked at 122 MB/s (98% of it), while peak IOPS reached 1,904/s -- 38% of the
+    # 5,000 the storageclass had already provisioned. Throughput bound it; IOPS did
+    # not. Mean read size was 77 KiB, which is why.
+    #
+    # StorageClass parameters only apply at provisioning time, so they cannot fix an
+    # existing volume. A VolumeAttributesClass can: setting it on a live PVC drives
+    # ec2:ModifyVolume in place, with no pod restart and no rebind. This is declared
+    # for every cluster because it costs nothing until a PVC references it by name.
+    #
+    # iops is pinned to 5,000 rather than omitted so the class states the full target
+    # geometry instead of silently inheriting whatever the volume happens to carry.
+    # That matches what `iopsPerGB: 50` yields for the 100Gi volumes this is aimed at.
+    kubernetes.storage.v1.VolumeAttributesClass(
+        resource_name=f"{cluster_name}-ebs-gp3-throughput-500-volumeattributesclass",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name="ebs-gp3-throughput-500",
+            labels=k8s_global_labels,
+        ),
+        driver_name="ebs.csi.aws.com",
+        # ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/modify-volume.md
+        parameters={
+            "type": "gp3",
+            "iops": "5000",
+            "throughput": "500",
+        },
+        opts=ResourceOptions(
+            provider=k8s_provider,
+            depends_on=[ebs_csi_driver_role, *node_groups],
+        ),
+    )
     aws_ebs_cni_driver_addon = eks.Addon(
         f"{cluster_name}-eks-addon-ebs-cni-driver-addon",
         cluster=cluster,

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -877,6 +877,30 @@ if eks_config.get_bool("ebs_csi_provisioner"):
             depends_on=[ebs_csi_driver_role, *node_groups],
         ),
     )
+    # Rollback target for the class above, and the only way back. Clearing
+    # volumeAttributesClassName on a PVC means "no class applies" -- it does not call
+    # ec2:ModifyVolume, so it leaves the volume at whatever geometry it was last given.
+    # Reverting the commit that set the class would therefore strand a volume at 500
+    # MB/s with nothing left in the repo describing how to undo it. Rolling back means
+    # pointing the PVC at this class and waiting for the modification to apply, then
+    # removing the reference.
+    kubernetes.storage.v1.VolumeAttributesClass(
+        resource_name=f"{cluster_name}-ebs-gp3-throughput-125-volumeattributesclass",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name="ebs-gp3-throughput-125",
+            labels=k8s_global_labels,
+        ),
+        driver_name="ebs.csi.aws.com",
+        parameters={
+            "type": "gp3",
+            "iops": "5000",
+            "throughput": "125",
+        },
+        opts=ResourceOptions(
+            provider=k8s_provider,
+            depends_on=[ebs_csi_driver_role, *node_groups],
+        ),
+    )
     aws_ebs_cni_driver_addon = eks.Addon(
         f"{cluster_name}-eks-addon-ebs-cni-driver-addon",
         cluster=cluster,


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/ol-infrastructure/issues/5690 and https://github.com/mitodl/hq/issues/13014. Closes neither — this raises the IO ceiling, it does not fix the undersized memory limit that causes the re-reading.

### Description (What does it do?)

mitxonline production Meilisearch holds a 12.02 GiB `studio_content` index in a pod with a 4Gi cgroup limit. Only ~2.26 GB of it can stay in page cache (`memory.stat` `file`), so the rest is re-read from EBS on every commit, and the volume runs at its throughput ceiling.

- Adds an `ebs-gp3-throughput-500` VolumeAttributesClass next to the existing `ebs-gp3-sc` StorageClass, plus `ebs-gp3-throughput-125` as an explicit rollback target. Declared for every cluster; they cost nothing until a PVC names one.
- Adds a `meilisearch:volume_attributes_class` config key. When set, the Helm-created PVC is patched to reference the class. Emitted only where configured, so the other eleven edxapp stacks render unchanged.
- Sets it on mitxonline Production only.

**Why a VolumeAttributesClass and not StorageClass parameters:** StorageClass parameters apply at provisioning time and cannot revise a volume that already exists. A VolumeAttributesClass drives `ec2:ModifyVolume` against the live volume instead. That matters beyond convenience here — the PVC has required node affinity on `us-east-1a` and `meilisearch.py` pins the pod to `ol.mit.edu/core_node=true`, so anything that forces a reschedule risks leaving `meilisearch-0` `Pending`. That risk is what closed https://github.com/mitodl/ol-infrastructure/pull/5611.

**Why a PVC patch and not a chart value:** the meilisearch-kubernetes 0.38.0 `templates/pvc.yaml` has no field for `volumeAttributesClassName`.

#### Measurements

15 consecutive minutes, 17:20–17:34 UTC on 2026-09-03, `vol-09030d59932897b45`, CloudWatch at 60s granularity:

| | measured | provisioned |
|---|---|---|
| read throughput | 110 MB/s mean, **122 MB/s peak** | 125 MB/s |
| IOPS | 1,464/s mean, 1,904/s peak | 5,000 |

98% of the throughput ceiling at peak against 38% of the IOPS budget, at a mean read size of 77 KiB. Total read over the window was 91.8 GiB against a 12.02 GiB index — the whole index 7.6 times over.

Meilisearch's own batch trace attributes 44.26s of a 47.45s single-document commit to `post processing facets > facet search`, and that cost is flat against batch size (1 document: 52.9s; 1,741 documents: 47.5s), which is what makes per-XBlock indexing during a course import so expensive.

### How can this be tested?

`pulumi preview --diff`:

- `infrastructure/aws/eks` @ `applications.Production` → `+ 2 to create, 175 unchanged`; the two VolumeAttributesClass objects and nothing else.
- `applications/edxapp` @ `mitxonline.Production` → adds one resource from this change, `kubernetes:core/v1:PersistentVolumeClaimPatch` with `volumeAttributesClassName: "ebs-gp3-throughput-500"`.

`pre-commit run --from-ref origin/main --to-ref HEAD` passes (ruff, ruff format, mypy, yamllint, detect-secrets).

**Apply order matters:** the EKS stack has to go first. There are currently no VolumeAttributesClass objects in `applications-production`, and per `kubectl explain pvc.spec.volumeAttributesClassName`, a claim naming a class that does not exist is held `Pending` under `status.modifyVolumeStatus` until it appears. The claim stays bound and the pod keeps running, so this delays the modification rather than causing an outage — but it is a silent no-op until the class exists.

**After applying**, verify against the volume rather than the PVC, since the PVC field reflects intent and the volume reflects the result:

```bash
kubectl get pvc meilisearch -n mitxonline-openedx \
  -o jsonpath='{.status.currentVolumeAttributesClassName}{"\n"}'

aws ec2 describe-volumes --volume-ids vol-09030d59932897b45 \
  --query 'Volumes[0].[Iops,Throughput]' --output text   # expect: 5000   500
```

Then re-read a single-document commit trace and check that the `post processing facets > facet search` step falls roughly in proportion to the throughput increase:

```bash
kubectl exec -n mitxonline-openedx meilisearch-0 -- sh -c \
  'curl -s -H "Authorization: Bearer $MEILI_MASTER_KEY" localhost:7700/batches?limit=1'
```

I have not applied this. The predicted improvement is inferred from the measured saturation, not observed.

### Additional Context

- EBS permits one modification per volume per six hours, so a correction here is slow to land — which is also why the rollback path is a named class rather than a revert.

**Rollback.** Reverting the config key does not undo this. Clearing `volumeAttributesClassName` means "no class applies"; it does not call `ec2:ModifyVolume`, so the volume keeps its last geometry and the revert silently leaves production at 500 MB/s. Roll back by pointing the claim at `ebs-gp3-throughput-125`, confirming `Throughput` reads `125` on the volume, and only then dropping the key. Documented in MEILISEARCH.md.
- `iops` is pinned to `5000` in the class rather than omitted, matching what `iopsPerGB: 50` yields for a 100Gi volume, so the class states the full target geometry rather than inheriting whatever the volume happens to carry.
- The durable fix is still the memory limit. https://github.com/mitodl/ol-infrastructure/issues/5690 was closed as completed on 2026-09-01, but nothing was applied — the repo and the live pod both still read `memory_limit: 4Gi` / `memory_request: 1Gi`. This PR is deliberately independent of that work: it needs no scheduling headroom and no pod restart, so it does not have to win the argument that closed #5611 first.
- Meilisearch QA cannot be used to validate the performance effect. Its index is 2.2 GiB and fits inside the same 4Gi limit, so the facet step there runs in 53ms rather than 44s and there is no saturation to relieve.

