### PR TITLE
fix(apisix): replace the wildcard CORS default with per-app origin lists

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -22,6 +22,43 @@ from ol_infrastructure.components.aws.cache import OLAmazonCache
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
+def browser_origins(stack_info: StackInfo, edxapp_config: Config) -> list[str]:
+    """Return the page origins that call edxapp cross-origin from a browser.
+
+    Shared by two consumers that have to agree: Django's CORS_ORIGIN_WHITELIST
+    below, and the APISIX cors plugin in k8s_resources.py.  The gateway is what
+    actually emits the Access-Control-* headers the browser enforces, so if it
+    allows less than Django does the browser blocks the request before Django
+    ever sees it.
+
+    Deliberately excludes two entries the Django whitelist also carries: the
+    edxnotes domain (an API the LMS calls, never a page origin, and only
+    available as a Pulumi Output here) and the storage bucket's S3 origin.
+    Neither is a document origin, so neither can be the Origin on a request to
+    edxapp.
+    """
+    domains = edxapp_config.require_object("domains")
+    marketing_domain = (
+        edxapp_config.get("mitxonline_domain")
+        if stack_info.env_prefix == "mitxonline"
+        else edxapp_config.get("marketing_domain")
+    )
+    origins = [
+        f"https://{domains['lms']}",
+        f"https://{domains['studio']}",
+        f"https://{domains['preview']}",
+        f"https://{marketing_domain}",
+        f"https://{edxapp_config.require('learn_ai_frontend_domain')}",
+        f"https://{edxapp_config.require('mit_learn_domain')}",
+        "https://canvas.mit.edu",
+    ]
+    # Canvas LTI and MIT's Shibboleth IdP post back to the LMS on the
+    # deployments that integrate with them.
+    if stack_info.env_prefix in ["mitx", "mitx-staging", "mitxonline"]:
+        origins.append("https://idp.mit.edu")
+    return origins
+
+
 def _build_interpolated_config_dict(
     stack_info: StackInfo,
     edxapp_config: Config,
@@ -101,17 +138,14 @@ def _build_interpolated_config_dict(
         "CELERY_BROKER_HOSTNAME": runtime_config["redis_hostname"],
         "CMS_BASE": domains["studio"],
         "CONTACT_EMAIL": edxapp_config.require("sender_email_address"),
-        # Base CORS origins - canvas.mit.edu and idp.mit.edu added conditionally below
+        # Page origins come from browser_origins(), which the APISIX cors
+        # plugin in k8s_resources.py reads too so the two stay in step.  The two
+        # extra entries here are not document origins (see that function).
+        # meilisearch is appended conditionally below.
         "CORS_ORIGIN_WHITELIST": [
-            f"https://{domains['lms']}",
-            f"https://{domains['studio']}",
-            f"https://{domains['preview']}",
-            f"https://{marketing_domain}",
+            *browser_origins(stack_info, edxapp_config),
             f"https://{runtime_config['notes_domain']}",
-            f"https://{edxapp_config.require('learn_ai_frontend_domain')}",
-            f"https://{edxapp_config.require('mit_learn_domain')}",
             f"https://{env_name}-edxapp-storage.s3.amazonaws.com",
-            "https://canvas.mit.edu",
         ],
         "COURSE_IMPORT_EXPORT_BUCKET": course_bucket_name,
         "CROSS_DOMAIN_CSRF_COOKIE_DOMAIN": domains["lms"],
@@ -296,10 +330,6 @@ def _build_interpolated_config_dict(
 
     # Residential-specific configuration (mitx, mitx-staging)
     if stack_info.env_prefix in ["mitx", "mitx-staging"]:
-        # Add Canvas and MIT IDP to CORS whitelist for residential deployments
-        config["CORS_ORIGIN_WHITELIST"].append(
-            "https://idp.mit.edu",
-        )
         config["CSRF_TRUSTED_ORIGINS"] = [
             "https://canvas.mit.edu",
             f"https://{domains['lms']}",
@@ -381,7 +411,6 @@ def _build_interpolated_config_dict(
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":
-        config["CORS_ORIGIN_WHITELIST"].append("https://idp.mit.edu")
         config["CSRF_TRUSTED_ORIGINS"] = [
             "https://canvas.mit.edu",
             f"https://{domains['lms']}",

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -21,6 +21,7 @@ from ol_infrastructure.applications.edxapp.k8s_autoscaling import (
     create_webapp_trigger_auth,
 )
 from ol_infrastructure.applications.edxapp.k8s_configmaps import (
+    browser_origins,
     create_k8s_configmaps,
 )
 from ol_infrastructure.applications.edxapp.k8s_secrets import create_k8s_secrets
@@ -2077,6 +2078,11 @@ def create_k8s_resources(  # noqa: C901
             k8s_namespace=namespace,
             k8s_labels=k8s_global_labels,
             enable_defaults=True,
+            # Same source as Django's CORS_ORIGIN_WHITELIST in
+            # k8s_configmaps.py.  The gateway emits the Access-Control-* headers
+            # the browser enforces, so Django's own list only takes effect if
+            # this one allows the origin first.
+            cors_allow_origins=browser_origins(stack_info, edxapp_config),
         ),
     )
 

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -8,6 +8,7 @@ from pulumi import Config, ResourceOptions
 
 from bridge.lib.versions import MEILISEARCH_CHART_VERSION, MEILISEARCH_VERSION
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.applications.edxapp.k8s_configmaps import browser_origins
 from ol_infrastructure.components.services.apisix import (
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
@@ -61,6 +62,10 @@ def create_meilisearch_resources(
             resource_suffix="ol-shared-plugins",
             k8s_namespace=namespace,
             k8s_labels=k8s_global_labels,
+            # Meilisearch is queried straight from the browser by Open edX's
+            # course-search MFE, which runs on the LMS and Studio origins, so it
+            # needs the same page-origin list edxapp itself allows.
+            cors_allow_origins=browser_origins(stack_info, Config("edxapp")),
             # OLApisixHTTPRoute attaches only the shared PluginConfig via
             # ExtensionRef when shared_plugin_config_name is set, ignoring the
             # route's own `plugins` list entirely -- including the request-id

--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -177,6 +177,10 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
             resource_suffix="ol-shared-plugins",
             k8s_namespace=namespace,
             k8s_labels=application_labels,
+            # JupyterHub serves its own UI, its API and every single-user server
+            # from this one host, so all of its browser traffic is same-origin.
+            # An empty list attaches no cors plugin at all.
+            cors_allow_origins=[],
             enable_defaults=True,
             plugins=[
                 # Evict the host-only cookie the OIDC resource below used to

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -301,6 +301,10 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
             resource_suffix="ol-shared-plugins",
             k8s_namespace=namespace,
             k8s_labels=application_labels,
+            # JupyterHub serves its own UI, its API and every single-user server
+            # from this one host, so all of its browser traffic is same-origin.
+            # An empty list attaches no cors plugin at all.
+            cors_allow_origins=[],
             enable_defaults=True,
             plugins=[
                 {

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -920,6 +920,25 @@ learn_ai_deployment_envfrom = [
 # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_plugin_config/
 # Ref: https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2/
 
+# Origins allowed to read learn-ai responses cross-origin, with credentials.
+# This shared config is attached to routes on both of learn-ai's hosts (the
+# legacy api-learn-ai.ol.mit.edu and the /ai/* paths on
+# api.<env>.learn.mit.edu), so it has to cover every frontend that calls either
+# one: learn-ai's own UI, and mit-learn, which embeds the chat widget.
+#
+# Derived from the domains rather than read out of the stack's
+# CSRF_ALLOWED_ORIGINS -- that list names the same four origins on QA and
+# Production but omits the learn.mit.edu pair on CI, even though learn-ai serves
+# api.ci.learn.mit.edu there. The gateway's headers are what the browser
+# enforces, so a gap here silently breaks the widget rather than Django's CSRF
+# check.
+learn_ai_cors_allow_origins = [
+    f"https://{learn_ai_frontend_domain}",
+    f"https://{learn_ai_config.require('backend_domain')}",
+    f"https://{learn_ai_config.require('learn_backend_domain')}",
+    f"https://{learn_ai_config.require('learn_backend_domain').removeprefix('api.')}",
+]
+
 # Instantiate shared plugins component
 learn_ai_shared_plugins = OLApisixSharedPlugins(
     f"learn-ai-{stack_info.env_suffix}-ol-shared-plugins",
@@ -929,6 +948,7 @@ learn_ai_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=learn_ai_namespace,
         k8s_labels=k8s_global_labels,
         enable_defaults=True,
+        cors_allow_origins=learn_ai_cors_allow_origins,
         plugins=[
             # Both of learn-ai's OIDC resources have now moved off
             # lua-resty-session's default "session" name, so every current user

--- a/src/ol_infrastructure/applications/marimo_data/__main__.py
+++ b/src/ol_infrastructure/applications/marimo_data/__main__.py
@@ -193,6 +193,10 @@ marimo_shared_plugins = OLApisixSharedPlugins(
         resource_suffix="ol-shared-plugins",
         k8s_namespace=marimo_namespace,
         k8s_labels=application_labels,
+        # Each published notebook is served to the browser from its own route on
+        # this same host, so every request its page makes is same-origin.
+        # An empty list attaches no cors plugin at all.
+        cors_allow_origins=[],
         enable_defaults=True,
     ),
 )

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
@@ -23,6 +23,7 @@ config:
     - "ci.learn.mit.edu"
     cors_urls:
     - "https://ci.learn.mit.edu"
+    - "https://courses.ci.learn.mit.edu"   # MITxOnline courseware MFE, same as csrf_domains below
     - "https://ocw-next.netlify.app"
     - "https://draft-ci.ocw.mit.edu"
     - "https://live-ci.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -20,6 +20,7 @@ config:
     cors_urls:
     - "https://api.learn.mit.edu"
     - "https://learn.mit.edu"
+    - "https://courses.learn.mit.edu"   # MITxOnline courseware MFE, same as csrf_domains below
     - "https://api.mitopen.odl.mit.edu"   # legacy
     - "https://mitopen.odl.mit.edu"   # legacy
     - "https://draft.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -23,6 +23,7 @@ config:
     cors_urls:
     - "https://mitopen-rc.odl.mit.edu"   # legacy
     - "https://rc.learn.mit.edu"
+    - "https://courses.rc.learn.mit.edu"   # MITxOnline courseware MFE, same as csrf_domains below
     - "https://ocw-next.netlify.app"
     - "https://draft-qa.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1428,6 +1428,10 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=learn_namespace,
         k8s_labels=application_labels,
         enable_defaults=True,
+        # The same list Django gets as CORS_ALLOWED_ORIGINS above.  The gateway
+        # sets the Access-Control-* headers the browser actually enforces, so
+        # the two have to agree or django-cors-headers' answer is irrelevant.
+        cors_allow_origins=cors_urls_list,
         # Explicit override, not the component's per-stack default (on
         # everywhere except Production pending a separate soak test): the
         # nginx sidecar this stage removes gzipped JSON responses

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -811,6 +811,17 @@ mitxonline_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=mitxonline_namespace,
         k8s_labels=k8s_app_labels,
         enable_defaults=True,
+        # The same origins Django is given as CORS_ALLOWED_ORIGINS: the gateway
+        # sets the Access-Control-* headers the browser enforces, so
+        # django-cors-headers' answer never reaches it.  This config is attached
+        # to routes on api.mitxonline.mit.edu, mitxonline.mit.edu *and* the
+        # /mitxonline/* paths on api.<env>.learn.mit.edu, so the list has to
+        # cover every frontend that calls any of them.
+        cors_allow_origins=[
+            origin.strip()
+            for origin in env_vars["CORS_ALLOWED_ORIGINS"].split(",")
+            if origin.strip()
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -582,6 +582,18 @@ ol_analytics_api_hosts = [ol_analytics_api_domain]
 if ol_analytics_api_learn_domain:
     ol_analytics_api_hosts.append(ol_analytics_api_learn_domain)
 
+# Origins allowed to read this API cross-origin, with credentials.  The
+# canonical host serves its own UI, so it needs nothing here for itself; the
+# Learn-scoped host exists precisely because the MIT Learn frontend calls it
+# with `fetch` from a different origin (see the second OIDC resource below), and
+# that call carries the shared session cookie, so it is a credentialed
+# cross-origin read and has to be named explicitly.
+ol_analytics_api_cors_allow_origins = [f"https://{ol_analytics_api_domain}"]
+if ol_analytics_api_learn_domain:
+    ol_analytics_api_cors_allow_origins.append(
+        f"https://{ol_analytics_api_learn_domain.removeprefix('analytics.')}"
+    )
+
 # Shared plugins (redirect http->https, cors, prometheus, opentelemetry, ...).
 ol_analytics_api_shared_plugins = OLApisixSharedPlugins(
     f"ol-analytics-api-{stack_info.env_suffix}-ol-shared-plugins",
@@ -591,6 +603,7 @@ ol_analytics_api_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=APPLICATION_NAMESPACE,
         k8s_labels=k8s_global_labels,
         enable_defaults=True,
+        cors_allow_origins=ol_analytics_api_cors_allow_origins,
     ),
     opts=ResourceOptions(delete_before_replace=True),
 )

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -343,6 +343,11 @@ opik_shared_plugins = OLApisixSharedPlugins(
         resource_suffix="ol-shared-plugins",
         k8s_namespace=OPIK_NAMESPACE,
         k8s_labels=k8s_global_labels,
+        # Opik's UI and API are served from the one host behind OIDC, and the
+        # SDK posts traces server-side where CORS never applies, so no origin
+        # other than Opik's own is meant to read these responses.  An empty list
+        # attaches no cors plugin at all.
+        cors_allow_origins=[],
         enable_defaults=True,
     ),
 )

--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -201,6 +201,10 @@ tika_shared_plugins = OLApisixSharedPlugins(
         resource_suffix="shared-plugins",
         k8s_namespace=tika_namespace,
         k8s_labels=application_labels,
+        # Tika is called server-to-server with an X-Access-Token header (see the
+        # route below); no browser page ever fetches it, so it needs no
+        # Access-Control-* headers.  An empty list attaches no cors plugin.
+        cors_allow_origins=[],
         enable_defaults=True,
     ),
 )

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -434,6 +434,22 @@ class OLApisixSharedPluginsConfig(BaseModel):
     application_name: str
     resource_suffix: str = "shared-plugins"
     enable_defaults: bool = True
+    # Origins the cors default plugin will echo back with
+    # Access-Control-Allow-Credentials: true.  Required whenever
+    # ``enable_defaults`` is set -- there is deliberately no default.  This used
+    # to be the APISIX wildcard "**", which reflects whatever Origin the browser
+    # sent *and* allows credentials, so any origin a user's cookies were sent to
+    # could read authenticated JSON off every OIDC host.  Pass the same list the
+    # application declares to its own framework (Django's
+    # CORS_ALLOWED_ORIGINS / CSRF_ALLOWED_ORIGINS, Open edX's
+    # CORS_ORIGIN_WHITELIST) so the gateway and the app agree; the gateway's
+    # headers are what the browser actually enforces.
+    #
+    # An empty list omits the cors plugin entirely, which is the right answer
+    # for a service whose only callers are same-origin browsers or
+    # server-to-server clients: no Access-Control-Allow-Origin header at all
+    # means no cross-origin read is possible.
+    cors_allow_origins: list[str] | None = None
     # Attach the opentelemetry plugin (OTLP trace export) to every route that
     # references this shared plugin config.  Automatically disabled on CI, where
     # the plugin is not loaded into APISIX and the Grafana Alloy collector does
@@ -455,6 +471,20 @@ class OLApisixSharedPluginsConfig(BaseModel):
     # Either raw CRD dicts or OLApisixPluginConfig objects; the component
     # normalises the latter to dicts before rendering.
     plugins: list[dict[str, Any] | OLApisixPluginConfig] = []
+
+    @model_validator(mode="after")
+    def require_explicit_cors_origins(self):
+        """Refuse to render the cors default plugin without an origin list."""
+        if self.enable_defaults and self.cors_allow_origins is None:
+            msg = (
+                f"{self.application_name}: cors_allow_origins is required when "
+                "enable_defaults is set. Pass the application's own allowed "
+                "origins (the list it gives Django's CORS_ALLOWED_ORIGINS or "
+                "equivalent), or [] to attach no cors plugin at all for a "
+                "service with no cross-origin browser callers."
+            )
+            raise ValueError(msg)
+        return self
 
 
 class OLApisixSharedPlugins(ComponentResource):
@@ -486,6 +516,29 @@ class OLApisixSharedPlugins(ComponentResource):
             "ol:infrastructure:services:k8s:OLApisixSharedPlugin", name, None, opts
         )
 
+        # APISIX matches the request Origin against this comma-separated list
+        # and echoes back only a member of it, so allow_credential stays safe.
+        # An empty ``cors_allow_origins`` renders no cors plugin at all -- see
+        # the field's comment on OLApisixSharedPluginsConfig.  allow_methods and
+        # allow_headers stay at "**": once the origin is pinned they only widen
+        # what an already-allowed origin may send.
+        __cors_plugins: list[dict[str, Any]] = (
+            [
+                {
+                    "name": "cors",
+                    "enable": True,
+                    "config": {
+                        "allow_origins": ",".join(plugin_config.cors_allow_origins),
+                        "allow_methods": "**",
+                        "allow_headers": "**",
+                        "allow_credential": True,
+                    },
+                }
+            ]
+            if plugin_config.cors_allow_origins
+            else []
+        )
+
         __default_plugins: list[dict[str, Any]] = [
             {
                 "name": "redirect",
@@ -494,16 +547,7 @@ class OLApisixSharedPlugins(ComponentResource):
                     "http_to_https": True,
                 },
             },
-            {
-                "name": "cors",
-                "enable": True,
-                "config": {
-                    "allow_origins": "**",
-                    "allow_methods": "**",
-                    "allow_headers": "**",
-                    "allow_credential": True,
-                },
-            },
+            *__cors_plugins,
             {
                 "name": "response-rewrite",
                 "enable": True,

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -473,7 +473,7 @@ class OLApisixSharedPluginsConfig(BaseModel):
     plugins: list[dict[str, Any] | OLApisixPluginConfig] = []
 
     @model_validator(mode="after")
-    def require_explicit_cors_origins(self):
+    def require_explicit_cors_origins(self) -> "OLApisixSharedPluginsConfig":
         """Refuse to render the cors default plugin without an origin list."""
         if self.enable_defaults and self.cors_allow_origins is None:
             msg = (

--- a/src/ol_infrastructure/infrastructure/aws/eks/APISIX_STANDALONE_SETUP.md
+++ b/src/ol_infrastructure/infrastructure/aws/eks/APISIX_STANDALONE_SETUP.md
@@ -378,6 +378,11 @@ shared_plugins = OLApisixSharedPlugins(
     plugin_config=OLApisixSharedPluginsConfig(
         application_name="my-app",
         k8s_namespace="my-app-namespace",
+        # Required whenever enable_defaults is set: the origins allowed to read
+        # this app's responses cross-origin with credentials. Pass [] for a
+        # service with no cross-origin browser callers and no cors plugin is
+        # attached at all.
+        cors_allow_origins=["https://my-app.mit.edu"],
         plugins=[
             {"name": "ip-restriction", "config": {"whitelist": ["10.0.0.0/8"]}},
             {"name": "limit-req", "config": {"rate": 100, "burst": 50}},

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -351,7 +351,13 @@ def test_cleanup_plugin_honours_a_custom_stale_name():
 
 
 def shared_plugins(name: str, **overrides) -> OLApisixSharedPlugins:
-    """Build a shared plugin config with the fields every caller has to supply."""
+    """Build a shared plugin config with the fields every caller has to supply.
+
+    ``cors_allow_origins`` has no default on the model on purpose, so that a
+    new gateway cannot inherit a wildcard by omission. Tests that are not about
+    CORS get a placeholder here; the ones that are pass their own.
+    """
+    overrides.setdefault("cors_allow_origins", ["https://myapp.mit.edu"])
     return OLApisixSharedPlugins(
         name,
         plugin_config=OLApisixSharedPluginsConfig(
@@ -528,3 +534,100 @@ def test_gzip_compression_level_stays_cheap():
         assert config["vary"] is True
 
     return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+# ─── CORS origins ──────────────────────────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_cors_renders_the_supplied_origins_with_credentials():
+    """APISIX matches the request Origin against this comma-separated list and
+    echoes back only a member of it, which is what makes allow_credential safe
+    here. The previous default was "**", which reflects whatever Origin the
+    browser sent -- allow_credential alongside it let any origin a user's
+    session cookie reached read authenticated JSON.
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-cors-origins",
+        cors_allow_origins=["https://learn.mit.edu", "https://ocw.mit.edu"],
+    )
+
+    def check(spec):
+        cors = plugin_named(spec["plugins"], "cors")
+        assert cors is not None
+        assert (
+            cors["config"]["allow_origins"]
+            == "https://learn.mit.edu,https://ocw.mit.edu"
+        )
+        assert cors["config"]["allow_credential"] is True
+        # Nothing here may reintroduce a wildcard origin by another route.
+        assert "*" not in cors["config"]["allow_origins"]
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_cors_is_omitted_entirely_for_an_empty_origin_list():
+    """A service whose only callers are same-origin browsers or server-to-server
+    clients gets no cors plugin at all rather than one with an empty allow list:
+    no Access-Control-Allow-Origin header means no cross-origin read is
+    possible. tika, opik, marimo-data and both JupyterHubs pass [].
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-cors-empty",
+        cors_allow_origins=[],
+    )
+
+    def check(spec):
+        assert plugin_named(spec["plugins"], "cors") is None
+        # The rest of the defaults still render -- [] opts out of CORS only.
+        assert plugin_named(spec["plugins"], "redirect") is not None
+        assert plugin_named(spec["plugins"], "prometheus") is not None
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_cors_origins_reach_the_gateway_api_plugin_config():
+    """The v1alpha1 PluginConfig is rendered by a separate comprehension, so
+    Gateway API HTTPRoutes need their own assertion rather than inheriting the
+    v2 one.
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-cors-gateway-api",
+        cors_allow_origins=["https://learn.mit.edu"],
+    )
+
+    def check(spec):
+        cors = plugin_named(spec["plugins"], "cors")
+        assert cors is not None
+        assert cors["config"]["allow_origins"] == "https://learn.mit.edu"
+        # v1alpha1 accepts only name and config -- ``enable`` is v2-only.
+        assert set(cors) == {"name", "config"}
+
+    return plugins.shared_plugin_pluginconfig_resource.spec.apply(check)
+
+
+def test_cors_origins_are_required_when_defaults_are_enabled():
+    """Omitting the list is rejected rather than defaulted, so a new gateway
+    cannot inherit a wildcard by saying nothing. [] is how a caller opts out.
+    """
+    with pytest.raises(ValidationError, match="cors_allow_origins is required"):
+        OLApisixSharedPluginsConfig(
+            application_name="myapp",
+            k8s_namespace="myapp-ns",
+        )
+
+
+def test_cors_origins_are_not_required_without_defaults():
+    """enable_defaults=False renders no cors plugin either way, so demanding an
+    origin list there would be a pointless argument for every caller that has
+    opted out of the shared defaults entirely.
+    """
+    config = OLApisixSharedPluginsConfig(
+        application_name="myapp",
+        k8s_namespace="myapp-ns",
+        enable_defaults=False,
+    )
+
+    assert config.cors_allow_origins is None


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/hq/issues/12175 (SOA login flow holistic fix-up, phase 0). Finding G1 of the login-flow review.

### Description (What does it do?)

- `OLApisixSharedPlugins` attached `allow_origins: "**"` with `allow_credential: true` to every route referencing a shared plugin config. That reflects whatever `Origin` the browser sent, so any origin a user's session cookie reached could read authenticated JSON off `api.learn.mit.edu`, `api.mitxonline.mit.edu`, the learn-ai hosts and analytics.
- `cors_allow_origins` is now a required argument whenever `enable_defaults` is set. There is no default, so a new gateway cannot inherit a wildcard by omission.
- Each app passes the origin list it already declares to its own framework. `[]` attaches no `cors` plugin at all, for services with only same-origin or server-to-server callers (tika, opik, marimo-data, both JupyterHubs).
- Two origins the wildcard was hiding are added, so pinning does not break them on day one: `courses.<env>.learn.mit.edu` in mit-learn's `cors_urls`, and the MIT Learn frontend origin on ol-analytics-api.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why the gateway list is the one that matters.** APISIX sets the `Access-Control-*` headers on the response, so each app's own `CORS_ALLOWED_ORIGINS` never reaches the browser. Pinning only Django would have changed nothing.

**Why `"**"` passed schema validation.** [`apisix/plugins/cors.lua`](https://github.com/apache/apisix/blob/master/apisix/plugins/cors.lua) rejects `allow_credential` alongside the literal `"*"`, but not `"**"`. `allow_origins` is parsed as a comma-separated list (`re_gmatch(allow_origins, "([^,]+)", "jiox")`); an `Origin` in the list is echoed back, and one that is not gets no `Access-Control-Allow-Origin` header at all. `allow_methods`/`allow_headers` stay `"**"` — once the origin is pinned they only widen what an already-allowed origin may send.

**Where each list comes from:**

| Stack | Source |
|---|---|
| mit-learn | `interpolation_vars.cors_urls`, the same value Django gets as `CORS_ALLOWED_ORIGINS` |
| mitxonline | `env_vars["CORS_ALLOWED_ORIGINS"]`, split on commas |
| learn-ai | derived from `frontend_domain` / `backend_domain` / `learn_backend_domain` |
| ol-analytics-api | its own host, plus the MIT Learn frontend origin |
| edxapp + meilisearch | new `browser_origins()` helper in `k8s_configmaps.py` |
| tika, opik, marimo-data, jupyterhub, jupyterhub-data | `[]` |

**learn-ai is derived rather than read from config** because its `CSRF_ALLOWED_ORIGINS` omits the `learn.mit.edu` pair on CI even though learn-ai serves `api.ci.learn.mit.edu` there. QA and Production come out identical to the declared list; CI gains the two entries it was missing.

**`browser_origins()`** is now the base of Django's `CORS_ORIGIN_WHITELIST` as well as the gateway's list, so the two cannot drift. It excludes two entries the Django list keeps because neither is a document origin and so neither can ever be an `Origin`: the edxnotes domain (also only available as a Pulumi `Output` here) and the storage bucket's S3 origin. The `idp.mit.edu` conditional moved into the helper unchanged (`mitx`, `mitx-staging`, `mitxonline`).

**Rendered Production values:**

```
mit-learn      api.learn.mit.edu, learn.mit.edu, courses.learn.mit.edu,
               api.mitopen.odl.mit.edu, mitopen.odl.mit.edu,
               draft.ocw.mit.edu, ocw.mit.edu
mitxonline     mitxonline.mit.edu, learn.mit.edu
learn-ai       learn-ai.ol.mit.edu, api-learn-ai.ol.mit.edu,
               api.learn.mit.edu, learn.mit.edu
analytics      analytics.ol.mit.edu, learn.mit.edu
edxapp         courses.learn.mit.edu, studio.courses.learn.mit.edu,
  (mitxonline) preview.courses.learn.mit.edu, mitxonline.mit.edu,
               learn-ai.ol.mit.edu, learn.mit.edu, canvas.mit.edu,
               idp.mit.edu
```

**The two gaps.** `courses.<env>.learn.mit.edu` was already in mit-learn's `csrf_domains` ("MITxOnline courseware MFE (content feedback submit)") but not in `cors_urls`, so that submit only worked because of the wildcard. ol-analytics-api's Learn-scoped host exists precisely because the MIT Learn frontend calls it with `fetch` from a different origin carrying the shared session cookie (see the comment on `ol_analytics_api_learn_oidc_resources` in `src/ol_infrastructure/applications/ol_analytics_api/__main__.py`); that origin is now named.

</details>

### How can this be tested?

What I ran:

- `pre-commit run --all-files` — passes (the hadolint failures are pre-existing on Dockerfiles this branch does not touch).
- `pulumi preview --diff` on Production for mit_learn, mitxonline, learn_ai, ol_analytics_api, edxapp/mitxonline, tika, opik, marimo_data, jupyterhub and jupyterhub_data, plus mit_learn CI. The only change in each is `allow_origins` on the two shared plugin config resources. The five `[]` services shift the plugin array by one index as `cors` is dropped, which is cosmetic. edxapp's `CORS_ORIGIN_WHITELIST` diff is reordering only — the `idp.mit.edu` and `canvas.mit.edu` entries visible in that preview come from 93ea3d324, which is merged but not yet deployed.
- Confirmed against the APISIX plugin source (linked above) that a comma-separated `allow_origins` is the supported form and that a non-member origin gets no header.

What I did **not** run, and what a reviewer should do after this lands on CI:

```bash
# Expect: no Access-Control-Allow-Origin in the response
curl -sI -H "Origin: https://evil.example" https://api.ci.learn.mit.edu/api/v0/users/me/ | grep -i access-control

# Expect: the origin echoed back
curl -sI -H "Origin: https://ci.learn.mit.edu" https://api.ci.learn.mit.edu/api/v0/users/me/ | grep -i access-control
```

Then exercise the two paths the gaps cover: content-feedback submit from `courses.ci.learn.mit.edu`, and the analytics fetch from the MIT Learn frontend.

### Additional Context

Draft on purpose. The failure mode of getting an origin wrong is a silently blocked cross-origin fetch, not an error anyone gets paged for, so this should soak on CI and QA before Production. Roll out per stack rather than all at once.

The origin lists are each app's declared intent, not a measurement of live traffic: APISIX's access log format is not customised in `apisix_official.py`, so the nginx default applies and no `Origin` header is recorded. There is therefore no production record of who actually calls these hosts cross-origin. If an origin is missing, this change is what will surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ncks6dGfsURo2UKKwaeVJS
