### PR TITLE
feat(otel): swap ocw-studio's OTEL endpoint var (hold for ocw-studio release)

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
@@ -41,7 +41,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-support@mit.edu'
-    OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
+    OTEL_EXPORTER_OTLP_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
     OTEL_RESOURCE_ATTRIBUTES: "service.namespace=ocw-studio,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_SERVICE_NAME: "ocw-studio-webapp"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
@@ -45,7 +45,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://live-qa.ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
-    OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
+    OTEL_EXPORTER_OTLP_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
     OTEL_RESOURCE_ATTRIBUTES: "service.namespace=ocw-studio,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_SERVICE_NAME: "ocw-studio-webapp"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked in the witan work-coordination graph as `tk-release-ocw-studio-with-mitol-django-observabili-3d79ac`, part of the OpenTelemetry APM coverage project)

### Description (What does it do?)
**DO NOT MERGE until an ocw-studio release carrying [mitodl/ocw-studio#3188](https://github.com/mitodl/ocw-studio/pull/3188) (merged, not yet released) has actually deployed to production.** Merging this ahead of that release breaks ocw-studio's currently-working tracing for zero metrics benefit — see below.

Swaps `applications/ocw_studio/Pulumi.Production.yaml` and `Pulumi.QA.yaml` from `OPENTELEMETRY_ENDPOINT` (a full `/v1/traces` URL) to `OTEL_EXPORTER_OTLP_ENDPOINT` (the base URL; the SDK appends the signal path itself).

Why this has to wait for a release: `mitol-django-observability` versions before `2026.8.19` (what ocw-studio's production image currently locks — confirmed live via `kube_pod_container_info`, tag `0.198.0`) read `OTEL_EXPORTER_OTLP_ENDPOINT` themselves and pass it to `OTLPSpanExporter(endpoint=...)` verbatim. An explicitly-passed endpoint is used as-is, so pointing it at the spec-correct base URL 404s every trace batch instead of exporting — surfaced as nothing louder than a `BatchSpanProcessor` warning. `2026.8.19` fixes that resolution and adds the `MeterProvider` that emits `http.server.duration`/`http.server.active_requests`, which is the actual point of this change: it's what makes ocw-studio-webapp selectable in the `Service RED - OpenTelemetry` dashboard's `$service` variable, the same metric-based RED alerting landed in [#5726](https://github.com/mitodl/ol-infrastructure/pull/5726).

### Screenshots (if appropriate):

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml` — passes.
- `pulumi preview` against both the QA and Production `ol-application-ocw-studio` stacks (with `OCW_STUDIO_DOCKER_TAG` set locally to run outside Concourse) shows an env-var-only diff: 6 resources update (`ocw-studio-app`, its celery worker/beat Deployments, and their init containers) and the pre-deploy `Job` shows as a replace rather than an update — Job pod templates are immutable in Kubernetes, so any env change to a Job forces delete+recreate; this is expected, not a config problem. Nothing else in the diff.
- Reviewer/merger validation before merging: confirm the release has landed by checking the running image's lock (`kube_pod_container_info` → tag → `gh api repos/mitodl/ocw-studio/contents/uv.lock?ref=<tag> --jq '.content' | base64 -d | grep -A2 'name = "mitol-django-observability"'`) shows `>=2026.8.19`. After merge and deploy, confirm `http_server_duration_milliseconds_count{service_name="ocw-studio-webapp"}` appears in grafanacloud-prom.

### Additional Context
Opened ahead of the release deliberately, at the requester's ask, so it's ready to merge the moment the ocw-studio release ships — not because it's safe to merge now.
