### PR TITLE
chore(deps): bump ol-concourse to 0.18.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1487,14 +1487,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.18.0"
+version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/c7/11baf9431380e337676f3ac887a9130f6b5cb983752757d60f01b48c0c41/ol_concourse-0.18.0.tar.gz", hash = "sha256:426c30c75cc72f6c32729b91f873a1015e6989b88da580f145751b543958ea4b", size = 68438, upload-time = "2026-08-25T19:59:37.288Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/01/5664d6456dcda2525f44cd735880fce96ee5f6825701ca4b364c363fd53f/ol_concourse-0.18.1.tar.gz", hash = "sha256:5ef37da0ddb7fd878f5cdcb816c3fe85140c50724345184204c65a86aa4ea663", size = 70508, upload-time = "2026-09-03T20:29:58.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/b3/860c547aba2a94a1d30b98a39c0aa454332569c7e247681265120757584e/ol_concourse-0.18.0-py3-none-any.whl", hash = "sha256:abe7f5b78dfa0c69008f5e98cc1c8e1ccb69da6dd1ca252651c35239c7ba79fa", size = 60143, upload-time = "2026-08-25T19:59:36.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c4/08476d87be7d463c2478de6c6d4e2886946b873c0d724178b51c70340538/ol_concourse-0.18.1-py3-none-any.whl", hash = "sha256:9e5fa8c8762e61ef140e1e79053fdb3cc2ca83abc93cd6076a1a4024498ea9a4", size = 60793, upload-time = "2026-09-03T20:29:57.656Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What are the relevant tickets?

Unblocks the release-resource rollout under mitodl/hq#7185. Releases mitodl/ol-concourse#100 via mitodl/ol-concourse#101.

## Description

`bump_version_task`'s semver->calver transition script only rewrote `[tool.bumpversion].current_version` when the key already existed, then printed `Updated pyproject.toml current_version tracking` regardless. Six of the eight apps queued for the release-resource rollout (`learn-ai`, `mit-learn`, `mitxonline`, `ocw-studio`, `odl-video-service`, `mitxpro`) have no `current_version` on their default branch, so the one release that was supposed to migrate them to calver left the gap in place, and the next release hit `bump-my-version` with nothing to parse. `odl-video-service` and `mitxpro` already carry calver tags, so they would have failed on their *first* release rather than their second.

0.18.1 seeds the key when it is absent, and routes a repo missing it to the transition script even without a semver baseline.

Lock-only: the `ol-concourse>=0.18,<0.19` constraint in `pyproject.toml:50` already allowed 0.18.1, so this is `uv lock --upgrade-package ol-concourse` and nothing else.

## How can this be tested?

The fix reaches Concourse through the generated pipeline YAML rather than the task image — the transition script is embedded in the task's bash args by the `ol_concourse` package, and `src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py:42` runs the generator inside the `mitodl/ol-infrastructure` image. So what matters is what the generator emits after this bump:

```
PYTHONPATH=src uv run python src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py ol-analytics-api
```

The single `bump-version` task in that output carries all four new markers (`PYPROJECT_TABLE=""`, the `print("table" if bv is not None else "")` probe, the `sed -n 1p` split, and the `[ -n "$PYPROJECT_TABLE" ] && [ -z "$PYPROJECT_VER" ]` guard) plus the `Inserted pyproject.toml current_version` branch. Re-ran the same generator with only `uv.lock` reverted to 0.18.0: all four absent. So the diff in the emitted pipeline is real and comes from this bump alone.

`pyproject.toml` is in the k8s-apps meta pipeline's trigger paths (`meta.py:73`, with `trigger=True` on the get at `meta.py:86`), so merging this regenerates and re-sets the app pipelines without a manual `fly sp`.

pre-commit clean on `uv.lock`.

## Additional context

`ol-analytics-api` is the only app currently on `use_release_resource_workflow`, and it is unaffected either way — it already has a calver `current_version` (`2026.8.28.2`), so it never took the broken path. This bump is what the *other* six need before they can be flipped on.

Re-verified against `bump-my-version==1.3.0`, the version the `ol-concourse-dsl` task image pins: the unfixed input fails with `TypeError: 'NoneType' object is not iterable`, and the post-seed calver-to-calver bump succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L5Dn27AT4e5doFaaBcuPA