### PR TITLE
fix(edxapp): trust the Studio origin for LMS CSRF, and make the ORA grading MFE URL absolute

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -303,6 +303,7 @@ def _build_interpolated_config_dict(
         config["CSRF_TRUSTED_ORIGINS"] = [
             "https://canvas.mit.edu",
             f"https://{domains['lms']}",
+            f"https://{domains['studio']}",
         ]
         config.update(
             {
@@ -340,7 +341,10 @@ def _build_interpolated_config_dict(
 
     # xPro-specific configuration
     elif stack_info.env_prefix == "xpro":
-        config["CSRF_TRUSTED_ORIGINS"] = [f"https://{domains['lms']}"]
+        config["CSRF_TRUSTED_ORIGINS"] = [
+            f"https://{domains['lms']}",
+            f"https://{domains['studio']}",
+        ]
         config.update(
             {
                 "XPRO_BASE_URL": f"https://{marketing_domain}",
@@ -680,7 +684,7 @@ def create_k8s_configmaps(  # noqa: PLR0915
         "OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS": 365,
         "OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS": 30,
         "OPTIMIZELY_PROJECT_ID": None,
-        "ORA_GRADING_MICROFRONTEND_URL": "/ora-grading",
+        "ORA_GRADING_MICROFRONTEND_URL": f"https://{edxapp_config.require_object('domains')['lms']}/ora-grading",
         "ORDER_HISTORY_MICROFRONTEND_URL": None,
         "ORGANIZATIONS_AUTOCREATE": True,
         "PAID_COURSE_REGISTRATION_CURRENCY": ["usd", "$"],


### PR DESCRIPTION
### What are the relevant tickets?

Refs https://github.com/mitodl/hq/issues/13197 — "CI VERAWOOD BLOCKER: 403 Forbidden Error: Staff Grading of ORA Assignments"

### Description (What does it do?)

Unblocks xPRO's Verawood CI testing of ORA staff grading.

- Adds the Studio domain to `CSRF_TRUSTED_ORIGINS` for xpro and the residential deployments. mitxonline already lists it.
- Makes `ORA_GRADING_MICROFRONTEND_URL` absolute (`https://<lms>/ora-grading`) instead of the relative `/ora-grading`.

The reported 403 is not a permissions problem. It happens when the Enhanced Staff Grader is loaded from the Studio origin instead of the LMS.

<details>
<summary><b>Implementation details</b></summary>
<br>

**How the grader ends up on the Studio origin**

edx-ora2 builds the ORA staff notification link as a bare concatenation ([notifications.py#L38](https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/utils/notifications.py#L38)):

```python
content_url=f"{getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', '')}/{problem_id}"
```

With the relative `/ora-grading` that stores a root-relative URL. The notification tray is rendered in Studio too, so clicking a grading notification there resolves the link against Studio's origin. Fastly then serves it: the `studio host` backend condition is `host == studio && path !~ mfe_regex`, so every MFE path — not just `authoring` — falls through to the MFE S3 bucket on the Studio domain.

**Why the POST fails from there**

Studio is in `CORS_ORIGIN_WHITELIST`, so preflights and GETs succeed. Unsafe methods do not. Django >= 4.0 validates the `Origin` header whenever it is present, independently of the Referer check, and edx-platform's `CorsCSRFMiddleware` only suppresses the Referer check — [`skip_cross_domain_referer_check`](https://github.com/openedx/edx-platform/blob/release/verawood/openedx/core/djangoapps/cors_csrf/helpers.py) just patches `request.is_secure()` to False. Nothing in `lms/djangoapps/ora_staff_grader` can return 403; its error paths are 400, 409 and 500. The rejection happens in middleware, before the view.

**Evidence**

Fastly access logs for `xpro-ci`, all three 403s in the last 7 days:

```
403 POST courses-ci.xpro.mit.edu/api/ora_staff_grader/submission/lock?...
    ref=https://studio-ci.xpro.mit.edu/   response_body_size_bytes=117
```

117 bytes is byte-exact for:

```json
{"detail":"CSRF Failed: Origin checking failed - https://studio-ci.xpro.mit.edu does not match any trusted origins."}
```

Same trace, same cause, different endpoint: `403 PATCH courses-ci.../api/notifications/read/ ref=https://studio-ci.../` — marking a notification read from Studio is broken today for the same reason.

Not a role problem. On 2026-09-03 23:53:18 the same reporter, same account, from the LMS origin, ran `POST /api/ora_staff_grader/submission/batch/unlock` and got 200.

Live config on `xpro-openedx` in the CI cluster before this change:

```
CSRF_TRUSTED_ORIGINS   = ['https://courses-ci.xpro.mit.edu']
CORS_ORIGIN_WHITELIST  = [..., 'https://studio-ci.xpro.mit.edu', ...]
ORA_GRADING_MICROFRONTEND_URL = '/ora-grading'
```

**Which change does what**

The trusted-origin change is what actually clears the 403, including for notification rows already written with the relative URL. The absolute URL stops new links from pointing at the wrong host in the first place; it does not rewrite existing rows.

Not a Verawood regression — the same `CSRF_TRUSTED_ORIGINS` code path serves xpro QA and Production on Ulmo.

</details>

### How can this be tested?

Validation run so far:

- `pre-commit run --files src/ol_infrastructure/applications/edxapp/k8s_configmaps.py` — ruff format, ruff check and mypy pass.
- `pulumi preview -s xpro.CI` — the only resources with data diffs are `ol-xpro-edxapp-interpolated-config-ci` (60-interpolated-config.yaml) and `ol-xpro-edxapp-lms-general-config-ci` (81-lms-general-config.yaml). Deployment/Job churn in that preview is from a placeholder `EDXAPP_DOCKER_IMAGE_DIGEST`, not from this change.

Not yet verified: nothing has been deployed, so the 403 has not been confirmed gone against a running LMS. After deploy to xpro CI:

1. `kubectl -n xpro-openedx get cm 60-interpolated-config-yaml -o yaml` should list `https://studio-ci.xpro.mit.edu` under `CSRF_TRUSTED_ORIGINS`, and `81-lms-general-config-yaml` should show the absolute `ORA_GRADING_MICROFRONTEND_URL`. Confirm the LMS pods actually restarted onto the new configmaps.
2. As a course staff (non-superuser) account, open `https://studio-ci.xpro.mit.edu/ora-grading/block-v1:xPRO-VERA_TEST+VERAWOOD_TEST+VERA_TEST+type@openassessment+block@openassessment2`, pick an ungraded response and click Start Grading. `POST /api/ora_staff_grader/submission/lock` should return 200.
3. Submit a new ORA response so a fresh staff notification is generated, then click it from the Studio header. It should now navigate to `courses-ci.xpro.mit.edu/ora-grading/...`.
4. Confirm the LMS-origin path still works: instructor dashboard -> Open Responses -> View and grade responses -> Start Grading.

### Additional Context

- Two follow-ups this deliberately does not do:
  - Narrowing the Fastly `studio host` condition ([__main__.py#L1074](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/edxapp/__main__.py#L1074)) so the Studio domain stops serving `ora-grading`, `learn`, `gradebook` and `discuss` bundles. Today any LMS MFE loads on the Studio host, which is what let this fail half-working instead of 404ing.
  - `CorsCSRFMiddleware.__init__` reads `settings.FEATURES['ENABLE_CORS_HEADERS']`, but Verawood moved that flag to module level (`lms/envs/production.py` uses the bare name), so the middleware raises `MiddlewareNotUsed` and is inert. That is an upstream inconsistency and does not affect this fix — the Origin check lives in the base `CsrfViewMiddleware` either way.
- mitx / mitx-staging get the same Studio entry here. They have the identical gap; the notification tray behaves the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfS9R9xwVcDs31Sv8Btbyi
