### PR TITLE
fix(dagster): grant read on the Tika access token to unbreak course_document_text

### DIFF
--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -134,6 +134,18 @@ path "secret-xpro/mongodb-forum" {
 path "secret-operations/data/institutional-research-bigquery-service-account" {
   capabilities = ["read"]
 }
+# X-Access-Token for the Tika service, needed by the openedx code location's
+# course_document_text asset. This flat path is the canonical one: the tika
+# stack writes it from the same `x_access_token` SOPS value it inlines as
+# `expected` in the APISIX serverless-pre-function guarding
+# tika-production.ol.mit.edu, so a token read here always matches the gateway.
+# Do not point a consumer at secret-operations/{production,rc}-apps/tika/
+# access-token -- tika_server_policy.hcl still grants those legacy env-scoped
+# paths, but applications/tika/__main__.py stopped writing them, so a reader
+# there gets a stale token and a 401 from APISIX.
+path "secret-operations/tika/access-token" {
+  capabilities = ["read"]
+}
 path "sys/leases/renew" {
   capabilities = ["update"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while investigating a `DagsterRunFailureRateCritical` page against `data-production` on 2026-09-04.

### Description (What does it do?)

- Grants the Dagster Vault role `read` on `secret-operations/tika/access-token`.
- Unblocks the `openedx` code location's `course_document_text` asset, which has **never materialized** on any of the mitxonline, mitx, or xpro deployments. It cannot read the Tika `X-Access-Token`, so every extraction call is rejected with a 401.
- **This is half the fix.** The asset currently reads the env-scoped `secret-operations/production-apps/tika/access-token`, which the tika stack no longer writes. A companion change in `ol-data-platform` has to repoint it at the flat path granted here before production recovers. See the checklist.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Failure chain**

1. `openedx/definitions.py` in `ol-data-platform` reads the Tika token from Vault **at definition load time**, from `secret-operations/{production-apps,rc-apps}/tika/access-token`.
2. That read returns `403 permission denied` — before this PR, [`dagster_server_policy.hcl`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl) granted only `secret-operations/sso/dagster` and one BigQuery path.
3. The read is wrapped in `except Exception: tika_access_token = ""`, which swallows the 403 **without logging**. The code location then loads healthy carrying an empty token.
4. [`tika-apisix-route-production`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/tika/__main__.py#L209-L240) guards `tika-production.ol.mit.edu` with a `serverless-pre-function` that string-compares `X-Access-Token` to a literal, so an empty token gets a 401.
5. The asset raises `TikaUnavailableError`; the level-triggered automation condition re-requests it every sensor tick and `run_retries.max_retries: 3` multiplies each attempt ×4.

Confirmed from inside the running code location pod:

```
loaded-at-startup: vault_authenticated=True vault_path='production-apps' token_len=0 sha8=e3b0c442
live vault read FAILED: Forbidden 1 error occurred:
	* permission denied
, on get https://vault-production.odl.mit.edu/v1/secret-operations/production-apps/tika/access-token
```

`sha8=e3b0c442` is the SHA-256 prefix of the empty string — Vault auth itself succeeds, only the token is missing.

**Why the flat path and not the env-scoped one**

`applications/tika/__main__.py` reads `x_access_token` from `tika/tika.{env}.yaml` once and uses that single value in two places: the Vault write at `secret-operations/tika/access-token`, and the `expected` literal inlined into the APISIX Lua. A token read from the flat path therefore always matches the gateway by construction.

`tika_server_policy.hcl:1-5` still grants `secret-operations/{production-apps,rc-apps}/tika/access-token`, but nothing writes those paths any more — that stale grant is the likely origin of the wrong path in the consumer. `mit_learn` is the one working consumer and already reads the flat path, granted at `mitlearn_policy.hcl:42`.

**Blast radius of the incident**

- 6h window at time of investigation: 398 failures / 555 terminal runs = **71.7%** (alert threshold 40%, normal 7.5%). 99 root runs became 396 attempts via retries.
- All failures were `openedx / __ASSET_JOB`, tagged `dagster/auto_materialize=true`.
- Sibling assets are unaffected — `course_structure` materialized normally throughout.
- The first burst (2026-09-03 16:40–19:10 EDT) drove the run queue to 5,133 QUEUED with a 24-minute oldest-queued wait, delaying unrelated work. The queue had fully drained by the time of investigation.

</details>

### How can this be tested?

Not end-to-end verifiable from this PR alone — the asset stays broken until the `ol-data-platform` path change lands too. What can be checked:

- After this stack applies, confirm the grant resolves from the code location pod. It should return a token whose SHA-256 prefix is *not* `e3b0c442`:
  ```
  kubectl exec -n dagster deploy/dagster-user-code-dagster-user-deployments-openedx \
    -c dagster-user-deployments -- python3 -c \
    'import hashlib; from openedx.definitions import vault; \
     v=vault.client.secrets.kv.v1.read_secret(mount_point="secret-operations", \
       path="tika/access-token")["data"]["value"]; \
     print(len(v), hashlib.sha256(v.encode()).hexdigest()[:8])'
  ```
- Once both halves are deployed and the code location restarted, `mitxonline/openedx/processed_data/course_document_text` should record its first-ever materialization, and `DagsterRunFailureRateCritical` on `data-production` should clear.

### Additional Context

- The token is read at **import time**, so a policy change alone changes nothing for a running pod — the code location has to be restarted after both changes deploy.
- Worth a separate fix: the `except Exception: tika_access_token = ""` in `definitions.py` is why a never-working integration reached production silently for a day. It should log an error or fail the location load rather than substituting an empty credential.
- `tika_server_policy.hcl:1-5` grants two Vault paths that nothing writes any more; cleaning those up would remove the trap that produced this bug.

### Checklist:
- [ ] Land the companion `ol-data-platform` change repointing `openedx/definitions.py` at `secret-operations/tika/access-token` (drop the `TIKA_VAULT_APP_PATH` env-scoping)
- [ ] Apply this Vault policy to `data-production`
- [ ] Restart the `openedx` code location so it re-reads the token at import
- [ ] Confirm `DagsterRunFailureRateCritical` clears on `data-production`
