### PR TITLE
fix(otel): give the tail-sampling counters their _total suffix so they scrape

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -496,6 +496,30 @@ def setup_grafana(
                     # surfaced the tail-sampler sizing bug (traces evicted
                     # before a decision was made, buffer occupancy far past
                     # the old 100-trace cap) instead of it going unnoticed.
+                    #
+                    # The _total suffixes are load-bearing. includeMetrics
+                    # lands in prometheus.relabel's keep_metrics, which Alloy
+                    # anchors as ^(?:...)$, and the collector's internal
+                    # Prometheus rendering appends _total to every monotonic
+                    # counter. Written without the suffix, four of the five
+                    # entries below matched nothing: between 2026-08-10 and
+                    # 2026-09-04 the only tail-sampling series that ever
+                    # reached Grafana Cloud was sampling_traces_on_memory,
+                    # which is the one Gauge in the set. The same mismatch
+                    # cannot bite the chart's own defaults because they spell
+                    # counters out (otelcol_receiver_accepted_spans_total,
+                    # otelcol_processor_batch_timeout_trigger_send_total) --
+                    # and those do arrive, from these same collectors, which
+                    # is what pins the cause on the suffix rather than on the
+                    # scrape. Instrument types per the tailsamplingprocessor
+                    # documentation.md.
+                    #
+                    # count_traces_sampled is the one carrying `policy` and
+                    # `sampled`, so until it lands there is no direct view of
+                    # which policy is deciding what; retention can only be
+                    # inferred from receiver-vs-exporter span ratios.
+                    # count_spans_sampled is its span-weighted counterpart,
+                    # which is the unit Grafana Cloud bills on.
                     "alloy": {
                         "instances": [
                             {
@@ -513,11 +537,14 @@ def setup_grafana(
                                 "metrics": {
                                     "tuning": {
                                         "includeMetrics": [
-                                            "otelcol_processor_tail_sampling_count_traces_sampled",
-                                            "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
-                                            "otelcol_processor_tail_sampling_new_trace_id_received",
+                                            # Counters -- _total suffix required.
+                                            "otelcol_processor_tail_sampling_count_traces_sampled_total",
+                                            "otelcol_processor_tail_sampling_count_spans_sampled_total",
+                                            "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early_total",
+                                            "otelcol_processor_tail_sampling_new_trace_id_received_total",
+                                            "otelcol_processor_tail_sampling_sampling_policy_evaluation_error_total",
+                                            # Gauge -- no suffix. Already arriving.
                                             "otelcol_processor_tail_sampling_sampling_traces_on_memory",
-                                            "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
                                         ],
                                     },
                                 },

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -502,8 +502,8 @@ def setup_grafana(
                     # anchors as ^(?:...)$, and the collector's internal
                     # Prometheus rendering appends _total to every monotonic
                     # counter. Written without the suffix, four of the five
-                    # entries below matched nothing: between 2026-08-10 and
-                    # 2026-09-04 the only tail-sampling series that ever
+                    # entries below matched nothing: from #5381 on 2026-08-12
+                    # to 2026-09-04 the only tail-sampling series that ever
                     # reached Grafana Cloud was sampling_traces_on_memory,
                     # which is the one Gauge in the set. The same mismatch
                     # cannot bite the chart's own defaults because they spell

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -518,8 +518,22 @@ def setup_grafana(
                     # `sampled`, so until it lands there is no direct view of
                     # which policy is deciding what; retention can only be
                     # inferred from receiver-vs-exporter span ratios.
-                    # count_spans_sampled is its span-weighted counterpart,
-                    # which is the unit Grafana Cloud bills on.
+                    #
+                    # Its span-weighted counterpart count_spans_sampled is
+                    # deliberately NOT listed, and listing it would do
+                    # nothing. Alloy v1.18.1 vendors tailsamplingprocessor
+                    # v0.153.0, where the only site that records it
+                    # (processor.go:519) sits behind the alpha, off-by-default
+                    # gate processor.tailsamplingprocessor.metricstatcount
+                    # spanssampled -- and Alloy's SetupOtelFeatureGates
+                    # (internal/util/otel_feature_gate.go) enables a hardcoded
+                    # list of exactly one gate, filelog.allowFileDeletion,
+                    # with no config or flag to add another. So the series is
+                    # not emitted and includeMetrics can only retain what is
+                    # already emitted. The line above it, count_traces_sampled
+                    # (processor.go:518), is ungated, as are
+                    # new_trace_id_received, sampling_trace_dropped_too_early
+                    # and sampling_policy_evaluation_error.
                     "alloy": {
                         "instances": [
                             {
@@ -539,7 +553,6 @@ def setup_grafana(
                                         "includeMetrics": [
                                             # Counters -- _total suffix required.
                                             "otelcol_processor_tail_sampling_count_traces_sampled_total",
-                                            "otelcol_processor_tail_sampling_count_spans_sampled_total",
                                             "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early_total",
                                             "otelcol_processor_tail_sampling_new_trace_id_received_total",
                                             "otelcol_processor_tail_sampling_sampling_policy_evaluation_error_total",


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Follow-on to #5381, which added these allowlist entries. Gates the tail-sampler sizing follow-up to #5741, which needs per-policy decisions and the input trace rate to size `numTraces` / `expectedNewTracesPerSec` against.

### Description (What does it do?)

Four tail-sampling metrics have been silently absent from Grafana Cloud since #5381 merged on 2026-08-12. Their allowlist entries were written without the `_total` suffix that the collector appends to counters, so the anchored keep rule matched nothing.

- Adds `_total` to the four counter names in `integrations.alloy.instances[].metrics.tuning.includeMetrics`.
- Leaves `sampling_traces_on_memory` alone. It is the one Gauge in the set, and the only one that was ever arriving.
- Does not change what is sampled or what is sent to Grafana Cloud.

`count_traces_sampled` is the only series carrying the `policy` and `sampled` labels, so until it lands there is no direct view of which tail-sampling policy is deciding what — retention can only be inferred from receiver-vs-exporter span ratios. `sampling_trace_dropped_too_early` is the direct signal for the eviction failure mode #5364 documents: traces evicted before their decision is made, silently, with nothing erroring.

<details>
<summary><b>Implementation details</b></summary>
<br>

`includeMetrics` is concatenated into `keep_metrics` on the chart's `alloy_integration_scrape` block, which the module consumes as:

```
rule {
  source_labels = ["__name__"]
  regex = coalesce(argument.keep_metrics.value, ".*")
  action = "keep"
}
```

Prometheus relabel regexes are fully anchored, and the collector's internal Prometheus rendering appends `_total` to every monotonic counter, so a name off by a suffix matches nothing. It fails silently: the Helm values look correct because they *are* passed through verbatim.

| Metric | Instrument | Before | After |
|---|---|---|---|
| `..._count_traces_sampled` | Counter | no match | `_total` |
| `..._sampling_trace_dropped_too_early` | Counter | no match | `_total` |
| `..._new_trace_id_received` | Counter | no match | `_total` |
| `..._sampling_policy_evaluation_error` | Counter | no match | `_total` |
| `..._sampling_traces_on_memory` | Gauge | arriving | unchanged |

`count_spans_sampled` was in the first revision of this PR and has been removed (c5c4ecdd8) after Copilot flagged it. In [tailsamplingprocessor v0.153.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.153.0/processor/tailsamplingprocessor/processor.go#L515-L522), which Alloy v1.18.1 vendors, the only site recording it is behind the alpha, off-by-default gate `processor.tailsamplingprocessor.metricstatcountspanssampled`. `count_traces_sampled` on the line directly above is unguarded. Alloy offers no way to turn the gate on: [`SetupOtelFeatureGates`](https://github.com/grafana/alloy/blob/v1.18.1/internal/util/otel_feature_gate.go) enables a hardcoded list of exactly one gate, `filelog.allowFileDeletion`. `includeMetrics` only retains an already-emitted series, so the entry was inert. The reasoning is now a comment above the list so it does not get re-added.

Cardinality is small and bounded. The config has 3 policies (`keep-errors`, `sample-slow-traces`, `sample-15pct-traces`), so `count_traces_sampled_total` contributes 3 × {`sampled=true`, `sampled=false`} = 6 series, plus 3 unlabeled counters: about 9 series per sampler pod.

</details>

### How can this be tested?

Evidence for the diagnosis:

- `list_prometheus_metric_names` against `grafanacloud-mitolproduction-prom`, regex `.*tail_sampling.*`, window `now-3h` (2026-09-04): returns exactly `otelcol_processor_tail_sampling_sampling_traces_on_memory` and nothing else. Same result as the 2026-09-03 check.
- The live `grafana-k8s-monitoring-alloy-metrics` ConfigMap in `applications-production` shows all five names passed through verbatim into `keep_metrics`, and the keep rule quoted above at lines 901-906. So the values reach the collector unmodified and the mismatch is in the strings themselves.
- The chart's own default entries in that same `keep_metrics` spell their counters out (`otelcol_receiver_accepted_spans_total`, `otelcol_processor_batch_timeout_trigger_send_total`) and both arrive from these same collectors. That is what pins the cause on the suffix rather than on the scrape or the telemetry level.
- Instrument types from the tailsamplingprocessor's `documentation.md`; gating confirmed by reading the v0.153.0 processor source, not the docs.

`pulumi preview --stack applications.QA` on `ol-substructure-eks`: 1 update, 48 unchanged, diff confined to the `includeMetrics` list.

Not yet verified, and not verifiable until this rolls out — the series cannot exist before then. Post-deploy check:

1. Re-run the `.*tail_sampling.*` metric-name query; the four `_total` series should appear.
2. `sum by (policy, sampled) (rate(otelcol_processor_tail_sampling_count_traces_sampled_total[5m]))` should return a row for each of the 3 configured policies.

### Additional Context

QA clusters report to `grafanacloud-mitolqa-prom` and production to `grafanacloud-mitolproduction-prom` — querying the wrong stack makes every cluster on the other one look like it is emitting nothing.

This is the third silent-failure trap documented in this block of `grafana.py`, after `numTraces >= 1_000_000` rendering as `1e+06` through Go's `%v` and an ambiguous `collector` key dropping the whole integrations feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVHThvSdibCwhQb7NZjZTG
