### PR TITLE
fix(release-bot): resolve Slack channel names to ids so proactive posts land

### DIFF
--- a/src/bridge/settings/apps.py
+++ b/src/bridge/settings/apps.py
@@ -28,8 +28,12 @@ class AppRegistration:
         when unset -- only set this when the repo name differs from the app
         name (e.g. app ``xpro`` lives in repo ``mitodl/mitxpro``).
     :param repo_main_branch: The repo's default branch.
-    :param slack_channel: Slack channel ID for release-bot notifications
-        (e.g. "ready to promote"). Unset means notifications are skipped for
+    :param slack_channel: Slack channel for release-bot notifications (e.g.
+        "ready to promote"), as either a channel id or a channel name. Slack's
+        Web API only accepts ids, so a name is resolved through
+        conversations.list at runtime (release_bot/slack_channels.py) -- which
+        needs groups:read on the bot token and, for a private channel, the bot
+        to have been invited to it. Unset means notifications are skipped for
         this app unless RELEASE_ANNOUNCE_CHANNEL provides a fallback.
     """
 
@@ -85,7 +89,7 @@ def repo_main_branch(app_name: str) -> str:
 
 
 def slack_channel(app_name: str) -> str | None:
-    """Return the configured Slack channel ID for release notifications, if any."""
+    """Return the configured Slack channel for release notifications, if any."""
     entry = APPS.get(app_name)
     return entry.slack_channel if entry else None
 

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -11,6 +11,7 @@ from typing import Any
 import bot_config as config
 import concourse_client as concourse
 import github_client as github
+import slack_channels
 import slack_users
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
@@ -362,7 +363,7 @@ async def _watch_checkboxes(app, app_name, cfg, channel) -> None:
                 continue
             if not issues:
                 await app.client.chat_postMessage(
-                    channel=channel,
+                    channel=await slack_channels.resolve(app.client, channel),
                     text=(
                         f"`{app_name}`: no open release issue any more — "
                         "no longer watching checkboxes."
@@ -400,7 +401,7 @@ async def _watch_checkboxes(app, app_name, cfg, channel) -> None:
             newly_done = outstanding - still_outstanding
             if newly_done:
                 await app.client.chat_postMessage(
-                    channel=channel,
+                    channel=await slack_channels.resolve(app.client, channel),
                     text=(
                         f"Thanks for checking off your boxes, "
                         f"{await slack_users.format_authors(app.client, newly_done)}!"
@@ -609,7 +610,7 @@ async def _notify_ready_to_promote(app, repos) -> None:
                 continue
             try:
                 await app.client.chat_postMessage(
-                    channel=channel,
+                    channel=await slack_channels.resolve(app.client, channel),
                     text=f"✅ `{app_name}` {version} is ready to promote.",
                     blocks=_ready_to_promote_blocks(
                         app_name,
@@ -787,7 +788,7 @@ async def _announce_deployments(app, repos, state: ReleaseProgressState) -> None
                 continue
             try:
                 await app.client.chat_postMessage(
-                    channel=channel,
+                    channel=await slack_channels.resolve(app.client, channel),
                     text=await _milestone_text(app_name, cfg, environment, deployment),
                 )
             except Exception:
@@ -857,7 +858,9 @@ async def _nag_stuck_releases(app, repos, state: ReleaseProgressState) -> None:
             )
             continue
         try:
-            await app.client.chat_postMessage(channel=channel, text=text)
+            await app.client.chat_postMessage(
+                channel=await slack_channels.resolve(app.client, channel), text=text
+            )
         except Exception:
             log.exception(
                 "Failed to report the stuck release %s for %s",
@@ -885,8 +888,40 @@ async def _poll_release_progress_loop(app, repos) -> None:
         await asyncio.sleep(_RELEASE_PROGRESS_POLL_SECONDS)
 
 
+async def _report_unreachable_channels(app, repos) -> None:
+    """Log configured channels the bot cannot post to, at boot.
+
+    Every proactive message is fire-and-forget inside a poll loop, so a
+    channel the bot was never invited to shows up only as a failed post
+    buried in the logs hours later. Say it once, at startup, naming the
+    channels.
+    """
+    configured = {
+        channel
+        for cfg in repos.values()
+        if (channel := _announce_channel(cfg)) is not None
+    }
+    if not configured:
+        return
+    try:
+        missing = await slack_channels.unresolvable(app.client, configured)
+    except Exception:
+        log.exception("Failed to check configured Slack channels at startup")
+        return
+    if missing:
+        log.error(
+            "Cannot resolve %s of %s configured Slack channel(s) to an id: %s."
+            " Posts to these will fail with channel_not_found until the bot is"
+            " invited to them (private channels are only visible to members)",
+            len(missing),
+            len(configured),
+            ", ".join(missing),
+        )
+
+
 async def main():
     app, repos = create_app()
+    await _report_unreachable_channels(app, repos)
     asyncio.create_task(_poll_ready_to_promote_loop(app, repos))  # noqa: RUF006
     asyncio.create_task(_poll_release_progress_loop(app, repos))  # noqa: RUF006
     handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])

--- a/src/ol_infrastructure/applications/release_bot/slack_channels.py
+++ b/src/ol_infrastructure/applications/release_bot/slack_channels.py
@@ -1,0 +1,169 @@
+"""Resolve configured Slack channel names to the IDs chat.postMessage needs.
+
+``AppRegistration.slack_channel`` (src/bridge/settings/apps.py) and
+``RELEASE_ANNOUNCE_CHANNEL`` are written as human-readable names --
+"product-mit-learn", "product-infrastructure". Slack's docs are explicit that
+``chat.postMessage`` wants "an encoded ID" and to "always use channel-like IDs
+instead to make sure your message gets to where it's going"; a bare name gets
+``channel_not_found``. That is what silently broke every proactive message the
+bot sends -- ready-to-promote, checkbox progress, deploy milestones, stuck
+release nags -- while slash-command replies kept working, because those go
+through Bolt's ``respond`` URL rather than the Web API.
+
+Names are resolved here through ``conversations.list`` and cached. The release
+channels are private, so this needs ``groups:read`` on the bot token (public
+channels would be ``channels:read`` -- see ``_CHANNEL_TYPES``), and Slack only
+lists private channels the bot has been invited to. A name that does not
+resolve therefore means one of exactly two things, both worth saying out loud:
+the bot is not in that channel, or the name is wrong.
+"""
+
+import logging
+import os
+import re
+import time
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Slack conversation ids: C (public), G (legacy private group), D (DM).
+_ID_RE = re.compile(r"^[CGD][A-Z0-9]{7,}$")
+
+# The release channels are private, so the default asks only for what
+# `groups:read` grants. Requesting public_channel as well would need
+# `channels:read` too, and Slack rejects the whole call for a type the token
+# cannot see -- which would take out private resolution along with it.
+_CHANNEL_TYPES = os.environ.get("SLACK_CHANNEL_TYPES", "private_channel")
+
+_PAGE_SIZE = 200
+
+# Re-listing on every cache miss would mean one conversations.list per poll
+# for a name that is simply wrong or a channel the bot was never invited to.
+_REFRESH_INTERVAL_SECONDS = 15 * 60
+
+# lowercased channel name -> id
+_name_to_id: dict[str, str] = {}
+_last_refresh: float | None = None
+
+# Set when Slack reports the token cannot list conversations. Every later call
+# would fail the same way, and these run on 60s/120s polls.
+_listing_disabled = False
+
+
+def _error_code(exc: Exception) -> str:
+    """Return Slack's error string from a SlackApiError, or "" for anything else.
+
+    Read reflectively so this module doesn't import slack_sdk: it is exercised
+    in a test environment that has neither slack_sdk nor slack_bolt installed.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return ""
+    try:
+        return str(response["error"])
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _page_channels(response: Any) -> tuple[list[dict[str, Any]], str]:
+    """Return (channels, next_cursor) from one conversations.list page."""
+    channels = response.get("channels") or []
+    cursor = (response.get("response_metadata") or {}).get("next_cursor") or ""
+    return channels, cursor
+
+
+async def _refresh(client: Any) -> None:
+    """Rebuild the name -> id map from conversations.list."""
+    global _last_refresh, _listing_disabled  # noqa: PLW0603
+
+    mapping: dict[str, str] = {}
+    cursor = ""
+    while True:
+        try:
+            response = await client.conversations_list(
+                types=_CHANNEL_TYPES,
+                exclude_archived=True,
+                limit=_PAGE_SIZE,
+                cursor=cursor,
+            )
+        except Exception as exc:
+            code = _error_code(exc)
+            if code == "missing_scope":
+                _listing_disabled = True
+                log.error(  # noqa: TRY400
+                    "Slack rejected conversations.list for lack of scope; the bot"
+                    " cannot turn configured channel names into ids and every"
+                    " proactive message will fail with channel_not_found."
+                    " Grant groups:read (private channels) on the bot token,"
+                    " or configure channel ids directly"
+                )
+            else:
+                log.exception("Failed to list Slack conversations")
+            # Keep whatever the last successful refresh cached rather than
+            # dropping known-good ids because one refresh failed.
+            _last_refresh = time.monotonic()
+            return
+        channels, cursor = _page_channels(response)
+        for channel in channels:
+            name = channel.get("name")
+            channel_id = channel.get("id")
+            if name and channel_id:
+                mapping[name.lower()] = channel_id
+        if not cursor:
+            break
+
+    _name_to_id.clear()
+    _name_to_id.update(mapping)
+    _last_refresh = time.monotonic()
+    log.info("Resolved %s Slack channel(s) from conversations.list", len(mapping))
+
+
+def _stale() -> bool:
+    return (
+        _last_refresh is None
+        or time.monotonic() - _last_refresh >= _REFRESH_INTERVAL_SECONDS
+    )
+
+
+async def resolve(client: Any, channel: str) -> str:
+    """Return the channel id for *channel*, or the input unchanged.
+
+    Returning the input on failure keeps the caller's own error handling in
+    play: the post then fails with the same ``channel_not_found`` it would
+    have anyway, next to this module's log line saying why.
+    """
+    if _ID_RE.match(channel):
+        return channel
+    name = channel.lstrip("#").lower()
+
+    cached = _name_to_id.get(name)
+    if cached:
+        return cached
+    if _listing_disabled:
+        return channel
+    if _stale():
+        await _refresh(client)
+        cached = _name_to_id.get(name)
+        if cached:
+            return cached
+
+    log.warning(
+        "No Slack channel named %r is visible to the bot. Private channels are"
+        " only listed once the bot is a member, so either invite it to the"
+        " channel or correct the configured name",
+        name,
+    )
+    return channel
+
+
+async def unresolvable(client: Any, channels: set[str]) -> list[str]:
+    """Return the configured *channels* that cannot be turned into an id.
+
+    Called once at startup so a misconfigured or un-invited channel is visible
+    at boot, rather than as a failed post buried in a poll loop later.
+    """
+    return [
+        channel
+        for channel in sorted(channels)
+        if await resolve(client, channel) == channel and not _ID_RE.match(channel)
+    ]

--- a/src/ol_infrastructure/applications/release_bot/slack_channels.py
+++ b/src/ol_infrastructure/applications/release_bot/slack_channels.py
@@ -10,12 +10,16 @@ bot sends -- ready-to-promote, checkbox progress, deploy milestones, stuck
 release nags -- while slash-command replies kept working, because those go
 through Bolt's ``respond`` URL rather than the Web API.
 
-Names are resolved here through ``conversations.list`` and cached. The release
-channels are private, so this needs ``groups:read`` on the bot token (public
-channels would be ``channels:read`` -- see ``_CHANNEL_TYPES``), and Slack only
-lists private channels the bot has been invited to. A name that does not
-resolve therefore means one of exactly two things, both worth saying out loud:
-the bot is not in that channel, or the name is wrong.
+Names are resolved here through ``conversations.list`` and cached. Both public
+and private channels are requested, which needs ``channels:read`` and
+``groups:read`` respectively. Slack's docs do not say whether asking for a type
+the token cannot see fails the whole call or just omits that type, so this does
+not depend on the answer: a ``missing_scope`` response narrows the request to
+private channels (what the release channels actually are) and retries once.
+
+Slack lists private channels only for the workspaces and conversations the
+token can reach, so a name that does not resolve means one of two things worth
+saying out loud: the bot is not in that channel, or the name is wrong.
 """
 
 import logging
@@ -29,11 +33,13 @@ log = logging.getLogger(__name__)
 # Slack conversation ids: C (public), G (legacy private group), D (DM).
 _ID_RE = re.compile(r"^[CGD][A-Z0-9]{7,}$")
 
-# The release channels are private, so the default asks only for what
-# `groups:read` grants. Requesting public_channel as well would need
-# `channels:read` too, and Slack rejects the whole call for a type the token
-# cannot see -- which would take out private resolution along with it.
-_CHANNEL_TYPES = os.environ.get("SLACK_CHANNEL_TYPES", "private_channel")
+_PRIVATE_ONLY = "private_channel"
+_ALL_CHANNEL_TYPES = f"public_channel,{_PRIVATE_ONLY}"
+
+# Pinning this in the environment turns off the narrowing retry below: an
+# explicit setting is a deliberate choice, not something to second-guess.
+_TYPES_PINNED = bool(os.environ.get("SLACK_CHANNEL_TYPES"))
+_channel_types = os.environ.get("SLACK_CHANNEL_TYPES", _ALL_CHANNEL_TYPES)
 
 _PAGE_SIZE = 200
 
@@ -44,9 +50,13 @@ _REFRESH_INTERVAL_SECONDS = 15 * 60
 # lowercased channel name -> id
 _name_to_id: dict[str, str] = {}
 _last_refresh: float | None = None
+# Whether the most recent listing attempt actually succeeded. A failed one
+# leaves every name unresolved, which must not be reported as "these channels
+# are misconfigured" -- see `unresolvable`.
+_last_refresh_ok = False
 
-# Set when Slack reports the token cannot list conversations. Every later call
-# would fail the same way, and these run on 60s/120s polls.
+# Set when Slack reports the token cannot list conversations at all. Every
+# later call would fail the same way, and these run on 60s/120s polls.
 _listing_disabled = False
 
 
@@ -72,37 +82,25 @@ def _page_channels(response: Any) -> tuple[list[dict[str, Any]], str]:
     return channels, cursor
 
 
-async def _refresh(client: Any) -> None:
-    """Rebuild the name -> id map from conversations.list."""
-    global _last_refresh, _listing_disabled  # noqa: PLW0603
-
+async def _list_all(client: Any, types: str) -> tuple[dict[str, str] | None, str]:
+    """Return (name -> id, "") for *types*, or (None, slack error code)."""
     mapping: dict[str, str] = {}
     cursor = ""
     while True:
         try:
             response = await client.conversations_list(
-                types=_CHANNEL_TYPES,
+                types=types,
                 exclude_archived=True,
                 limit=_PAGE_SIZE,
                 cursor=cursor,
             )
         except Exception as exc:
             code = _error_code(exc)
-            if code == "missing_scope":
-                _listing_disabled = True
-                log.error(  # noqa: TRY400
-                    "Slack rejected conversations.list for lack of scope; the bot"
-                    " cannot turn configured channel names into ids and every"
-                    " proactive message will fail with channel_not_found."
-                    " Grant groups:read (private channels) on the bot token,"
-                    " or configure channel ids directly"
-                )
-            else:
+            if code != "missing_scope":
+                # A scope error is handled by the caller, which may still have
+                # a narrower request to try; anything else is worth a trace.
                 log.exception("Failed to list Slack conversations")
-            # Keep whatever the last successful refresh cached rather than
-            # dropping known-good ids because one refresh failed.
-            _last_refresh = time.monotonic()
-            return
+            return None, code
         channels, cursor = _page_channels(response)
         for channel in channels:
             name = channel.get("name")
@@ -110,12 +108,57 @@ async def _refresh(client: Any) -> None:
             if name and channel_id:
                 mapping[name.lower()] = channel_id
         if not cursor:
-            break
+            return mapping, ""
 
-    _name_to_id.clear()
-    _name_to_id.update(mapping)
-    _last_refresh = time.monotonic()
-    log.info("Resolved %s Slack channel(s) from conversations.list", len(mapping))
+
+async def _refresh(client: Any) -> bool:
+    """Rebuild the name -> id map. Return whether the listing succeeded."""
+    global _channel_types, _last_refresh, _last_refresh_ok, _listing_disabled  # noqa: PLW0603
+
+    while True:
+        mapping, code = await _list_all(client, _channel_types)
+        if mapping is not None:
+            # Replace wholesale so a renamed or archived channel drops out.
+            _name_to_id.clear()
+            _name_to_id.update(mapping)
+            _last_refresh = time.monotonic()
+            _last_refresh_ok = True
+            log.info(
+                "Resolved %s Slack channel(s) from conversations.list", len(mapping)
+            )
+            return True
+
+        if (
+            code == "missing_scope"
+            and not _TYPES_PINNED
+            and _channel_types != _PRIVATE_ONLY
+        ):
+            # The token cannot see every requested type. Which types a partial
+            # token gets back is undocumented, so drop to the one the release
+            # channels actually need instead of assuming either behaviour.
+            log.warning(
+                "Slack rejected conversations.list for %s; retrying with %s."
+                " Grant channels:read as well if any release channel is public",
+                _channel_types,
+                _PRIVATE_ONLY,
+            )
+            _channel_types = _PRIVATE_ONLY
+            continue
+
+        if code == "missing_scope":
+            _listing_disabled = True
+            log.error(
+                "Slack rejected conversations.list for lack of scope; the bot"
+                " cannot turn configured channel names into ids and every"
+                " proactive message will fail with channel_not_found."
+                " Grant groups:read (private channels) and channels:read"
+                " (public) on the bot token, or configure channel ids directly"
+            )
+        # Keep whatever the last successful refresh cached rather than dropping
+        # known-good ids because one refresh failed.
+        _last_refresh = time.monotonic()
+        _last_refresh_ok = False
+        return False
 
 
 def _stale() -> bool:
@@ -156,12 +199,26 @@ async def resolve(client: Any, channel: str) -> str:
     return channel
 
 
+class ListingError(RuntimeError):
+    """conversations.list did not succeed, so nothing can be classified."""
+
+
 async def unresolvable(client: Any, channels: set[str]) -> list[str]:
     """Return the configured *channels* that cannot be turned into an id.
 
     Called once at startup so a misconfigured or un-invited channel is visible
     at boot, rather than as a failed post buried in a poll loop later.
+
+    Raises ``ListingError`` when the listing itself did not succeed. Without
+    that, a Slack outage or a rate limit at boot leaves every name unresolved
+    and would be reported as "all eight channels are misconfigured" -- sending
+    someone to check invites that are perfectly fine.
     """
+    if _stale() or not _last_refresh_ok:
+        await _refresh(client)
+    if not _last_refresh_ok:
+        msg = "conversations.list did not succeed; channel state is unknown"
+        raise ListingError(msg)
     return [
         channel
         for channel in sorted(channels)

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -1084,3 +1084,71 @@ async def test_the_stuck_threshold_is_configurable(repos, slack_app, monkeypatch
     await bot._nag_stuck_releases(slack_app, repos, bot.ReleaseProgressState())
 
     slack_app.client.chat_postMessage.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# channel resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_proactive_posts_go_to_the_resolved_channel_id(repos, monkeypatch):
+    """chat.postMessage rejects the configured name; it must get the id."""
+    monkeypatch.setattr(
+        bot.slack_channels, "resolve", AsyncMock(return_value="C0RESOLVED")
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "open_release_issues",
+        AsyncMock(
+            return_value=[
+                {
+                    "number": 1,
+                    "title": "Release my-app",
+                    "url": "https://github.com/mitodl/my-app/issues/1",
+                    "body": (
+                        "## Release 2026.9.1.1\n\n- [x] **A** (#1) by alice@example.com"
+                    ),
+                    "labels": ["release"],
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(bot.github, "add_issue_label", AsyncMock())
+    app = MagicMock()
+    app.client.chat_postMessage = AsyncMock()
+
+    await bot._notify_ready_to_promote(app, repos)
+
+    assert app.client.chat_postMessage.call_args.kwargs["channel"] == "C0RESOLVED"
+
+
+async def test_startup_reports_channels_the_bot_cannot_reach(
+    repos, monkeypatch, caplog
+):
+    """A channel the bot was never invited to must be visible at boot.
+
+    Otherwise it surfaces only as a failed post inside a poll loop, which is
+    how 137 channel_not_found errors went unnoticed.
+    """
+    monkeypatch.setattr(
+        bot.slack_channels,
+        "unresolvable",
+        AsyncMock(return_value=["product-mit-learn"]),
+    )
+    app = MagicMock()
+
+    with caplog.at_level("ERROR"):
+        await bot._report_unreachable_channels(app, repos)
+
+    assert "product-mit-learn" in caplog.text
+
+
+async def test_startup_check_survives_a_slack_failure(repos, monkeypatch):
+    """A validation that can kill startup is worse than no validation."""
+    monkeypatch.setattr(
+        bot.slack_channels,
+        "unresolvable",
+        AsyncMock(side_effect=RuntimeError("Slack is down")),
+    )
+
+    await bot._report_unreachable_channels(MagicMock(), repos)

--- a/tests/ol_infrastructure/applications/release_bot/test_slack_channels.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_slack_channels.py
@@ -1,0 +1,153 @@
+"""Tests for turning configured channel names into the ids Slack requires."""
+
+import pytest
+import slack_channels
+
+_MISSING_SCOPE = "missing_scope"
+
+
+class _FakeSlackError(Exception):
+    """Stand-in for slack_sdk's SlackApiError, which isn't installed here."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"error": code}
+
+
+class _FakeClient:
+    """conversations.list over *pages*, each a list of channel dicts."""
+
+    def __init__(self, pages=None, error=None):
+        self.pages = pages if pages is not None else [[]]
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    async def conversations_list(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error:
+            raise _FakeSlackError(self.error)
+        index = 0
+        cursor = kwargs.get("cursor") or ""
+        if cursor:
+            index = int(cursor)
+        next_cursor = str(index + 1) if index + 1 < len(self.pages) else ""
+        return {
+            "channels": self.pages[index],
+            "response_metadata": {"next_cursor": next_cursor},
+        }
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    slack_channels._name_to_id.clear()
+    slack_channels._last_refresh = None
+    slack_channels._listing_disabled = False
+    yield
+    slack_channels._name_to_id.clear()
+    slack_channels._last_refresh = None
+    slack_channels._listing_disabled = False
+
+
+async def test_a_name_resolves_to_an_id():
+    """The whole point: chat.postMessage rejects the configured name."""
+    client = _FakeClient([[{"id": "C123", "name": "product-mit-learn"}]])
+
+    resolved = await slack_channels.resolve(client, "product-mit-learn")
+
+    assert resolved == "C123"
+
+
+async def test_an_id_is_passed_through_without_an_api_call():
+    """Config may already hold an id; there is nothing to look up."""
+    client = _FakeClient()
+
+    assert await slack_channels.resolve(client, "C0123ABCD") == "C0123ABCD"
+    assert client.calls == []
+
+
+async def test_a_leading_hash_and_case_are_tolerated():
+    client = _FakeClient([[{"id": "C123", "name": "product-xpro"}]])
+
+    assert await slack_channels.resolve(client, "#Product-XPro") == "C123"
+
+
+async def test_the_listing_is_paginated():
+    """A workspace past one page would otherwise silently lose channels."""
+    client = _FakeClient(
+        [
+            [{"id": "C1", "name": "product-one"}],
+            [{"id": "C2", "name": "product-two"}],
+        ]
+    )
+
+    assert await slack_channels.resolve(client, "product-two") == "C2"
+
+
+async def test_resolution_is_cached():
+    """These run on 60s and 120s poll loops; one list call must serve them."""
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+
+    await slack_channels.resolve(client, "product-ovs")
+    await slack_channels.resolve(client, "product-ovs")
+
+    assert len(client.calls) == 1
+
+
+async def test_an_unknown_name_does_not_relist_on_every_call():
+    """A wrong name or an un-invited channel must not cost a call per poll."""
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+
+    await slack_channels.resolve(client, "product-typo")
+    await slack_channels.resolve(client, "product-typo")
+
+    assert len(client.calls) == 1
+
+
+async def test_an_unknown_name_falls_back_to_the_input():
+    """Returning the name keeps the caller's own error path intact."""
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+
+    assert await slack_channels.resolve(client, "product-typo") == "product-typo"
+
+
+async def test_missing_scope_stops_further_listing():
+    """Without groups:read every call fails identically -- stop asking."""
+    client = _FakeClient(error=_MISSING_SCOPE)
+
+    first = await slack_channels.resolve(client, "product-ovs")
+    second = await slack_channels.resolve(client, "product-xpro")
+
+    assert first == "product-ovs"
+    assert second == "product-xpro"
+    assert len(client.calls) == 1
+    assert slack_channels._listing_disabled
+
+
+async def test_a_failed_refresh_keeps_previously_resolved_ids():
+    """One bad refresh must not drop ids that are already known good."""
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+    await slack_channels.resolve(client, "product-ovs")
+
+    slack_channels._last_refresh = None
+    client.error = "ratelimited"
+
+    assert await slack_channels.resolve(client, "product-ovs") == "C123"
+
+
+async def test_the_private_channel_type_is_requested_by_default():
+    """Asking for public_channel too would need channels:read and 400 the call."""
+    client = _FakeClient([[]])
+
+    await slack_channels.resolve(client, "product-ovs")
+
+    assert client.calls[0]["types"] == "private_channel"
+
+
+async def test_unresolvable_names_the_channels_that_cannot_be_reached():
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+
+    missing = await slack_channels.unresolvable(
+        client, {"product-ovs", "product-typo", "C0123ABCD"}
+    )
+
+    assert missing == ["product-typo"]

--- a/tests/ol_infrastructure/applications/release_bot/test_slack_channels.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_slack_channels.py
@@ -20,10 +20,15 @@ class _FakeClient:
     def __init__(self, pages=None, error=None):
         self.pages = pages if pages is not None else [[]]
         self.error = error
+        # Raised on the first call only, so a test can model a request that
+        # fails for the types it asked for and succeeds once narrowed.
+        self.error_once: str | None = None
         self.calls: list[dict[str, object]] = []
 
     async def conversations_list(self, **kwargs):
         self.calls.append(kwargs)
+        if self.error_once and len(self.calls) == 1:
+            raise _FakeSlackError(self.error_once)
         if self.error:
             raise _FakeSlackError(self.error)
         index = 0
@@ -37,15 +42,19 @@ class _FakeClient:
         }
 
 
+def _reset():
+    slack_channels._name_to_id.clear()
+    slack_channels._last_refresh = None
+    slack_channels._last_refresh_ok = False
+    slack_channels._listing_disabled = False
+    slack_channels._channel_types = slack_channels._ALL_CHANNEL_TYPES
+
+
 @pytest.fixture(autouse=True)
 def _reset_module_state():
-    slack_channels._name_to_id.clear()
-    slack_channels._last_refresh = None
-    slack_channels._listing_disabled = False
+    _reset()
     yield
-    slack_channels._name_to_id.clear()
-    slack_channels._last_refresh = None
-    slack_channels._listing_disabled = False
+    _reset()
 
 
 async def test_a_name_resolves_to_an_id():
@@ -110,8 +119,22 @@ async def test_an_unknown_name_falls_back_to_the_input():
     assert await slack_channels.resolve(client, "product-typo") == "product-typo"
 
 
-async def test_missing_scope_stops_further_listing():
-    """Without groups:read every call fails identically -- stop asking."""
+async def test_missing_scope_narrows_to_private_channels_and_retries():
+    """Slack does not document what a partial-scope token gets back.
+
+    Rather than assuming the whole call fails (or that it quietly filters),
+    drop to the type the release channels actually are and try once more.
+    """
+    client = _FakeClient([[{"id": "C123", "name": "product-ovs"}]])
+    client.error_once = _MISSING_SCOPE
+
+    assert await slack_channels.resolve(client, "product-ovs") == "C123"
+    assert client.calls[0]["types"] == slack_channels._ALL_CHANNEL_TYPES
+    assert client.calls[1]["types"] == "private_channel"
+
+
+async def test_missing_scope_on_the_narrowed_request_stops_further_listing():
+    """With neither scope every call fails identically -- stop asking."""
     client = _FakeClient(error=_MISSING_SCOPE)
 
     first = await slack_channels.resolve(client, "product-ovs")
@@ -119,7 +142,8 @@ async def test_missing_scope_stops_further_listing():
 
     assert first == "product-ovs"
     assert second == "product-xpro"
-    assert len(client.calls) == 1
+    # One for the full request, one for the narrowed retry, then nothing.
+    assert len(client.calls) == 2
     assert slack_channels._listing_disabled
 
 
@@ -134,13 +158,26 @@ async def test_a_failed_refresh_keeps_previously_resolved_ids():
     assert await slack_channels.resolve(client, "product-ovs") == "C123"
 
 
-async def test_the_private_channel_type_is_requested_by_default():
-    """Asking for public_channel too would need channels:read and 400 the call."""
+async def test_both_channel_types_are_requested_by_default():
+    """A configured channel may be public; the fallback announce one especially."""
     client = _FakeClient([[]])
 
     await slack_channels.resolve(client, "product-ovs")
 
-    assert client.calls[0]["types"] == "private_channel"
+    assert client.calls[0]["types"] == "public_channel,private_channel"
+
+
+async def test_unresolvable_raises_when_the_listing_itself_failed():
+    """A Slack outage must not read as "all your channels are misconfigured".
+
+    Without this, one failed listing leaves every name unresolved and the
+    startup check blames the configuration, sending someone to check invites
+    that are fine.
+    """
+    client = _FakeClient(error="ratelimited")
+
+    with pytest.raises(slack_channels.ListingError):
+        await slack_channels.unresolvable(client, {"product-ovs"})
 
 
 async def test_unresolvable_names_the_channels_that_cannot_be_reached():


### PR DESCRIPTION
## What are the relevant tickets?

Part of the Doof decommission epic (mitodl/hq#7185). Found while verifying the `users:read.email` grant from #5708.

## Description (What does it do?)

Every `chat.postMessage` the release bot makes is failing in production. `kubectl logs release-bot-production-cd989c4b8-p2jmt -n operations` on applications.Production showed **137 `channel_not_found` responses in that pod's ~3h lifetime**, across the stuck-release nags (odl-video-service `2026.6.16.1`, xpro `2026.6.12.1`) and the ol-analytics-api RC announcement — and by extension ready-to-promote and checkbox progress, which post the same way. Slash-command replies were unaffected, which is why nobody noticed: those go through Bolt's `respond` URL rather than the Web API.

`AppRegistration.slack_channel` is documented as a channel ID, but every value in `src/bridge/settings/apps.py` is a *name* (`product-mit-learn`, `product-xpro`, …), as is the `RELEASE_ANNOUNCE_CHANNEL` default (`product-infrastructure`). Slack's docs for `chat.postMessage` say the argument wants "an encoded ID" and to "always use channel-like IDs instead to make sure your message gets to where it's going"; a bare name gets `channel_not_found`.

New `slack_channels.py`:

- Resolves a configured name to its id via `conversations.list`, cached, refreshed at most every 15 minutes — without that floor a wrong name or an un-invited channel costs a list call on every 60s/120s poll.
- Passes an id in config straight through, no API call.
- Tolerates a leading `#` and any casing.
- On failure returns the input unchanged, so the caller's existing error handling still fires, next to a log line saying which of the two possible causes applies.
- `missing_scope` disables listing for the process after one error log rather than failing per poll.

Startup now logs the configured channels it cannot reach, naming them. The previous behaviour left that to a failed post inside a poll loop, which is how 137 failures went unnoticed.

## Deploy notes / how can this be tested?

**Needs `groups:read` (private channels) and `channels:read` (public) on the bot token — both are now granted — and the bot must be invited to each release channel.** Slack's conversations.list docs say the returned channels "depend on what the calling token has access to" but do not spell out the private-channel membership rule, so I have treated an un-invited channel as unresolvable; the bot must be in the channel to post either way. That is what the new startup log names.

`SLACK_CHANNEL_TYPES` pins the requested conversation types (and, being explicit, disables the narrowing retry). By default both `public_channel` and `private_channel` are requested. Slack's docs do not say whether asking for a type the token cannot see fails the whole call or just omits that type — an earlier revision of this PR assumed the former, which was unverified — so the code no longer depends on the answer: a `missing_scope` response narrows to `private_channel` and retries once.

`uv run pytest tests/ol_infrastructure/applications/release_bot` — 121 passed, including pagination, the cache, the refresh floor, the missing-scope shutoff, id passthrough, and that the post sites actually use the resolved id.

Not verified against live Slack: I could not run a resolution from the pod (exec blocked), so the `groups:read` behaviour is asserted from Slack's docs, not observed. The check after deploy is the startup log line — it either names unreachable channels or says nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fJUUnTeht7kfR2brU1hCc
