### PR TITLE
fix(omnigraph): grant read on secret-operations/witan/probe-token

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
+++ b/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
@@ -26,6 +26,13 @@ path "secret-operations/witan/token-sync-oidc" {
   capabilities = ["read"]
 }
 
+# svc-witan-probe's bearer token, written by this stack's own
+# vault.generic.Secret (__main__.py) and synced by the VSO into the
+# witan-council-probe CronJob's Secret. Consumed only within this namespace.
+path "secret-operations/witan/probe-token" {
+  capabilities = ["read"]
+}
+
 path "sys/leases/renew" {
   capabilities = ["update"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #5739. `tk-an-authenticated-synthetic-probe-for-council-to--e89d8f`

### Description (What does it do?)
`omnigraph_policy.hcl` — the Vault policy backing the omnigraph namespace's VSO sync — never granted `read` on `secret-operations/witan/probe-token`, so the `witan-council-probe` CronJob's token secret can never sync, independent of the path bug #5739 already fixed.

Adds:
```hcl
path "secret-operations/witan/probe-token" {
  capabilities = ["read"]
}
```
matching the existing `witan/actor-tokens` and `witan/token-sync-oidc` grants in the same file.

<details>
<summary><b>Implementation details</b></summary>
<br>

#5739 fixed `OLVaultK8SStaticSecretConfig`'s `path=` argument (it was double-counting the `secret-operations` mount). That made the Vault *request* correct, but the VSO's own Vault role still had no ACL grant on the corrected path at all — a separate gap in `omnigraph_policy.hcl`, the file passed as `vault_policy_path` to `OLEKSAuthBinding` in `__main__.py`. The `witan-probe-token` secret is written to Vault by this stack's own `vault.generic.Secret` resource (`__main__.py:771`) but was never added to the read policy the same stack's VSO role uses to sync it back out.
</details>

### How can this be tested?
- `pre-commit run --files src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl` — clean.
- Confirmed the failure directly against the live QA cluster before writing the fix (after #5739 had already merged and QA had already redeployed):
  ```
  kubectl -n omnigraph describe vaultstaticsecret witan-probe-token
  #   Failed to sync the secret ... Code: 403 ... permission denied
  #   URL: GET https://vault-qa.odl.mit.edu/v1/secret-operations/witan/probe-token
  kubectl -n omnigraph get jobs | grep witan-council-probe
  #   every run Failed, 0/1, every 15m
  ```
  The path in that URL is already correct (#5739's fix applied) — the 403 is a pure ACL gap.
- Not yet re-verified against a live deploy with this fix applied — the natural next step once this merges and QA redeploys: confirm `VaultStaticSecret` reports `SYNCED=True`, the `witan-probe-token` Secret exists, and the next scheduled CronJob run succeeds.

### Additional Context
Second live-only bug in this rollout (see #5739) — a Vault ACL gap, not something ruff/mypy/pytest can see. Found by reading the `VaultStaticSecret`'s own status conditions against the deployed QA cluster after the first fix had already landed and re-deployed, not from code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jeXu6jUy5UEQJGGPHqpgB