### PR TITLE
fix(alerting): group WorkloadJobFailed* on the owning CronJob, not the Job

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -162,6 +162,15 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
             # per rule -- and, once promoted past `channel=devops-warnings`,
             # one Rootly incident per rule instead of one per service.
             "service_name",
+            # Same reasoning once more for metric_rules/eks_general.py's
+            # WorkloadJobFailed*, which aggregate `sum by (cluster, namespace,
+            # workload)` -- `workload` is the owning CronJob for a scheduled Job
+            # and the Job's own name otherwise. That aggregation drops
+            # `job_name` (deliberately: it is the per-tick ordinal that made
+            # every run a separate alert), so without `workload` here two
+            # unrelated failing CronJobs in the same namespace would arrive as
+            # one grouped notification.
+            "workload",
         ],
         # "1m", not "60s" — Grafana normalizes durations to the largest unit and
         # a mismatched spelling shows as a perpetual diff on every preview.

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -435,6 +435,31 @@ def create(
             #                       break. Remove this exclusion once that job is
             #                       fixed -- see tk-witan-ci-indexer-cronjob-fails-on
             #                       -nearly-every-r-4c1462.
+            #
+            # Grouped on the OWNING CronJob, not the Job. A CronJob's job_name
+            # carries the schedule ordinal (`witan-council-probe-29808780`), so
+            # keying on it makes every tick a new series -- a new alert instance,
+            # and a new Rootly alert that `deduplication_key_kind="payload"`
+            # cannot collapse because the payload differs. Measured 2026-09-04:
+            # a probe CronJob at */15 that stayed broken for ~19h produced 76 of
+            # the 99 Rootly alerts created in that window, burying the one
+            # unrelated critical in the same list. Nobody was paged 76 times
+            # (rootly/__main__.py demotes WorkloadJobFailedCritical to the
+            # non-paging urgency), but the volume is unbounded in the duration
+            # of the outage.
+            #
+            # `kube_job_owner` supplies the owner: CronJob-owned Jobs carry
+            # owner_kind="CronJob" and owner_name=<cronjob>, while a standalone
+            # Job (e.g. a Pulumi-created migration Job) has the series with
+            # those labels ABSENT -- so the `unless` arm below is what keeps
+            # non-CronJob Jobs covered, still keyed on their own name. Both arms
+            # verified against operations-production 2026-09-04: three failed
+            # witan-ci-indexer Jobs collapse to one `workload="witan-ci-indexer"`
+            # series, and witan-migrations-production-34bf072f keeps its own.
+            #
+            # The exclusion regex stays on `job_name` deliberately: it filters
+            # the raw kube_job_failed series before the join, so it matches the
+            # ordinal-suffixed Job names as it always did.
             alerting.RuleGroupRuleArgs(
                 name="WorkloadJobFailedWarning",
                 condition="C",
@@ -443,10 +468,22 @@ def create(
                 exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
-                    "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
+                    "description": "Job {{ $labels.workload }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_failed{cluster=~".*-(ci|qa)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)'
+                    "sum by (cluster, namespace, workload) (\n"
+                    "  label_replace(\n"
+                    '    (kube_job_failed{cluster=~".*-(ci|qa)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)\n'
+                    "      * on (cluster, namespace, job_name) group_left(owner_name)\n"
+                    '      kube_job_owner{owner_kind="CronJob"},\n'
+                    '    "workload", "$1", "owner_name", "(.*)")\n'
+                    "  or\n"
+                    "  label_replace(\n"
+                    '    (kube_job_failed{cluster=~".*-(ci|qa)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)\n'
+                    "      unless on (cluster, namespace, job_name)\n"
+                    '      kube_job_owner{owner_kind="CronJob"},\n'
+                    '    "workload", "$1", "job_name", "(.*)")\n'
+                    ")"
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -457,10 +494,22 @@ def create(
                 exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
-                    "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
+                    "description": "Job {{ $labels.workload }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_failed{cluster=~".*-(production)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)'
+                    "sum by (cluster, namespace, workload) (\n"
+                    "  label_replace(\n"
+                    '    (kube_job_failed{cluster=~".*-(production)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)\n'
+                    "      * on (cluster, namespace, job_name) group_left(owner_name)\n"
+                    '      kube_job_owner{owner_kind="CronJob"},\n'
+                    '    "workload", "$1", "owner_name", "(.*)")\n'
+                    "  or\n"
+                    "  label_replace(\n"
+                    '    (kube_job_failed{cluster=~".*-(production)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)\n'
+                    "      unless on (cluster, namespace, job_name)\n"
+                    '      kube_job_owner{owner_kind="CronJob"},\n'
+                    '    "workload", "$1", "job_name", "(.*)")\n'
+                    ")"
                 ),
             ),
             # --- HPA at max replicas ---


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

`WorkloadJobFailed{Warning,Critical}` grouped on `job_name`, and a CronJob's `job_name` carries the schedule ordinal (`witan-council-probe-29808780`). Every tick was therefore a new series, a new alert instance, and a new Rootly alert that `deduplication_key_kind="payload"` could not collapse.

- Group on the owning CronJob instead, via a `kube_job_owner` join, so a failing schedule is one alert that persists for the outage rather than one per tick.
- Keep standalone Jobs covered under their own name — they have no owner labels at all, so an `unless` arm picks them up.
- Add `workload` to the Alertmanager `group_bies`, for the same reason `cronjob`, `matched_host` and `service_name` are already there: the aggregation drops `job_name`, so without it two unrelated failing CronJobs in one namespace would arrive as a single grouped notification.

No change to what is alerted on, only to how firings are keyed. Coverage is unchanged in both directions.

<details>
<summary><b>Implementation details</b></summary>
<br>

Both rules now evaluate:

```promql
sum by (cluster, namespace, workload) (
  label_replace(
    (kube_job_failed{...} == 1)
      * on (cluster, namespace, job_name) group_left(owner_name)
      kube_job_owner{owner_kind="CronJob"},
    "workload", "$1", "owner_name", "(.*)")
  or
  label_replace(
    (kube_job_failed{...} == 1)
      unless on (cluster, namespace, job_name)
      kube_job_owner{owner_kind="CronJob"},
    "workload", "$1", "job_name", "(.*)")
)
```

`kube_job_owner` is what separates the two arms. A CronJob-owned Job carries `owner_kind="CronJob"` and `owner_name=<cronjob>`; a standalone Job (a Pulumi-created migration Job, say) has the series present but those labels *absent*, not empty — which is why the complement is `unless` rather than a negative matcher.

The `job_name!~"witan-ci-indexer.*"` exclusion deliberately stays keyed on `job_name`: it filters the raw `kube_job_failed` series before the join, so it still matches the ordinal-suffixed names as it always did.

</details>

### How can this be tested?

Both arms were run against live Prometheus before and after, since the expression cannot be unit-tested here (there are no tests under `tests/` for `grafana_alerting`).

**Production** (`grafanacloud-mitolproduction-prom`), using the exact rendered `.*-(production)` expression with the `witan-ci-indexer` exclusion lifted so there was data to match:

- three failed `witan-ci-indexer-*` Jobs collapse to one series, `workload="witan-ci-indexer"`, value `3`
- `witan-migrations-production-34bf072f`, a standalone Job, keeps its own name

**QA** (`grafanacloud-mitolqa-prom`), same shape via `kube_job_complete` so both arms had data: 14 CronJobs each collapsed to a single series — including `witan-council-probe`, the one that prompted this — while `witan-migrations-qa-e2a9eff9`, `omnigraph-cluster-apply-qa-174e1a6f`, `witan-token-sync-bootstrap-qa-c2c1bac7` and `om-server-config-577586cc` stayed individually named.

The production Grafana Cloud stack holds only `*-production` clusters, so the `.*-(ci|qa)` arm returns empty there no matter how correct it is — it has to be checked against the QA stack.

Also run: `pre-commit` (ruff format, ruff check, mypy, detect-secrets) clean, and `pulumi preview --stack QA` at `2 to update, 36 unchanged` — the eks-general RuleGroup and the NotificationPolicy, which is the intended blast radius.

To validate after merge: wait for a CronJob to fail repeatedly and confirm Rootly shows one alert that persists rather than one per tick.

### Additional Context

The volume this fixes, from the Rootly API for alerts created since 2026-09-03T18:00Z: `total_count` 106, of which page 1 of 20 alone holds 16 `witan-council-probe` job-failure alerts, each a distinct alert with its own `short_id` and its own ordinal (`…-29808780`, `…-29808765`, `…-29808750`, …). The `DagsterRunFailureRateCritical` in the same window is one row buried among them.

Nobody was paged 106 times — `saas/rootly/__main__.py` deliberately demotes `WorkloadJobFailedCritical` to the non-paging urgency. The cost is that one condition buries everything else in the list, and the volume is unbounded in the duration of the outage.

This is not specific to the witan probe; it is how any frequently-scheduled CronJob behaves under these rules. That probe is simply the first one that both runs every 15 minutes and stayed broken for hours.

Two alternatives considered and not taken: excluding CronJob-owned Jobs from `WorkloadJobFailed*` entirely in favour of the existing `ScheduledJobStaleFast*` rules (cleaner separation, but needs a check that no non-CronJob coverage is lost), and leaving the rules alone and adding a Rootly grouping rule on alertname+namespace (moves the problem downstream of the alert store).

Both existing `WorkloadJobFailed*` rules and the Rootly routing carry comments recording previous mistakes in this area — the `Kube.*` silence, and `kube_job_status_failed` vs `kube_job_failed`. Neither is disturbed here.
