### PR TITLE
feat(canaries): source the mit-learn RC canary login from Vault

### DIFF
--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -107,6 +107,9 @@ pipelines:
     release_bot_app_id: ENC[AES256_GCM,data:0hKun97QGQ==,iv:qK3cMS2C6lJoB6ZYqieK3uLZXeYH31N2PSxAUfPaOFw=,tag:NX9hxwjHBVB5ZrbagNhqVA==,type:int]
     #ENC[AES256_GCM,data:W+mOgYMbbn7WyfKwf/0onOhSecaOJaOPCkmy20eY1edXiEV+bHsFeRJ/,iv:UV7NPl5BFvuaupCRbKAnAouAZs2AS1A0SqaCa3c9pMk=,tag:lgpdEoaaeMX110zwwj//7A==,type:comment]
     release_bot_app_installation_id: ENC[AES256_GCM,data:nCjDk7sy4Avu,iv:vJYCJLDgxsUk8OEhlBhAXOGPUgBDOT8nlUNfffNDemM=,tag:p1kr2BuInndcCttTNwaNkw==,type:int]
+  infrastructure/canary_mit_learn:
+    email: ENC[AES256_GCM,data:Y5WXOYh0vZsR7B2TB257fn+o5Ucv1chXK5RqDunb72Y35MgjTho=,iv:onSVKk/VUM1UUProqizM8ceQrabxekAnhwJuNMu3iTw=,tag:ub4xLsPV80DWPQd/iNmC4A==,type:str]
+    password: ENC[AES256_GCM,data:iTziw6NpD+c9x1ryDTr0fE+nm7a2szoBovhrk1hebF+Q74bOi8zi0g==,iv:jeVvOfN+drBHDmWU4OqlWVbAK2+xbUL8PoTapwNneKk=,tag:z8siHsJjl3NqMvaI/HaChA==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-30T19:59:40Z"
@@ -119,7 +122,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-30T19:59:40Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFc++sLNA6j6p2pl3FmF0DfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMlps8T60GLfvSOP6PAgEQgDtyh7VqxM2GLdaXvJ0xYxHPX1CDzQc3NHPLta4PG+LVDiFHjsGIPvd2I+x4CoP9NgKWWwbBgY8HdD1mwQ==
-  lastmodified: "2026-08-18T17:50:16Z"
-  mac: ENC[AES256_GCM,data:WtoeFX8oJL8HO9QxTrzuDCtk0VUJ1DZ3Iq6SOqo6/0oyXNNZh9e/WhYoU9/lWjtS07Sxt/pJDYEIqn6jYsxnfH1losmz4yvCxYoFMPBwqJEqMOleN6jTYLo69u8fPiA7Hku6qETwMh8jKWnUOB/y6Q/tkbljXiV/uLXQ0MtpuU8=,iv:G6v12TKc9Qyu/fWEIe2UWZyEBpCqhd2bnSJ9CSZe0bY=,tag:7wLJ6lVY29U2dRZuZEJ4kg==,type:str]
+  lastmodified: "2026-09-04T16:02:51Z"
+  mac: ENC[AES256_GCM,data:C4RvWitHsHod2Lo/NBgQGgEAAx9rOHHb0dhFwagZX3gD4Mtw7Y7tW2iowTN8+uULkDhIyTOLLByky6fMwlL9CeMgAhPXSHEx/vXaK8H490qa/7ts235f3DbLO3ENQFxUw8GyBg1pmFxoXbTkewAj9OJZNBMiiTmwkh39YH76Jmc=,iv:ENbczfyljBdAdVGHfgiDZ5DdYPApm3tDXf66SshcoW0=,tag:KCEvabROgZqWg4lvSH9B6Q==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -104,6 +104,14 @@ downloads none.
 - **Web-first assertions only.** `expect(locator)` auto-retries; `expect(await
   locator.count())` does not, and is the most common source of canary flake.
 - **Never `waitForTimeout`.** Wait for the thing you actually need.
+- **Retry the action, not just the assertion, when interacting before hydration.**
+  Auto-waiting gets a locator that is present and enabled, which is not the same as
+  one the framework has attached a handler to yet — a keystroke into a
+  server-rendered search box is silently dropped. Wrap the action and its outcome in
+  `expect(async () => { … }).toPass()` rather than sleeping. `login-and-search.spec.ts`
+  does this; the race was caught only because the journey was run in WebKit, where the
+  page is slower to hydrate. Chromium passed it every time, which is what this class of
+  bug looks like right up until the target has a bad day.
 
 ## Failure artifacts
 

--- a/src/ol_concourse/pipelines/canaries/pipeline.py
+++ b/src/ol_concourse/pipelines/canaries/pipeline.py
@@ -146,6 +146,9 @@ pipeline_params: dict[str, CanaryParams] = {
     "mit-learn": CanaryParams(
         canary_name="mit-learn",
         base_url="https://rc.learn.mit.edu",
+        # The Concourse credential's NAME, not a credential. Resolves from Vault at
+        # secret-concourse/infrastructure/canary_mit_learn for pr-inf pipelines.
+        credential_secret="canary_mit_learn",  # noqa: S106  # pragma: allowlist secret
     ),
 }
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -13,12 +13,71 @@
 
 ## Login flow
 
-RC and production use a **multi-screen** Keycloak login: email, Next, password, Next.
-A local Docker stack presents a single-screen form instead. Canaries only ever run
-against deployed environments, so only the multi-screen flow matters here.
+RC authenticates against `sso-qa.ol.mit.edu`, realm `olapps`, client `ol-mitlearn-client`.
+The flow is **identity-first** and measured as three screens:
+
+| Screen | Path | Form control |
+|---|---|---|
+| Email | `/protocol/openid-connect/auth` | `input[name="username"]`, `button[name="login"]` |
+| Password (existing account) | `/login-actions/authenticate` | `input[name="password"]`, `button[name="login"]` |
+| Signup (unknown account) | `/login-actions/registration` | **has a captcha** |
 
 Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
 sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
+
+### Two things a login journey here must do
+
+1. **Assert the flow reached `/login-actions/authenticate`, not `/login-actions/registration`.**
+   Because the flow is identity-first, an account that is missing, disabled or locked out
+   does not produce a login error — Keycloak silently routes to the signup form, which
+   *does* have a captcha. Without this assertion the symptom of "our stored password
+   drifted" reads as "a captcha now blocks login", which sends triage the wrong way.
+2. **Never retry a *rejected* password.** See the lockout note below. Retrying a page that
+   failed to load is fine; retrying a refused credential is not.
+
+## Canary account
+
+| | |
+|---|---|
+| Account | `odl-devops+canary-mit-learn-rc@mit.edu` |
+| Realm | `olapps` on `sso-qa.ol.mit.edu` (what RC authenticates against) |
+| Credential | Vault `secret-concourse/infrastructure/canary_mit_learn`, keys `email` / `password` |
+| Source of truth | `src/bridge/secrets/concourse/operations.production.yaml` under `pipelines:`, applied by the `concourse` Pulumi project |
+| Referenced as | `CanaryParams.credential_secret` set to `canary_mit_learn` in `../../pipeline.py` |
+
+The address is a plus-address on the devops list deliberately: the domain is one MIT
+controls, so a password-reset mail can never be received by anyone else, and anything the
+account does generate reaches a monitored mailbox instead of bouncing.
+
+**This user is not Pulumi-managed.** There are no `keycloak.User` resources in this
+repository, so the account was created through the admin API and exists only in the
+realm. It will not be recreated by a `pulumi up`, and nothing will detect its removal
+except the canary failing. It carries `emailVerified=true` and an empty
+`requiredActions` — the realm sets `verifyEmail=true` and has `VERIFY_EMAIL` as a
+*default action*, so a newly created user gets that action attached and cannot log in
+until it is cleared. It also needs the `fullName` attribute, which the realm's user
+profile marks required, and which rejects parentheses.
+
+### Rotation must be atomic, or the account is disabled
+
+Realm `olapps` is configured `failureFactor=10`, `permanentLockout=true`,
+`maxTemporaryLockouts=1`, `maxDeltaTimeSeconds=43200`. Ten consecutive failed logins
+gives one temporary lockout; the next ten **permanently disable the account**, which
+needs an admin to undo. The 12-hour reset window means a scheduled canary never lets the
+failure counter age out, so failures accumulate until lockout rather than settling into a
+harmless recurring error.
+
+So: **change Keycloak and the SOPS/Vault value together.** The gap between the two is
+itself enough to disable the account, and it will present as a captcha error rather than
+an auth error.
+
+### First-login onboarding, already cleared
+
+The first successful login redirects to `/onboarding?next=…&is_new_user=1`, not the
+dashboard. That has already been consumed for this account — subsequent logins land on
+`/dashboard`, and `/search?q=…` is reachable directly while authenticated. A *new* canary
+account would hit onboarding again, so anyone provisioning one should log in once by hand
+before relying on a journey that expects the dashboard.
 
 ## Content dependencies
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -8,8 +8,26 @@
 
 | Spec | Journey | Status |
 |---|---|---|
-| `homepage.spec.ts` | Homepage renders in a real browser | Active |
-| _(pending)_ | Log in, then search for a course | Not yet written |
+| `homepage.spec.ts` | Homepage renders in a real browser, anonymously | Active |
+| `login-and-search.spec.ts` | Log in, reach the dashboard, then search for courses | Active |
+
+## Helpers
+
+| File | Purpose |
+|---|---|
+| `helpers/sign-in.ts` | Drives the real multi-screen Keycloak login from the homepage |
+| `helpers/signed-in-test.ts` | `test` whose `page` fixture is already signed in |
+
+A journey that needs a session imports `test` from `helpers/signed-in-test` and takes
+the ordinary `{ page }` fixture — do not call `signIn` yourself. The session is
+established once per worker and reused, so adding a third signed-in journey costs no
+extra logins. Journeys that must be anonymous, like `homepage.spec.ts`, keep importing
+`@playwright/test` directly.
+
+The session is held in memory and deliberately never written to disk: a `storageState`
+file carries live tokens and this project's failure artifacts are published. For the
+same reason the login context is not traced, so `sign-in.ts` puts the diagnosis in its
+error messages instead.
 
 ## Login flow
 
@@ -18,22 +36,39 @@ The flow is **identity-first** and measured as three screens:
 
 | Screen | Path | Form control |
 |---|---|---|
-| Email | `/protocol/openid-connect/auth` | `input[name="username"]`, `button[name="login"]` |
-| Password (existing account) | `/login-actions/authenticate` | `input[name="password"]`, `button[name="login"]` |
-| Signup (unknown account) | `/login-actions/registration` | **has a captcha** |
+| Email | `/protocol/openid-connect/auth` | label `Email`, button `Next` |
+| Password (account exists in the realm) | `/login-actions/authenticate` | label `Password`, button `Next` |
+| Signup (unknown non-MIT address) | `/login-actions/registration` | **has a captcha** |
+| Touchstone hand-off (unknown `@mit.edu` address) | `/broker/touchstone-idp/login` → `okta.mit.edu` | MIT credentials |
+
+There is **no captcha on the login path**, so the canary drives the real UI; no bypass,
+dedicated flow or injected `storageState` is needed.
 
 Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
 sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
 
 ### Two things a login journey here must do
 
-1. **Assert the flow reached `/login-actions/authenticate`, not `/login-actions/registration`.**
-   Because the flow is identity-first, an account that is missing, disabled or locked out
-   does not produce a login error — Keycloak silently routes to the signup form, which
-   *does* have a captcha. Without this assertion the symptom of "our stored password
-   drifted" reads as "a captcha now blocks login", which sends triage the wrong way.
+Both are implemented in `helpers/sign-in.ts`; they are recorded here because they are
+properties of the realm, not of the code, and the next property to authenticate against
+`olapps` will need them too.
+
+1. **Assert the password screen was reached, positively.** The flow is identity-first, so
+   an account that is missing, disabled or renamed never produces a login error —
+   Keycloak just sends the browser elsewhere, and *which* elsewhere depends on the email
+   domain. The canary account is `@mit.edu`, so its failure mode is a silent hand-off to
+   Touchstone; a non-MIT address instead lands on the captcha'd signup form. Testing for
+   those destinations one at a time is how you end up reporting "login now requires SSO"
+   or "a captcha now blocks login" when the truth is that the account is gone. Worse, a
+   flow that assumes it is on the password screen will type the canary's password into
+   whatever page is actually showing — including MIT's own IdP.
 2. **Never retry a *rejected* password.** See the lockout note below. Retrying a page that
-   failed to load is fine; retrying a refused credential is not.
+   failed to load is fine; retrying a refused credential is not. Playwright starts a
+   fresh worker process for a retry, so `sign-in.ts` records the refusal in a file under
+   `tmpdir` — per-container, so it covers the run and nothing beyond it. Note that the
+   realm's custom theme means Keycloak's stock alert markup is absent: the refusal is
+   detected by its visible text (`Invalid username or password.`), which is what a user
+   sees anyway.
 
 ## Canary account
 
@@ -87,7 +122,15 @@ that merely happens to exist in RC today is a future false page:
 
 | Journey | Requires | Guaranteed by |
 |---|---|---|
-| | | |
+| `login-and-search.spec.ts` | A search for `mathematics` returns at least one **course** | Nothing contractual — see below |
+
+That query is deliberately broad: MIT's catalogue not containing a single mathematics
+course is not a realistic content change, so the assertion is a real signal about search
+rather than a bet on one course's continued existence. It is still a content dependency,
+and the honest reading of a failure is "search returned nothing", which is a **failure
+worth paging on** — an emptied or half-rebuilt index looks exactly like this from a
+user's seat. Anything narrower, such as a named course or an exact result count, is a
+false page waiting for the next content sync.
 
 ## Prior art
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
@@ -1,0 +1,129 @@
+import { expect, type Page } from "@playwright/test"
+import { existsSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Realm `olapps` is permanentLockout=true, failureFactor=10, with a 12h counter
+// reset — so a credential that has drifted between Keycloak and Vault does not
+// settle into a harmless recurring failure, it disables the account for good in
+// about two hours at a 10-minute cadence. Playwright starts a fresh worker for a
+// retry, so refusing the second attempt has to be recorded somewhere outside the
+// process. Not under canary-results/, which is published as build artifacts;
+// tmpdir is per-container, so the refusal covers the run and nothing beyond it.
+const REJECTED_CREDENTIAL_MARKER = join(tmpdir(), "mit-learn-canary-credential-rejected")
+
+// Bounded so a rejected credential surfaces as itself. Left to the 90s test
+// timeout it would instead report as "test timeout", and the diagnosis below
+// would never run.
+const REDIRECT_TIMEOUT = 30_000
+
+function canaryCredentials(): { email: string; password: string } {
+  const email = process.env.CANARY_USER_EMAIL
+  const password = process.env.CANARY_USER_PASSWORD
+  if (!email || !password) {
+    throw new Error(
+      "CANARY_USER_EMAIL and CANARY_USER_PASSWORD are required. The pipeline " +
+        "sources them from Vault; locally, export them from SOPS. A canary never " +
+        "falls back to a default credential — see ../../../AGENTS.md.",
+    )
+  }
+  return { email, password }
+}
+
+// The realm ships a custom theme, so Keycloak's stock alert markup is not there
+// to key on — a refusal is ordinary visible text, which is also exactly what the
+// user is shown. Listed as whole phrases rather than as loose keywords so that
+// unrelated page copy cannot be read as a rejection and stop the canary.
+const REJECTION_MESSAGE =
+  /invalid username or password|invalid user credentials|account is (temporarily )?disabled|account is locked/i
+
+async function rejectionMessage(page: Page): Promise<string | null> {
+  const message = page.getByText(REJECTION_MESSAGE).first()
+  if (!(await message.isVisible().catch(() => false))) {
+    return null
+  }
+  return (await message.innerText()).trim()
+}
+
+/**
+ * Drive the real MIT Learn login, from the homepage through Keycloak.
+ *
+ * Fails with the actual cause rather than the visible symptom. The realm's flow
+ * is identity-first, so an account it does not recognise is never answered with
+ * a login error — the browser is simply sent somewhere else. See ../README.md.
+ */
+export async function signIn(page: Page): Promise<void> {
+  if (existsSync(REJECTED_CREDENTIAL_MARKER)) {
+    throw new Error(
+      "Refusing to re-submit a credential Keycloak already rejected in this run. " +
+        "Ten consecutive failures lock the canary account, and the next ten disable " +
+        "it permanently. Fix the credential in Keycloak and SOPS together.",
+    )
+  }
+  const { email, password } = canaryCredentials()
+
+  await page.goto("/")
+  // Step one of the journey, and the reason login starts here rather than at a
+  // deep link: a homepage that no longer offers a way in is a user-facing outage
+  // that a direct hop to the IdP would sail straight past.
+  await expect(page.locator("main")).toBeVisible()
+  const applicationOrigin = new URL(page.url()).origin
+
+  await page.getByRole("link", { name: "Log In" }).click()
+  await page.waitForURL((url) => url.origin !== applicationOrigin, {
+    timeout: REDIRECT_TIMEOUT,
+  })
+
+  const identityProvider = new URL(page.url()).origin
+  const emailScreen = page.url()
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  await page.waitForURL((url) => url.href !== emailScreen, { timeout: REDIRECT_TIMEOUT })
+
+  // Assert the local password screen positively, rather than testing for the
+  // known wrong destinations. An unrecognised account goes to whichever of them
+  // fits the address — measured: an @mit.edu one is handed off to Touchstone,
+  // any other domain gets the captcha'd signup form — and both mean the account
+  // is gone, not that login has grown a captcha or an SSO requirement. Guessing
+  // wrong here is not just a bad message: it would type the canary's password
+  // into whatever page happened to be showing.
+  const reached = new URL(page.url())
+  const onPasswordScreen =
+    reached.origin === identityProvider &&
+    reached.pathname.endsWith("/login-actions/authenticate")
+  if (!onPasswordScreen) {
+    throw new Error(
+      `After submitting the canary address, the flow reached ${reached.origin}` +
+        `${reached.pathname} instead of the password screen, so the account does ` +
+        "not exist in this realm. This is an account problem — not a captcha " +
+        "problem and not an SSO problem, whichever of those the page says.",
+    )
+  }
+
+  await page.getByLabel("Password", { exact: true }).fill(password)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  try {
+    await page.waitForURL((url) => url.origin === applicationOrigin, {
+      timeout: REDIRECT_TIMEOUT,
+    })
+  } catch (error) {
+    const rejection = await rejectionMessage(page)
+    if (rejection) {
+      writeFileSync(REJECTED_CREDENTIAL_MARKER, rejection)
+      throw new Error(
+        `Keycloak rejected the canary credential: "${rejection}". Not retrying — ` +
+          "see the lockout note in ../README.md. Rotation must change Keycloak and " +
+          "the SOPS/Vault value together; the gap between the two is itself enough " +
+          "to disable the account.",
+      )
+    }
+    throw error
+  }
+
+  if (new URL(page.url()).pathname.startsWith("/onboarding")) {
+    throw new Error(
+      "Login landed on onboarding, which only a canary account that has never " +
+        "completed it does. Log the account in by hand once, then re-run.",
+    )
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
@@ -1,0 +1,46 @@
+import { test as base, type BrowserContextOptions } from "@playwright/test"
+import { signIn } from "./sign-in"
+
+type SignedInWorkerFixtures = {
+  /** Session established once per worker, reused by every test in it. */
+  canarySession: BrowserContextOptions["storageState"]
+}
+
+/**
+ * `test` for journeys that need to be signed in.
+ *
+ * Import this instead of `@playwright/test` and the ordinary `page` fixture
+ * arrives authenticated, so a second journey reuses the login rather than
+ * re-implementing or re-running it. Journeys that should be anonymous — the
+ * homepage canary — keep importing `@playwright/test` directly.
+ *
+ * The session is held in memory and never written to disk: a storageState file
+ * carries live tokens, and this project's failure artifacts get published.
+ */
+export const test = base.extend<{}, SignedInWorkerFixtures>({
+  canarySession: [
+    async ({ browser }, use) => {
+      // A context built straight off `browser` inherits nothing from the project's
+      // `use`, so the config's required base URL has to be handed over explicitly
+      // or every `page.goto("/")` below is an invalid URL. Read from the project
+      // rather than the environment to keep playwright.config.ts the one place
+      // that decides what a canary targets.
+      const context = await browser.newContext({
+        baseURL: base.info().project.use.baseURL,
+      })
+      // Deliberately untraced, unlike the fixture-provided page: a trace of the
+      // login screens would embed the canary account's address, and traces are
+      // published as build artifacts. signIn() reports the cause in its message.
+      const page = await context.newPage()
+      await signIn(page)
+      const session = await context.storageState()
+      await context.close()
+      await use(session)
+    },
+    { scope: "worker" },
+  ],
+
+  storageState: ({ canarySession }, use) => use(canarySession),
+})
+
+export { expect } from "@playwright/test"

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./helpers/signed-in-test"
+
+// Broad enough that a working index cannot plausibly return nothing for it, and
+// specific enough that a result matching it means the query was actually applied.
+// Recorded in ../README.md's content-dependency table.
+const SEARCH_QUERY = "mathematics"
+
+test.describe("MIT Learn signed-in journey", () => {
+  test("signs in and reaches a page anonymous visitors cannot", async ({ page }) => {
+    await page.goto("/dashboard")
+
+    // Anonymous, this URL redirects to Keycloak, so arriving at the dashboard's
+    // own heading is proof of an authenticated session rather than proof that a
+    // redirect completed.
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole("heading", { name: "Your MIT Learning Journey" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "User Menu" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Log In" })).toHaveCount(0)
+  })
+
+  test("searches for courses and gets results relevant to the query", async ({ page }) => {
+    await page.goto("/")
+
+    // Retried as a unit because the header search box is in the server-rendered
+    // markup before React attaches a handler to it, so a keystroke can land in a
+    // box that is not listening yet and is silently dropped. Measured in WebKit;
+    // it is a race rather than a browser difference, and Chromium only wins it by
+    // being faster — which is the shape of a canary that passes until the day the
+    // target is slow, then pages someone at 3am.
+    const searchBox = page.getByRole("textbox", { name: "Search for" })
+    await expect(async () => {
+      await searchBox.fill(SEARCH_QUERY)
+      await searchBox.press("Enter")
+      await expect(page).toHaveURL(new RegExp(`/search\\?.*q=${SEARCH_QUERY}`), {
+        timeout: 5_000,
+      })
+    }).toPass({ timeout: 30_000 })
+
+    await expect(page.getByRole("heading", { name: "Search Results" })).toBeVisible()
+    await expect(page.getByRole("article").first()).toBeVisible()
+
+    // The tab set present but reading "Courses (0)" is what an emptied or
+    // half-rebuilt index looks like from a user's seat, so assert the count is
+    // non-zero separately from asserting the tab rendered at all.
+    const coursesTab = page.getByRole("tab", { name: /^Courses/ })
+    await expect(coursesTab).toBeVisible()
+    await expect(page.getByRole("tab", { name: /^Courses \([1-9]\d*\)/ })).toBeVisible()
+
+    await coursesTab.click()
+    // Relevance, not an exact count: any specific number is a false page waiting
+    // for the next content sync.
+    await expect(
+      page.getByRole("article", { name: new RegExp(`^Course:.*${SEARCH_QUERY}`, "i") }).first(),
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5592.

**Stacked on #5747** (which is itself stacked on #5707). Targets `canary/pipeline-renderer` so the diff is just this change; GitHub will retarget as the stack merges.

### Description (What does it do?)

Sources the mit-learn RC canary's login and completes the credential wiring.

- Adds `pipelines: infrastructure/canary_mit_learn` (`email`, `password`) to `src/bridge/secrets/concourse/operations.production.yaml`. The `concourse` Pulumi project already iterates that map, so it lands in Vault at `secret-concourse/infrastructure/canary_mit_learn`.
- Sets `credential_secret` on the mit-learn `CanaryParams`, which renders `CANARY_USER_EMAIL=((canary_mit_learn.email))` and `CANARY_USER_PASSWORD=((canary_mit_learn.password))`.
- Documents the account in `specs/mit-learn/README.md`, including the measured login flow and its form controls.

**The account:** `odl-devops+canary-mit-learn-rc@mit.edu`, realm `olapps` on `sso-qa.ol.mit.edu`. Dedicated and disposable rather than a shared human login. The plus-address is deliberate — the domain is one MIT controls, so a password-reset mail can never be received by anyone else (`resetPasswordAllowed=true` in this realm), and any mail it does generate reaches a monitored list instead of bouncing.

**It is not Pulumi-managed.** There are no `keycloak.User` resources in this repo, so it was created through the admin API and exists only in the realm. Nothing will recreate it and nothing detects its removal except the canary going red — hence the README section.

Two realm behaviours are documented because they are silent and fatal:

- `VERIFY_EMAIL` is a realm **default action**, so it gets attached to a newly created user *even when the create call sends an empty `requiredActions`*. I hit this: the account could not have logged in until it was cleared.
- The required `fullName` profile attribute rejects parentheses (`error-person-name-invalid-character`).

### How can this be tested?

Credential correctness was verified against the live environment, not assumed:

- **Login completes end to end.** Drove the real browser flow against `https://rc.learn.mit.edu` in the pinned Playwright image using only env-sourced credentials. It reached `/login-actions/authenticate` — *not* the captcha'd `/login-actions/registration` — and landed authenticated.
- **The stored value is the one Keycloak has.** The password decrypted from SOPS matches the value set via the admin API by SHA-256 (`408ae451…`), so the Vault path and the realm cannot be out of step as of this commit.
- **No plaintext leaks into a rendered pipeline.** `python pipeline.py mit-learn` emits only the `((…))` indirections; a scan for a 40-char literal finds nothing.
- **Both SOPS recipients survived the edit.** `hc_vault` and `kms` metadata compare byte-identical before/after (unchanged `created_at` and `enc`); only `mac` and `lastmodified` differ, which is correct for a value edit rather than a key rotation. Worth stating explicitly because I have no transit-encrypt permission on `infrastructure/encrypt/sops` — `sops set` reuses the existing data key, so it never needed it.
- `pre-commit` fully clean (including detect-secrets); 386 `tests/ol_concourse/` tests pass. `secrets_map.py` needs no entry — the canary reads its credential through Concourse's Vault credential manager at task runtime, not via `read_yaml_secrets` in a Pulumi project.

Not tested: nothing is deployed. The `concourse` Pulumi project must be applied before any canary referencing `((canary_mit_learn.*))` can resolve it, and there is still no logged-in journey — the only spec remains the content-free homepage check.

### Additional Context

**Rotation must be atomic, and this is the part worth reading.** Realm `olapps` is `failureFactor=10`, `permanentLockout=true`, `maxTemporaryLockouts=1`, `maxDeltaTimeSeconds=43200`. Ten consecutive failures gives one temporary lockout; the next ten **permanently disable the account**, requiring admin recovery. The 12-hour counter reset means a scheduled canary never lets failures age out, so they accumulate to lockout instead of settling into a harmless recurring error — roughly two hours at a 10-minute cadence.

And because the flow is identity-first, a disabled account is routed to the captcha'd registration form, so the whole thing surfaces as *"a captcha now blocks our canary"* rather than *"our password drifted"*. Changing Keycloak and this file together is what avoids it.

Consequently the login journey must not retry a **rejected** credential (retrying a page that failed to load is fine), and the `schedule_interval` default from #5747 is a placeholder for the cadence ticket, not a considered value.
