### PR TITLE
fix(local-dev): derive the Qdrant image from bridge.lib.versions

### DIFF
--- a/local-dev/infra/modules/search.py
+++ b/local-dev/infra/modules/search.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 import pulumi_kubernetes as k8s
 from pulumi import ResourceOptions
 
+from bridge.lib.versions import QDRANT_VERSION
+
 
 @dataclass
 class SearchResources:
@@ -37,7 +39,11 @@ def create_search(
                     "containers": [
                         {
                             "name": "qdrant",
-                            "image": "qdrant/qdrant:v1.12.5",
+                            # Shared with the Qdrant Cloud clusters
+                            # (infrastructure/qdrant_cloud) so local dev runs
+                            # the same server MIT Learn talks to in QA and
+                            # production, and renovate moves both at once.
+                            "image": f"qdrant/qdrant:{QDRANT_VERSION}",
                             # Qdrant mmaps ~30 files per segment and mit-learn
                             # shards its collections 6 ways, so it needs far
                             # more than the 1024-fd soft limit a pod inherits


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

- Derives the local-dev Qdrant image from `QDRANT_VERSION` in `src/bridge/lib/versions.py` instead of hardcoding it, so renovate moves local dev and the Qdrant Cloud clusters together.
- Fixes local hybrid search, reported as HTTP 500 on every text query. `local-dev` was on `qdrant/qdrant:v1.12.5`; 1.12 has no `formula` query variant and mit-learn's hybrid path always sends one, substituting an identity rescore when there is nothing to boost. Empty-query browse was unaffected because it goes through `client.scroll`, which is why the breakage looked selective.
- `v1.12.5` was wrong from the start rather than drifted: when local-dev landed in #4495, `QDRANT_VERSION` was already `v1.18.2` and mit-learn's compose said `:latest`, so it matched neither. The string appears nowhere else in either repo's history.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why the pins were never connected.** `local-dev/infra` is a standalone Pulumi project whose `__main__.py` puts its own directory on `sys.path` and imports only `modules.*`; nothing under it referenced `src/bridge`. Renovate bumped `QDRANT_VERSION` four times (1.17.1 → 1.18.0 → 1.18.2 → 1.18.3 → 1.19.0) with local dev sitting still.

**The import needs no new plumbing.** `local-dev/infra/*/Pulumi.yaml` declares `runtime: python` with no `virtualenv:` option, but Pulumi does not fall back to the PATH interpreter. It discovers the repo-root `pyproject.toml`/`uv.lock` by ancestor lookup and drives the program through `uv`, which resolves the workspace `.venv` where `ol-infrastructure` is installed and `bridge` resolves. Taking `uv` off PATH makes the mechanism explicit:

```
$ env PATH="/usr/bin:/bin" pulumi preview --stack local-dev.core.Dev
error: failed to discover package requirements: Could not find `uv` executable.
```

`local-dev/scripts/setup.sh:244` already requires `uv` as a hard prerequisite, which is why `uv sync` in `start.sh` suffices without activation. This is the same path that has always resolved `pulumi_kubernetes` — imported by every module under `local-dev/infra/` and absent from the ambient interpreter — so it is not a new dependency of this change.

**Qdrant is the only overlap.** `valkey`, `mailpit`, `litellm`, `apache/tika` and the Loki/Alloy/Grafana constants in `observability.py` have no counterpart in `versions.py`, and local-dev's Keycloak is a digest-pinned `mitodl/keycloak` build unrelated to `KEYCLOAK_VERSION`.

**Target version.** No stack overrides `cluster_version` in `Pulumi.mitlearn.{CI,QA,Production}.yaml`, so `QDRANT_VERSION` is what the cloud clusters are provisioned with. `qdrant-client 1.18.0` reports `is_compatible('1.18.0', '1.19.0') == True`; its window is ±1 minor and breaks at 1.20.

**Out of scope.** mit-learn pins the same image a third time in `docker-compose.services.yml`, currently `v1.18.3` with a renovate ceiling of `<1.19`. That is a separate repo and a separate decision. `src/bridge/lib/version_pins/QDRANT_VERSION` already exists as a one-line projection of the constant if a cross-repo consumer ever wants to track it.

</details>

### How can this be tested?

Against the k3d local-dev stack, `pulumi up` on `local-dev.core.Dev` rolls the Qdrant deployment to `QDRANT_VERSION`. The pod's storage is `emptyDir`, so the restart drops all collections and they have to be rebuilt:

```
kubectl -n mit-learn exec deploy/mitlearn-webapp -c app -- \
  python manage.py generate_embeddings --all --skip-contentfiles --recreate-collections
```

That took 3142s here and produced 2298 points in `mitlearn-local.resources` (2305 published resources minus the course blocklist).

Hybrid text search, which was the 500, then returns results:

```
GET /api/v0/vector_learning_resources_search/?q=linear+algebra&hybrid_search=true   -> 200, count=14
GET /api/v0/vector_learning_resources_search/?q=linear+algebra&hybrid_search=false  -> 200, count=200
```

The 1.12 behaviour is reproducible directly against a throwaway `qdrant/qdrant:v1.12.5` pod. Posting an identity formula to `/collections/<c>/points/query`:

```
{"query": {"formula": {"sum": ["$score"]}}, "limit": 3}
```

returns `400 Format error in JSON body: Expected some form of vector, id, or a type of query`, while `{"query": {"fusion": "rrf"}}` with a prefetch returns 200 on the same server. On 1.19.0 the same bare formula is rejected as `cannot apply Formula without prefetches` — recognised as a variant, and objecting only to the missing prefetch that mit-learn does supply.

### Additional Context

Two follow-ups this does not address:

- The Qdrant pod's storage is `emptyDir` (`local-dev/infra/modules/search.py`), so every pod restart discards the embeddings and costs a ~52-minute rebuild. Worth a PVC.
- `mitlearn-local.topics` is left empty by `generate_embeddings`; it is populated by `sync_topic_embeddings` on a separate beat schedule.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
