### PR TITLE
feat(canaries): canary-meta pipeline and the CanaryParams renderer

### DIFF
--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -107,6 +107,9 @@ pipelines:
     release_bot_app_id: ENC[AES256_GCM,data:0hKun97QGQ==,iv:qK3cMS2C6lJoB6ZYqieK3uLZXeYH31N2PSxAUfPaOFw=,tag:NX9hxwjHBVB5ZrbagNhqVA==,type:int]
     #ENC[AES256_GCM,data:W+mOgYMbbn7WyfKwf/0onOhSecaOJaOPCkmy20eY1edXiEV+bHsFeRJ/,iv:UV7NPl5BFvuaupCRbKAnAouAZs2AS1A0SqaCa3c9pMk=,tag:lgpdEoaaeMX110zwwj//7A==,type:comment]
     release_bot_app_installation_id: ENC[AES256_GCM,data:nCjDk7sy4Avu,iv:vJYCJLDgxsUk8OEhlBhAXOGPUgBDOT8nlUNfffNDemM=,tag:p1kr2BuInndcCttTNwaNkw==,type:int]
+  infrastructure/canary_mit_learn:
+    email: ENC[AES256_GCM,data:Y5WXOYh0vZsR7B2TB257fn+o5Ucv1chXK5RqDunb72Y35MgjTho=,iv:onSVKk/VUM1UUProqizM8ceQrabxekAnhwJuNMu3iTw=,tag:ub4xLsPV80DWPQd/iNmC4A==,type:str]
+    password: ENC[AES256_GCM,data:iTziw6NpD+c9x1ryDTr0fE+nm7a2szoBovhrk1hebF+Q74bOi8zi0g==,iv:jeVvOfN+drBHDmWU4OqlWVbAK2+xbUL8PoTapwNneKk=,tag:z8siHsJjl3NqMvaI/HaChA==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-30T19:59:40Z"
@@ -119,7 +122,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-30T19:59:40Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFc++sLNA6j6p2pl3FmF0DfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMlps8T60GLfvSOP6PAgEQgDtyh7VqxM2GLdaXvJ0xYxHPX1CDzQc3NHPLta4PG+LVDiFHjsGIPvd2I+x4CoP9NgKWWwbBgY8HdD1mwQ==
-  lastmodified: "2026-08-18T17:50:16Z"
-  mac: ENC[AES256_GCM,data:WtoeFX8oJL8HO9QxTrzuDCtk0VUJ1DZ3Iq6SOqo6/0oyXNNZh9e/WhYoU9/lWjtS07Sxt/pJDYEIqn6jYsxnfH1losmz4yvCxYoFMPBwqJEqMOleN6jTYLo69u8fPiA7Hku6qETwMh8jKWnUOB/y6Q/tkbljXiV/uLXQ0MtpuU8=,iv:G6v12TKc9Qyu/fWEIe2UWZyEBpCqhd2bnSJ9CSZe0bY=,tag:7wLJ6lVY29U2dRZuZEJ4kg==,type:str]
+  lastmodified: "2026-09-04T16:02:51Z"
+  mac: ENC[AES256_GCM,data:C4RvWitHsHod2Lo/NBgQGgEAAx9rOHHb0dhFwagZX3gD4Mtw7Y7tW2iowTN8+uULkDhIyTOLLByky6fMwlL9CeMgAhPXSHEx/vXaK8H490qa/7ts235f3DbLO3ENQFxUw8GyBg1pmFxoXbTkewAj9OJZNBMiiTmwkh39YH76Jmc=,iv:ENbczfyljBdAdVGHfgiDZ5DdYPApm3tDXf66SshcoW0=,tag:KCEvabROgZqWg4lvSH9B6Q==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -104,6 +104,14 @@ downloads none.
 - **Web-first assertions only.** `expect(locator)` auto-retries; `expect(await
   locator.count())` does not, and is the most common source of canary flake.
 - **Never `waitForTimeout`.** Wait for the thing you actually need.
+- **Retry the action, not just the assertion, when interacting before hydration.**
+  Auto-waiting gets a locator that is present and enabled, which is not the same as
+  one the framework has attached a handler to yet — a keystroke into a
+  server-rendered search box is silently dropped. Wrap the action and its outcome in
+  `expect(async () => { … }).toPass()` rather than sleeping. `login-and-search.spec.ts`
+  does this; the race was caught only because the journey was run in WebKit, where the
+  page is slower to hydrate. Chromium passed it every time, which is what this class of
+  bug looks like right up until the target has a bad day.
 
 ## Failure artifacts
 

--- a/src/ol_concourse/pipelines/canaries/README.md
+++ b/src/ol_concourse/pipelines/canaries/README.md
@@ -42,12 +42,60 @@ find a course?". Alerting for the two is kept separate on purpose.
 ## Layout
 
 ```
-playwright.config.ts   Shared config. Requires CANARY_BASE_URL.
+meta.py                The canary-meta pipeline. `canary_names` is the source of
+                       truth for which canaries are actually deployed.
+pipeline.py            CanaryParams + the renderer for one canary-<property>
+                       pipeline. `pipeline_params` is a superset of canary_names.
+playwright.config.ts   Shared config. Requires CANARY_BASE_URL. Declares one
+                       project per browser; CanaryParams.browsers selects.
 package.json           Pins @playwright/test. Single source of truth for the
                        container image tag the pipeline pulls.
 specs/<property>/      One directory per web property.
   mit-learn/
 ```
+
+## How these run in Concourse
+
+`canary-meta` manages the fleet and re-sets itself. Each managed pipeline is named
+`canary-<property>` and holds a single job that pulls the stock Playwright image,
+runs `npm ci`, and runs that property's specs on a `time` trigger.
+
+```bash
+cd src/ol_concourse/pipelines/canaries
+python meta.py && fly -t pr-inf sp -p canary-meta -c definition.json
+```
+
+After that first manual set, `canary-meta` updates itself and every canary pipeline
+from `main`.
+
+Onboarding a property is **two list edits**, the same shape as
+[`simple_pulumi`](../infrastructure/simple_pulumi/):
+
+1. a `CanaryParams` entry in `pipeline.py`, and
+2. its name in `canary_names` in `meta.py`.
+
+The registry is deliberately the wider of the two, so a canary can be added and
+reviewed before it starts running against a live property. **Adding a journey to a
+property that already has a canary needs neither edit** — `spec_paths` defaults to the
+whole `specs/<property>/` directory.
+
+## Which Concourse instance
+
+The production instance (`pr-inf`), and there is deliberately no `--env` switch of the
+kind [`simple_pulumi/meta.py`](../infrastructure/simple_pulumi/meta.py) carries.
+
+That switch exists there because some Pulumi stacks run `local.Command` resources
+needing VPC-level access to QA or CI infrastructure, so the pipeline has to run *inside*
+that network. A canary has the opposite requirement: it is meant to see the property the
+way a member of the public does. Every current target — including `rc.learn.mit.edu` — is
+publicly reachable, so driving them from one instance is both sufficient and more
+faithful to what the canary claims to measure.
+
+A canary against an internal-only endpoint would break that assumption and need the
+`--env` treatment: a `canary_names` split per instance and an `extra_args` passthrough on
+the self-update job, copied from `simple_pulumi`. Note that such a canary is also no
+longer measuring the public user journey, which is worth questioning before adding the
+machinery.
 
 ## Running a canary locally
 

--- a/src/ol_concourse/pipelines/canaries/meta.py
+++ b/src/ol_concourse/pipelines/canaries/meta.py
@@ -1,0 +1,162 @@
+# pyright: reportCallIssue=false
+"""Meta pipeline managing the fleet of Playwright canary pipelines.
+
+Emits one ``create-<name>-pipeline`` job per entry in :data:`canary_names`, each of
+which renders and sets ``canary-<name>``, plus a job that re-sets this pipeline
+itself. Modeled on
+``src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py``.
+
+:data:`canary_names` is the source of truth for what is actually deployed.
+``pipeline.py``'s ``pipeline_params`` is a superset of it, so a canary can be
+prepared and reviewed before it starts running against a live property.
+
+Deployed to the production Concourse instance only -- there is deliberately no
+``--env`` switch here; see ``README.md`` ("Which Concourse instance") for the
+reasoning and for what would have to change to drive an internal-only target.
+"""
+
+import sys
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    SetPipelineStep,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+CANARY_DEFINITIONS = Identifier("canary-pipeline-definitions")
+CANARY_REPO_PATH = "src/ol_concourse/pipelines/canaries"
+
+_OL_INFRA_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+    "tag": "latest",
+    "aws_region": ECR_REGION,
+}
+
+
+def _render_pipeline_task(task_name: Identifier, script_args: list[str]) -> TaskStep:
+    """Run a canary rendering script and hand ``definition.json`` to the next step.
+
+    ``PYTHONPATH`` points at the *checked-out* ``src``, which is the point of the
+    git resource: the fleet must be rendered from the commit that triggered the
+    job, not from the copy baked into the image. ``ol_concourse`` is a namespace
+    package in both places, so they merge -- ``ol_concourse.pipelines`` resolves
+    from the checkout while ``ol_concourse.lib`` still comes from the image's
+    ``ol-concourse`` install.
+
+    :param task_name: Concourse task name.
+    :param script_args: ``python`` arguments, script path first.
+    :returns: The task step.
+    """
+    return TaskStep(
+        task=task_name,
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type="registry-image",
+                source=_OL_INFRA_IMAGE_SOURCE,
+            ),
+            inputs=[Input(name=CANARY_DEFINITIONS)],
+            outputs=[Output(name=Identifier("pipeline"))],
+            params={"PYTHONPATH": f"../{CANARY_DEFINITIONS}/src"},
+            run=Command(
+                path="python",
+                # definition.json is written to the CWD, so the CWD is the output
+                # the SetPipelineStep reads from.
+                dir="pipeline",
+                user="root",
+                args=script_args,
+            ),
+        ),
+    )
+
+
+def meta_job(canary_name: str) -> Job:
+    """Build the job that renders and sets one property's canary pipeline.
+
+    :param canary_name: Key into ``pipeline.py``'s ``pipeline_params``.
+    :returns: A job that sets ``canary-<canary_name>``.
+    """
+    return Job(
+        name=Identifier(f"create-{canary_name}-pipeline"),
+        plan=[
+            GetStep(get=CANARY_DEFINITIONS, trigger=True),
+            _render_pipeline_task(
+                Identifier(f"generate-{canary_name}-pipeline-file"),
+                [
+                    f"../{CANARY_DEFINITIONS}/{CANARY_REPO_PATH}/pipeline.py",
+                    canary_name,
+                ],
+            ),
+            SetPipelineStep(
+                set_pipeline=Identifier(f"canary-{canary_name}"),
+                file="pipeline/definition.json",
+            ),
+        ],
+    )
+
+
+def meta_pipeline(canary_names: list[str]) -> Pipeline:
+    """Build the self-managing canary meta pipeline.
+
+    :param canary_names: Canaries to deploy. The source of truth for the fleet.
+    :returns: The pipeline to set as ``canary-meta``.
+    """
+    pipeline_definitions = git_repo(
+        name=CANARY_DEFINITIONS,
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        # Narrower than simple_pulumi's watch list on purpose: nothing under this
+        # directory imports jobs.py, secrets_map.py or versions_map.py, so a change
+        # to those cannot alter a rendered canary and must not re-render the fleet.
+        paths=[
+            f"{CANARY_REPO_PATH}/",
+            "src/ol_concourse/pipelines/constants.py",
+            "pyproject.toml",
+        ],
+    )
+
+    jobs = [meta_job(canary_name) for canary_name in canary_names]
+    jobs.append(
+        Job(
+            name=Identifier("set-canary-meta-pipeline"),
+            plan=[
+                GetStep(get=CANARY_DEFINITIONS, trigger=True),
+                _render_pipeline_task(
+                    Identifier("generate-canary-meta-pipeline-file"),
+                    [f"../{CANARY_DEFINITIONS}/{CANARY_REPO_PATH}/meta.py"],
+                ),
+                SetPipelineStep(set_pipeline="self", file="pipeline/definition.json"),
+            ],
+        )
+    )
+
+    return Pipeline(resources=[pipeline_definitions], jobs=jobs)
+
+
+# The deployed fleet. Adding a name here is what puts a canary live, and is the
+# second of the two list edits that onboarding a property takes -- the first being
+# a CanaryParams entry in pipeline.py.
+canary_names = [
+    "mit-learn",
+]
+
+
+if __name__ == "__main__":
+    pipeline_json = meta_pipeline(canary_names).model_dump_json(indent=2)
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(pipeline_json)
+    sys.stdout.write(pipeline_json)
+    print()  # noqa: T201
+    print("fly -t pr-inf sp -p canary-meta -c definition.json")  # noqa: T201

--- a/src/ol_concourse/pipelines/canaries/pipeline.py
+++ b/src/ol_concourse/pipelines/canaries/pipeline.py
@@ -146,6 +146,9 @@ pipeline_params: dict[str, CanaryParams] = {
     "mit-learn": CanaryParams(
         canary_name="mit-learn",
         base_url="https://rc.learn.mit.edu",
+        # The Concourse credential's NAME, not a credential. Resolves from Vault at
+        # secret-concourse/infrastructure/canary_mit_learn for pr-inf pipelines.
+        credential_secret="canary_mit_learn",  # noqa: S106  # pragma: allowlist secret
     ),
 }
 

--- a/src/ol_concourse/pipelines/canaries/pipeline.py
+++ b/src/ol_concourse/pipelines/canaries/pipeline.py
@@ -1,0 +1,264 @@
+# pyright: reportCallIssue=false
+"""Render a Concourse pipeline that runs one web property's Playwright canaries.
+
+One managed pipeline per property, named ``canary-<name>``. Which properties are
+actually deployed is decided by the name list in ``meta.py``; ``pipeline_params``
+below is a superset, so an entry can be prepared and reviewed here before it goes
+live -- the same onboarding shape as
+``src/ol_concourse/pipelines/infrastructure/simple_pulumi/``.
+
+Read ``AGENTS.md`` in this directory before changing anything here, and
+``docs/adr/0011-playwright-canary-specs-in-ol-infrastructure.md`` for why the specs
+live next to this file.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    Platform,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo, schedule
+from pydantic import BaseModel, model_validator
+
+CANARY_DIRECTORY = Path(__file__).parent
+# Where this directory sits in a checkout, for the git resource's watched paths.
+CANARY_REPO_PATH = "src/ol_concourse/pipelines/canaries"
+OL_INFRASTRUCTURE_URI = "https://github.com/mitodl/ol-infrastructure"
+
+# Not routed through the ECR pull-through cache: that cache is configured for
+# Docker Hub (see dockerhub_ecr_image_uri) and this image is on Microsoft's
+# registry, which has no anonymous pull limit to work around.
+PLAYWRIGHT_IMAGE_REPOSITORY = "mcr.microsoft.com/playwright"
+
+# Browsers baked into the Playwright image, each of which playwright.config.ts
+# declares a project for. Adding one here without adding the project there
+# renders a pipeline that fails with "unknown project".
+Browser = Literal["chromium", "firefox", "webkit"]
+
+
+def playwright_image_tag(canary_directory: Path = CANARY_DIRECTORY) -> str:
+    """Derive the Playwright image tag from ``package.json``'s pin.
+
+    ``package.json`` is the single source of truth for the Playwright version, and
+    the browsers are baked into the image at a revision keyed to that exact
+    version. Hardcoding a tag here instead re-creates the drift that ADR 0011
+    exists to make unreachable, and whose only symptom is::
+
+        browserType.launch: Executable doesn't exist at
+        /ms-playwright/chromium_headless_shell-1208/...
+
+    which names neither the pin nor the tag.
+
+    :param canary_directory: Directory holding ``package.json``.
+    :returns: An image tag such as ``v1.62.1-noble``.
+    :raises ValueError: If the pin is absent or is a range rather than an exact
+        version. A range lets the installed version drift away from the image tag,
+        which is the failure above.
+    """
+    package_json = json.loads((canary_directory / "package.json").read_text())
+    pin = package_json.get("devDependencies", {}).get("@playwright/test")
+    if not pin:
+        msg = (
+            f"@playwright/test is not pinned in {canary_directory / 'package.json'}; "
+            "it is the single source of truth for the canary image tag."
+        )
+        raise ValueError(msg)
+    if not re.fullmatch(r"\d+\.\d+\.\d+", pin):
+        msg = (
+            f"@playwright/test must be pinned to an exact version, got {pin!r}. "
+            "A range lets the installed Playwright drift from the image tag, and "
+            "the resulting failure names neither version. See ADR 0011."
+        )
+        raise ValueError(msg)
+    return f"v{pin}-noble"
+
+
+class CanaryParams(BaseModel):
+    """One web property's canary pipeline.
+
+    Attributes:
+        canary_name: Property name. Becomes the pipeline name ``canary-<name>``
+            and, by default, the spec directory ``specs/<name>``.
+        base_url: Environment the journeys run against, e.g.
+            ``https://rc.learn.mit.edu``. Passed as ``CANARY_BASE_URL``, which
+            ``playwright.config.ts`` requires and never defaults.
+        spec_paths: Paths passed to ``playwright test``, relative to this
+            directory. Defaults to the property's whole spec directory, so
+            **adding a journey needs no change here** -- drop a new
+            ``specs/<name>/<journey>.spec.ts`` in and it runs. Narrow this only
+            to deliberately exclude a journey from the schedule.
+        browsers: Playwright projects to run. Chromium alone is the default: each
+            extra browser multiplies the load this canary puts on a live
+            property, and cross-browser coverage is a job for an application test
+            suite, not a canary.
+        credential_secret: Name of the Concourse credential holding this
+            property's canary login, with ``email`` and ``password`` keys --
+            surfaced to the specs as ``CANARY_USER_EMAIL`` and
+            ``CANARY_USER_PASSWORD``. Leave unset for a property whose journeys
+            are all anonymous. Never put a credential itself here; this file is
+            public source.
+        timeout: Per-test budget in milliseconds.
+        expect_timeout: Per-assertion budget in milliseconds. Well under
+            ``timeout`` so a failing assertion reports as itself rather than as a
+            whole-test timeout.
+        schedule_interval: How often the canary runs.
+        schedule_start: Optional daily window start, ``HH:MM``.
+        schedule_stop: Optional daily window end, ``HH:MM``.
+        schedule_days: Optional days to run, e.g. ``["Monday"]``.
+        branch: Branch the specs are read from.
+    """
+
+    canary_name: str
+    base_url: str
+    spec_paths: list[str] = []
+    browsers: list[Browser] = ["chromium"]
+    credential_secret: str | None = None
+    timeout: int = 90_000
+    expect_timeout: int = 15_000
+    schedule_interval: str = "10m"
+    schedule_start: str | None = None
+    schedule_stop: str | None = None
+    schedule_days: list[str] | None = None
+    branch: str = "main"
+
+    @model_validator(mode="after")
+    def default_spec_paths_to_property_directory(self) -> "CanaryParams":
+        """Run the property's whole spec directory unless told otherwise."""
+        if not self.spec_paths:
+            self.spec_paths = [f"specs/{self.canary_name}"]
+        return self
+
+
+pipeline_params: dict[str, CanaryParams] = {
+    "mit-learn": CanaryParams(
+        canary_name="mit-learn",
+        base_url="https://rc.learn.mit.edu",
+    ),
+}
+
+
+def build_canary_pipeline(canary_name: str) -> Pipeline:
+    """Render the canary pipeline for one property.
+
+    :param canary_name: Key into :data:`pipeline_params`.
+    :returns: The pipeline to set as ``canary-<canary_name>``.
+    :raises ValueError: On an unknown name, listing the available ones.
+    """
+    if canary_name not in pipeline_params:
+        msg = (
+            f"Unknown canary {canary_name!r}. "
+            f"Available canaries: {', '.join(sorted(pipeline_params))}"
+        )
+        raise ValueError(msg)
+    params = pipeline_params[canary_name]
+
+    canary_code = git_repo(
+        name=Identifier("canary-code"),
+        uri=OL_INFRASTRUCTURE_URI,
+        branch=params.branch,
+        paths=[f"{CANARY_REPO_PATH}/"],
+    )
+    canary_schedule = schedule(
+        name=Identifier("canary-schedule"),
+        interval=params.schedule_interval,
+        start=params.schedule_start,
+        stop=params.schedule_stop,
+        days=params.schedule_days,
+    )
+
+    task_params: dict[str, Any] = {
+        "CANARY_BASE_URL": params.base_url,
+        "CANARY_TIMEOUT": str(params.timeout),
+        "CANARY_EXPECT_TIMEOUT": str(params.expect_timeout),
+    }
+    if params.credential_secret:
+        # Resolved by Concourse's Vault credential manager at task start, so the
+        # value never appears in this pipeline's definition.json.
+        task_params["CANARY_USER_EMAIL"] = f"(({params.credential_secret}.email))"
+        task_params["CANARY_USER_PASSWORD"] = f"(({params.credential_secret}.password))"
+
+    project_flags = " ".join(f"--project={browser}" for browser in params.browsers)
+    spec_arguments = " ".join(params.spec_paths)
+    run_canary = "\n".join(
+        [
+            "set -euo pipefail",
+            f"cd canary-code/{CANARY_REPO_PATH}",
+            # @playwright/test is not installed globally in the image, so this is
+            # mandatory. It is also cheap -- 6 packages, no browser download,
+            # because the browsers are already in the image -- which is why no
+            # bespoke canary image is built. Keep it that way (see AGENTS.md).
+            "npm ci",
+            f"npx playwright test {spec_arguments} {project_flags}",
+        ]
+    )
+
+    return Pipeline(
+        resources=[canary_code, canary_schedule],
+        jobs=[
+            Job(
+                name=Identifier(f"run-{params.canary_name}-canary"),
+                # A canary that piles up behind a slow run reports on a target it
+                # is also still loading, and the failures interleave.
+                max_in_flight=1,
+                plan=[
+                    GetStep(get=canary_schedule.name, trigger=True),
+                    GetStep(get=canary_code.name, trigger=True),
+                    TaskStep(
+                        task=Identifier(f"run-{params.canary_name}-journeys"),
+                        config=TaskConfig(
+                            platform=Platform.linux,
+                            image_resource=AnonymousResource(
+                                type="registry-image",
+                                source={
+                                    "repository": PLAYWRIGHT_IMAGE_REPOSITORY,
+                                    "tag": playwright_image_tag(),
+                                },
+                            ),
+                            inputs=[Input(name=canary_code.name)],
+                            params=task_params,
+                            run=Command(
+                                path="bash",
+                                args=["-c", run_canary],
+                            ),
+                        ),
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+if __name__ == "__main__":
+    min_args = 2
+    if len(sys.argv) < min_args:
+        msg = (
+            "Please provide a canary name as a command line argument.\n"
+            f"Available canaries: {', '.join(sorted(pipeline_params))}"
+        )
+        raise ValueError(msg)
+
+    canary_name = sys.argv[1]
+
+    try:
+        pipeline_json = build_canary_pipeline(canary_name).model_dump_json(indent=2)
+        with open("definition.json", "w") as definition:  # noqa: PTH123
+            definition.write(pipeline_json)
+        sys.stdout.write(pipeline_json)
+        print()  # noqa: T201
+        print(f"fly -t pr-inf sp -p canary-{canary_name} -c definition.json")  # noqa: T201
+    except ValueError as error:
+        sys.stderr.write(f"Error: {error}\n")
+        sys.exit(1)

--- a/src/ol_concourse/pipelines/canaries/playwright.config.ts
+++ b/src/ol_concourse/pipelines/canaries/playwright.config.ts
@@ -37,12 +37,26 @@ export default defineConfig({
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
-    launchOptions: {
-      // Concourse gives a task container the 64MB default /dev/shm, which is
-      // where Chromium puts its renderer shared memory; without this it dies
-      // with a bare tab crash partway through a journey.
-      args: ["--disable-dev-shm-usage"],
-    },
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // One project per browser the image ships. `pipeline.py`'s CanaryParams.browsers
+  // selects between them with --project, and defaults to chromium alone: every
+  // extra browser multiplies the load a canary puts on a live property.
+  // A name added there must exist here.
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          // Concourse gives a task container the 64MB default /dev/shm, which
+          // is where Chromium puts its renderer shared memory; without this it
+          // dies with a bare tab crash partway through a journey. Chromium-only
+          // — Firefox and WebKit reject the flag.
+          args: ["--disable-dev-shm-usage"],
+        },
+      },
+    },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
 })

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -8,17 +8,111 @@
 
 | Spec | Journey | Status |
 |---|---|---|
-| `homepage.spec.ts` | Homepage renders in a real browser | Active |
-| _(pending)_ | Log in, then search for a course | Not yet written |
+| `homepage.spec.ts` | Homepage renders in a real browser, anonymously | Active |
+| `login-and-search.spec.ts` | Log in, reach the dashboard, then search for courses | Active |
+
+## Helpers
+
+| File | Purpose |
+|---|---|
+| `helpers/sign-in.ts` | Drives the real multi-screen Keycloak login from the homepage |
+| `helpers/signed-in-test.ts` | `test` whose `page` fixture is already signed in |
+
+A journey that needs a session imports `test` from `helpers/signed-in-test` and takes
+the ordinary `{ page }` fixture — do not call `signIn` yourself. The session is
+established once per worker and reused, so adding a third signed-in journey costs no
+extra logins. Journeys that must be anonymous, like `homepage.spec.ts`, keep importing
+`@playwright/test` directly.
+
+The session is held in memory and deliberately never written to disk: a `storageState`
+file carries live tokens and this project's failure artifacts are published. For the
+same reason the login context is not traced, so `sign-in.ts` puts the diagnosis in its
+error messages instead.
 
 ## Login flow
 
-RC and production use a **multi-screen** Keycloak login: email, Next, password, Next.
-A local Docker stack presents a single-screen form instead. Canaries only ever run
-against deployed environments, so only the multi-screen flow matters here.
+RC authenticates against `sso-qa.ol.mit.edu`, realm `olapps`, client `ol-mitlearn-client`.
+The flow is **identity-first** and measured as three screens:
+
+| Screen | Path | Form control |
+|---|---|---|
+| Email | `/protocol/openid-connect/auth` | label `Email`, button `Next` |
+| Password (account exists in the realm) | `/login-actions/authenticate` | label `Password`, button `Next` |
+| Signup (unknown non-MIT address) | `/login-actions/registration` | **has a captcha** |
+| Touchstone hand-off (unknown `@mit.edu` address) | `/broker/touchstone-idp/login` → `okta.mit.edu` | MIT credentials |
+
+There is **no captcha on the login path**, so the canary drives the real UI; no bypass,
+dedicated flow or injected `storageState` is needed.
 
 Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
 sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
+
+### Two things a login journey here must do
+
+Both are implemented in `helpers/sign-in.ts`; they are recorded here because they are
+properties of the realm, not of the code, and the next property to authenticate against
+`olapps` will need them too.
+
+1. **Assert the password screen was reached, positively.** The flow is identity-first, so
+   an account that is missing, disabled or renamed never produces a login error —
+   Keycloak just sends the browser elsewhere, and *which* elsewhere depends on the email
+   domain. The canary account is `@mit.edu`, so its failure mode is a silent hand-off to
+   Touchstone; a non-MIT address instead lands on the captcha'd signup form. Testing for
+   those destinations one at a time is how you end up reporting "login now requires SSO"
+   or "a captcha now blocks login" when the truth is that the account is gone. Worse, a
+   flow that assumes it is on the password screen will type the canary's password into
+   whatever page is actually showing — including MIT's own IdP.
+2. **Never retry a *rejected* password.** See the lockout note below. Retrying a page that
+   failed to load is fine; retrying a refused credential is not. Playwright starts a
+   fresh worker process for a retry, so `sign-in.ts` records the refusal in a file under
+   `tmpdir` — per-container, so it covers the run and nothing beyond it. Note that the
+   realm's custom theme means Keycloak's stock alert markup is absent: the refusal is
+   detected by its visible text (`Invalid username or password.`), which is what a user
+   sees anyway.
+
+## Canary account
+
+| | |
+|---|---|
+| Account | `odl-devops+canary-mit-learn-rc@mit.edu` |
+| Realm | `olapps` on `sso-qa.ol.mit.edu` (what RC authenticates against) |
+| Credential | Vault `secret-concourse/infrastructure/canary_mit_learn`, keys `email` / `password` |
+| Source of truth | `src/bridge/secrets/concourse/operations.production.yaml` under `pipelines:`, applied by the `concourse` Pulumi project |
+| Referenced as | `CanaryParams.credential_secret` set to `canary_mit_learn` in `../../pipeline.py` |
+
+The address is a plus-address on the devops list deliberately: the domain is one MIT
+controls, so a password-reset mail can never be received by anyone else, and anything the
+account does generate reaches a monitored mailbox instead of bouncing.
+
+**This user is not Pulumi-managed.** There are no `keycloak.User` resources in this
+repository, so the account was created through the admin API and exists only in the
+realm. It will not be recreated by a `pulumi up`, and nothing will detect its removal
+except the canary failing. It carries `emailVerified=true` and an empty
+`requiredActions` — the realm sets `verifyEmail=true` and has `VERIFY_EMAIL` as a
+*default action*, so a newly created user gets that action attached and cannot log in
+until it is cleared. It also needs the `fullName` attribute, which the realm's user
+profile marks required, and which rejects parentheses.
+
+### Rotation must be atomic, or the account is disabled
+
+Realm `olapps` is configured `failureFactor=10`, `permanentLockout=true`,
+`maxTemporaryLockouts=1`, `maxDeltaTimeSeconds=43200`. Ten consecutive failed logins
+gives one temporary lockout; the next ten **permanently disable the account**, which
+needs an admin to undo. The 12-hour reset window means a scheduled canary never lets the
+failure counter age out, so failures accumulate until lockout rather than settling into a
+harmless recurring error.
+
+So: **change Keycloak and the SOPS/Vault value together.** The gap between the two is
+itself enough to disable the account, and it will present as a captcha error rather than
+an auth error.
+
+### First-login onboarding, already cleared
+
+The first successful login redirects to `/onboarding?next=…&is_new_user=1`, not the
+dashboard. That has already been consumed for this account — subsequent logins land on
+`/dashboard`, and `/search?q=…` is reachable directly while authenticated. A *new* canary
+account would hit onboarding again, so anyone provisioning one should log in once by hand
+before relying on a journey that expects the dashboard.
 
 ## Content dependencies
 
@@ -28,7 +122,15 @@ that merely happens to exist in RC today is a future false page:
 
 | Journey | Requires | Guaranteed by |
 |---|---|---|
-| | | |
+| `login-and-search.spec.ts` | A search for `mathematics` returns at least one **course** | Nothing contractual — see below |
+
+That query is deliberately broad: MIT's catalogue not containing a single mathematics
+course is not a realistic content change, so the assertion is a real signal about search
+rather than a bet on one course's continued existence. It is still a content dependency,
+and the honest reading of a failure is "search returned nothing", which is a **failure
+worth paging on** — an emptied or half-rebuilt index looks exactly like this from a
+user's seat. Anything narrower, such as a named course or an exact result count, is a
+false page waiting for the next content sync.
 
 ## Prior art
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
@@ -1,0 +1,129 @@
+import { expect, type Page } from "@playwright/test"
+import { existsSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Realm `olapps` is permanentLockout=true, failureFactor=10, with a 12h counter
+// reset — so a credential that has drifted between Keycloak and Vault does not
+// settle into a harmless recurring failure, it disables the account for good in
+// about two hours at a 10-minute cadence. Playwright starts a fresh worker for a
+// retry, so refusing the second attempt has to be recorded somewhere outside the
+// process. Not under canary-results/, which is published as build artifacts;
+// tmpdir is per-container, so the refusal covers the run and nothing beyond it.
+const REJECTED_CREDENTIAL_MARKER = join(tmpdir(), "mit-learn-canary-credential-rejected")
+
+// Bounded so a rejected credential surfaces as itself. Left to the 90s test
+// timeout it would instead report as "test timeout", and the diagnosis below
+// would never run.
+const REDIRECT_TIMEOUT = 30_000
+
+function canaryCredentials(): { email: string; password: string } {
+  const email = process.env.CANARY_USER_EMAIL
+  const password = process.env.CANARY_USER_PASSWORD
+  if (!email || !password) {
+    throw new Error(
+      "CANARY_USER_EMAIL and CANARY_USER_PASSWORD are required. The pipeline " +
+        "sources them from Vault; locally, export them from SOPS. A canary never " +
+        "falls back to a default credential — see ../../../AGENTS.md.",
+    )
+  }
+  return { email, password }
+}
+
+// The realm ships a custom theme, so Keycloak's stock alert markup is not there
+// to key on — a refusal is ordinary visible text, which is also exactly what the
+// user is shown. Listed as whole phrases rather than as loose keywords so that
+// unrelated page copy cannot be read as a rejection and stop the canary.
+const REJECTION_MESSAGE =
+  /invalid username or password|invalid user credentials|account is (temporarily )?disabled|account is locked/i
+
+async function rejectionMessage(page: Page): Promise<string | null> {
+  const message = page.getByText(REJECTION_MESSAGE).first()
+  if (!(await message.isVisible().catch(() => false))) {
+    return null
+  }
+  return (await message.innerText()).trim()
+}
+
+/**
+ * Drive the real MIT Learn login, from the homepage through Keycloak.
+ *
+ * Fails with the actual cause rather than the visible symptom. The realm's flow
+ * is identity-first, so an account it does not recognise is never answered with
+ * a login error — the browser is simply sent somewhere else. See ../README.md.
+ */
+export async function signIn(page: Page): Promise<void> {
+  if (existsSync(REJECTED_CREDENTIAL_MARKER)) {
+    throw new Error(
+      "Refusing to re-submit a credential Keycloak already rejected in this run. " +
+        "Ten consecutive failures lock the canary account, and the next ten disable " +
+        "it permanently. Fix the credential in Keycloak and SOPS together.",
+    )
+  }
+  const { email, password } = canaryCredentials()
+
+  await page.goto("/")
+  // Step one of the journey, and the reason login starts here rather than at a
+  // deep link: a homepage that no longer offers a way in is a user-facing outage
+  // that a direct hop to the IdP would sail straight past.
+  await expect(page.locator("main")).toBeVisible()
+  const applicationOrigin = new URL(page.url()).origin
+
+  await page.getByRole("link", { name: "Log In" }).click()
+  await page.waitForURL((url) => url.origin !== applicationOrigin, {
+    timeout: REDIRECT_TIMEOUT,
+  })
+
+  const identityProvider = new URL(page.url()).origin
+  const emailScreen = page.url()
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  await page.waitForURL((url) => url.href !== emailScreen, { timeout: REDIRECT_TIMEOUT })
+
+  // Assert the local password screen positively, rather than testing for the
+  // known wrong destinations. An unrecognised account goes to whichever of them
+  // fits the address — measured: an @mit.edu one is handed off to Touchstone,
+  // any other domain gets the captcha'd signup form — and both mean the account
+  // is gone, not that login has grown a captcha or an SSO requirement. Guessing
+  // wrong here is not just a bad message: it would type the canary's password
+  // into whatever page happened to be showing.
+  const reached = new URL(page.url())
+  const onPasswordScreen =
+    reached.origin === identityProvider &&
+    reached.pathname.endsWith("/login-actions/authenticate")
+  if (!onPasswordScreen) {
+    throw new Error(
+      `After submitting the canary address, the flow reached ${reached.origin}` +
+        `${reached.pathname} instead of the password screen, so the account does ` +
+        "not exist in this realm. This is an account problem — not a captcha " +
+        "problem and not an SSO problem, whichever of those the page says.",
+    )
+  }
+
+  await page.getByLabel("Password", { exact: true }).fill(password)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  try {
+    await page.waitForURL((url) => url.origin === applicationOrigin, {
+      timeout: REDIRECT_TIMEOUT,
+    })
+  } catch (error) {
+    const rejection = await rejectionMessage(page)
+    if (rejection) {
+      writeFileSync(REJECTED_CREDENTIAL_MARKER, rejection)
+      throw new Error(
+        `Keycloak rejected the canary credential: "${rejection}". Not retrying — ` +
+          "see the lockout note in ../README.md. Rotation must change Keycloak and " +
+          "the SOPS/Vault value together; the gap between the two is itself enough " +
+          "to disable the account.",
+      )
+    }
+    throw error
+  }
+
+  if (new URL(page.url()).pathname.startsWith("/onboarding")) {
+    throw new Error(
+      "Login landed on onboarding, which only a canary account that has never " +
+        "completed it does. Log the account in by hand once, then re-run.",
+    )
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
@@ -1,0 +1,46 @@
+import { test as base, type BrowserContextOptions } from "@playwright/test"
+import { signIn } from "./sign-in"
+
+type SignedInWorkerFixtures = {
+  /** Session established once per worker, reused by every test in it. */
+  canarySession: BrowserContextOptions["storageState"]
+}
+
+/**
+ * `test` for journeys that need to be signed in.
+ *
+ * Import this instead of `@playwright/test` and the ordinary `page` fixture
+ * arrives authenticated, so a second journey reuses the login rather than
+ * re-implementing or re-running it. Journeys that should be anonymous — the
+ * homepage canary — keep importing `@playwright/test` directly.
+ *
+ * The session is held in memory and never written to disk: a storageState file
+ * carries live tokens, and this project's failure artifacts get published.
+ */
+export const test = base.extend<{}, SignedInWorkerFixtures>({
+  canarySession: [
+    async ({ browser }, use) => {
+      // A context built straight off `browser` inherits nothing from the project's
+      // `use`, so the config's required base URL has to be handed over explicitly
+      // or every `page.goto("/")` below is an invalid URL. Read from the project
+      // rather than the environment to keep playwright.config.ts the one place
+      // that decides what a canary targets.
+      const context = await browser.newContext({
+        baseURL: base.info().project.use.baseURL,
+      })
+      // Deliberately untraced, unlike the fixture-provided page: a trace of the
+      // login screens would embed the canary account's address, and traces are
+      // published as build artifacts. signIn() reports the cause in its message.
+      const page = await context.newPage()
+      await signIn(page)
+      const session = await context.storageState()
+      await context.close()
+      await use(session)
+    },
+    { scope: "worker" },
+  ],
+
+  storageState: ({ canarySession }, use) => use(canarySession),
+})
+
+export { expect } from "@playwright/test"

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./helpers/signed-in-test"
+
+// Broad enough that a working index cannot plausibly return nothing for it, and
+// specific enough that a result matching it means the query was actually applied.
+// Recorded in ../README.md's content-dependency table.
+const SEARCH_QUERY = "mathematics"
+
+test.describe("MIT Learn signed-in journey", () => {
+  test("signs in and reaches a page anonymous visitors cannot", async ({ page }) => {
+    await page.goto("/dashboard")
+
+    // Anonymous, this URL redirects to Keycloak, so arriving at the dashboard's
+    // own heading is proof of an authenticated session rather than proof that a
+    // redirect completed.
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole("heading", { name: "Your MIT Learning Journey" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "User Menu" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Log In" })).toHaveCount(0)
+  })
+
+  test("searches for courses and gets results relevant to the query", async ({ page }) => {
+    await page.goto("/")
+
+    // Retried as a unit because the header search box is in the server-rendered
+    // markup before React attaches a handler to it, so a keystroke can land in a
+    // box that is not listening yet and is silently dropped. Measured in WebKit;
+    // it is a race rather than a browser difference, and Chromium only wins it by
+    // being faster — which is the shape of a canary that passes until the day the
+    // target is slow, then pages someone at 3am.
+    const searchBox = page.getByRole("textbox", { name: "Search for" })
+    await expect(async () => {
+      await searchBox.fill(SEARCH_QUERY)
+      await searchBox.press("Enter")
+      await expect(page).toHaveURL(new RegExp(`/search\\?.*q=${SEARCH_QUERY}`), {
+        timeout: 5_000,
+      })
+    }).toPass({ timeout: 30_000 })
+
+    await expect(page.getByRole("heading", { name: "Search Results" })).toBeVisible()
+    await expect(page.getByRole("article").first()).toBeVisible()
+
+    // The tab set present but reading "Courses (0)" is what an emptied or
+    // half-rebuilt index looks like from a user's seat, so assert the count is
+    // non-zero separately from asserting the tab rendered at all.
+    const coursesTab = page.getByRole("tab", { name: /^Courses/ })
+    await expect(coursesTab).toBeVisible()
+    await expect(page.getByRole("tab", { name: /^Courses \([1-9]\d*\)/ })).toBeVisible()
+
+    await coursesTab.click()
+    // Relevance, not an exact count: any specific number is a false page waiting
+    // for the next content sync.
+    await expect(
+      page.getByRole("article", { name: new RegExp(`^Course:.*${SEARCH_QUERY}`, "i") }).first(),
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5592.

**Stacked on #5707** — targets `adr/playwright-canary-spec-packaging` because it depends on the `package.json` added there. Review #5707 first; GitHub will retarget this to `main` when it merges.

### Description (What does it do?)

Adds the Concourse side of the canary harness: a meta pipeline plus the per-property renderer, in the shape of [`infrastructure/simple_pulumi`](https://github.com/mitodl/ol-infrastructure/tree/main/src/ol_concourse/pipelines/infrastructure/simple_pulumi).

- **`pipeline.py`** — `CanaryParams` (Pydantic) + a `pipeline_params` registry + `build_canary_pipeline(name)`. Renders one `canary-<property>` pipeline: pull the stock Playwright image, `npm ci`, run that property's specs on a `time` trigger.
- **`meta.py`** — one `create-<name>-pipeline` job per entry in `canary_names`, plus a `set-canary-meta-pipeline` job that re-sets itself.
- Onboarding a property stays **two list edits**. Adding a *journey* to an existing property needs neither — `spec_paths` defaults to the whole `specs/<property>/` directory.

Three things worth a reviewer's attention:

- **The image tag is derived from `package.json`, and the derivation refuses a range pin.** ADR 0011 requires deriving rather than hardcoding; a range (`^1.62.1`) would re-open the same drift, since the browsers are baked into the image at a revision keyed to the exact Playwright version. That failure names neither version, so it's enforced rather than documented.
- **`playwright.config.ts` gains `firefox` and `webkit` projects.** It declared only `chromium`, so any other `CanaryParams.browsers` value would render a valid pipeline that failed at run time with "unknown project". `--disable-dev-shm-usage` moves into the chromium project — Firefox and WebKit reject the flag.
- **No `--env` switch**, unlike `simple_pulumi`. That switch exists there for stacks whose `local.Command` resources need VPC-level access; a canary wants the opposite — to see the property as the public does. Reasoning and the migration path for an internal-only target are in the README.

Deliberately **not** included, since each is owned by its own ticket: alerting (no dead notification field), failure-artifact publishing, and the login journey + its credential. `CanaryParams.credential_secret` is implemented and renders `((secret.email))` / `((secret.password))` indirections, but no canary sets it yet.

### How can this be tested?

```bash
cd src/ol_concourse/pipelines/canaries
python meta.py     # writes definition.json, prints the fly command
python pipeline.py mit-learn
```

What I ran:

- **The generated script, in the derived image, against live RC.** Extracted the exact `run` args the renderer emits and executed them in `mcr.microsoft.com/playwright:v1.62.1-noble` at the default 64MB `/dev/shm` (matching a Concourse task container) against `https://rc.learn.mit.edu`: chromium passed twice (638ms, 771ms), firefox and webkit each passed. `npm ci` reproduced at 6 packages / ~460ms with no browser download.
- **The real Concourse invocation shape** — cwd = the `pipeline` output dir, script by relative path, `PYTHONPATH` set. Both scripts write `definition.json` to the CWD the `SetPipelineStep` reads from and emit valid JSON. This is what confirms the `__file__`-relative `package.json` read still derives `v1.62.1-noble` from a different CWD.
- **The pin guard**: `^1.62.1`, `~1.62.1`, `latest` and a missing pin are each refused with a message naming the cause.
- **Credential rendering**: a `credential_secret` entry puts only `((...))` indirections in `definition.json`, never a value.
- `pre-commit` clean on all four files (ruff format, ruff check, mypy, detect-secrets); 386 tests in `tests/ol_concourse/` pass.

Not done: nothing has been set on Concourse. No canary is live, and there is no logged-in journey yet — the only spec is the content-free homepage check from #5707.

### Additional Context

While confirming the credential path I measured the `olapps` brute-force config on `sso-qa` (read-only): `failureFactor=10`, `permanentLockout=true`, `maxTemporaryLockouts=1`, `maxDeltaTimeSeconds=43200`. The 12-hour counter reset means a canary never gets a quiet window, so a credential that drifts between Keycloak and Vault escalates to a **permanently disabled account in roughly two hours** at a 10-minute cadence — and because the realm's flow is identity-first, it then presents as a *captcha* error rather than an auth error.

Two consequences for the tickets that follow this one, not for this diff: the login helper must not retry a rejected credential, and the `schedule_interval="10m"` default here is a placeholder for the cadence ticket to overwrite, not a considered value.
