### PR TITLE
fix(omnigraph): witan-probe-token VaultStaticSecret double-prefixed its Vault path

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -1037,7 +1037,15 @@ if witan_probe_token_vault_secret is not None:
             dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
             mount="secret-operations",
             mount_type="kv-v1",
-            path=WITAN_PROBE_TOKEN_VAULT_PATH,
+            # Relative to `mount`, same as actor_tokens_secret's `path=
+            # "witan/actor-tokens"` above — NOT the full
+            # WITAN_PROBE_TOKEN_VAULT_PATH, which already includes the
+            # `secret-operations/` mount prefix for the vault.generic.Secret
+            # WRITE above (a different resource with a different path
+            # convention). Passing the full path here double-counts the
+            # mount and 403s: "GET .../secret-operations/secret-operations
+            # /witan/probe-token".
+            path="witan/probe-token",
             exclude_raw=True,
             excludes=[".*"],
             templates={


### PR DESCRIPTION
### What are the relevant tickets?
`tk-an-authenticated-synthetic-probe-for-council-to--e89d8f` (follow-up to #5727, which merged and deployed to QA)

### Description (What does it do?)
Live-deploy bug in #5727. Once merged and deployed to QA, the `witan-council-probe` CronJob's first scheduled run failed with `Error: secret "witan-probe-token" not found`. Root cause was in the `OLVaultK8SStaticSecretConfig` that syncs the token into that Secret: `path=WITAN_PROBE_TOKEN_VAULT_PATH` where that constant is `"secret-operations/witan/probe-token"` — the full Vault path, correct for the `vault.generic.Secret` *write* a few lines earlier, but `OLVaultK8SStaticSecretConfig.path` is relative to its own `mount="secret-operations"` argument (see `actor_tokens_secret`'s `path="witan/actor-tokens"` a few lines above, which does it correctly). The combination double-counted the mount and asked Vault for a path that never existed:

```
GET https://vault-qa.odl.mit.edu/v1/secret-operations/secret-operations/witan/probe-token
Code: 403. permission denied
```

Fix: `path="witan/probe-token"`, matching the existing `actor_tokens_secret` convention.

### How can this be tested?
- `uv run ruff check` / `mypy` on the changed file — clean.
- `pre-commit run --files src/ol_infrastructure/applications/omnigraph/__main__.py` — every hook passes.
- Confirmed the failure directly against the live QA cluster before writing the fix:
  ```
  kubectl -n omnigraph describe vaultstaticsecret witan-probe-token
  #   Message: Failed to sync the secret ... Code: 403 ... permission denied
  #   URL: GET .../v1/secret-operations/secret-operations/witan/probe-token
  kubectl -n omnigraph get jobs
  #   witan-council-probe-29807745   ...   FAILED: 1   (DeadlineExceeded, pod: "secret witan-probe-token not found")
  ```
- Not yet re-verified against a live deploy with this fix applied — that's the natural next step once this merges and QA redeploys: confirm the `VaultStaticSecret` reports `SYNCED=True`, the `witan-probe-token` Secret exists, and the next scheduled CronJob run succeeds.

### Additional Context
No code review caught this because it's a live-environment-only failure (a wrong Vault ACL path, not something ruff/mypy/pytest can see) — found by deploying to QA and reading the VaultStaticSecret's own status conditions and events, not from code inspection alone.