### PR TITLE
feat(canaries): the mit-learn login and course-search journey

### DIFF
--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -104,6 +104,14 @@ downloads none.
 - **Web-first assertions only.** `expect(locator)` auto-retries; `expect(await
   locator.count())` does not, and is the most common source of canary flake.
 - **Never `waitForTimeout`.** Wait for the thing you actually need.
+- **Retry the action, not just the assertion, when interacting before hydration.**
+  Auto-waiting gets a locator that is present and enabled, which is not the same as
+  one the framework has attached a handler to yet — a keystroke into a
+  server-rendered search box is silently dropped. Wrap the action and its outcome in
+  `expect(async () => { … }).toPass()` rather than sleeping. `login-and-search.spec.ts`
+  does this; the race was caught only because the journey was run in WebKit, where the
+  page is slower to hydrate. Chromium passed it every time, which is what this class of
+  bug looks like right up until the target has a bad day.
 
 ## Failure artifacts
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -8,8 +8,26 @@
 
 | Spec | Journey | Status |
 |---|---|---|
-| `homepage.spec.ts` | Homepage renders in a real browser | Active |
-| _(pending)_ | Log in, then search for a course | Not yet written |
+| `homepage.spec.ts` | Homepage renders in a real browser, anonymously | Active |
+| `login-and-search.spec.ts` | Log in, reach the dashboard, then search for courses | Active |
+
+## Helpers
+
+| File | Purpose |
+|---|---|
+| `helpers/sign-in.ts` | Drives the real multi-screen Keycloak login from the homepage |
+| `helpers/signed-in-test.ts` | `test` whose `page` fixture is already signed in |
+
+A journey that needs a session imports `test` from `helpers/signed-in-test` and takes
+the ordinary `{ page }` fixture — do not call `signIn` yourself. The session is
+established once per worker and reused, so adding a third signed-in journey costs no
+extra logins. Journeys that must be anonymous, like `homepage.spec.ts`, keep importing
+`@playwright/test` directly.
+
+The session is held in memory and deliberately never written to disk: a `storageState`
+file carries live tokens and this project's failure artifacts are published. For the
+same reason the login context is not traced, so `sign-in.ts` puts the diagnosis in its
+error messages instead.
 
 ## Login flow
 
@@ -18,22 +36,39 @@ The flow is **identity-first** and measured as three screens:
 
 | Screen | Path | Form control |
 |---|---|---|
-| Email | `/protocol/openid-connect/auth` | `input[name="username"]`, `button[name="login"]` |
-| Password (existing account) | `/login-actions/authenticate` | `input[name="password"]`, `button[name="login"]` |
-| Signup (unknown account) | `/login-actions/registration` | **has a captcha** |
+| Email | `/protocol/openid-connect/auth` | label `Email`, button `Next` |
+| Password (account exists in the realm) | `/login-actions/authenticate` | label `Password`, button `Next` |
+| Signup (unknown non-MIT address) | `/login-actions/registration` | **has a captcha** |
+| Touchstone hand-off (unknown `@mit.edu` address) | `/broker/touchstone-idp/login` → `okta.mit.edu` | MIT credentials |
+
+There is **no captcha on the login path**, so the canary drives the real UI; no bypass,
+dedicated flow or injected `storageState` is needed.
 
 Credentials come from the environment (`CANARY_USER_EMAIL`, `CANARY_USER_PASSWORD`),
 sourced from Vault by the pipeline. Never commit them — see `../../AGENTS.md`.
 
 ### Two things a login journey here must do
 
-1. **Assert the flow reached `/login-actions/authenticate`, not `/login-actions/registration`.**
-   Because the flow is identity-first, an account that is missing, disabled or locked out
-   does not produce a login error — Keycloak silently routes to the signup form, which
-   *does* have a captcha. Without this assertion the symptom of "our stored password
-   drifted" reads as "a captcha now blocks login", which sends triage the wrong way.
+Both are implemented in `helpers/sign-in.ts`; they are recorded here because they are
+properties of the realm, not of the code, and the next property to authenticate against
+`olapps` will need them too.
+
+1. **Assert the password screen was reached, positively.** The flow is identity-first, so
+   an account that is missing, disabled or renamed never produces a login error —
+   Keycloak just sends the browser elsewhere, and *which* elsewhere depends on the email
+   domain. The canary account is `@mit.edu`, so its failure mode is a silent hand-off to
+   Touchstone; a non-MIT address instead lands on the captcha'd signup form. Testing for
+   those destinations one at a time is how you end up reporting "login now requires SSO"
+   or "a captcha now blocks login" when the truth is that the account is gone. Worse, a
+   flow that assumes it is on the password screen will type the canary's password into
+   whatever page is actually showing — including MIT's own IdP.
 2. **Never retry a *rejected* password.** See the lockout note below. Retrying a page that
-   failed to load is fine; retrying a refused credential is not.
+   failed to load is fine; retrying a refused credential is not. Playwright starts a
+   fresh worker process for a retry, so `sign-in.ts` records the refusal in a file under
+   `tmpdir` — per-container, so it covers the run and nothing beyond it. Note that the
+   realm's custom theme means Keycloak's stock alert markup is absent: the refusal is
+   detected by its visible text (`Invalid username or password.`), which is what a user
+   sees anyway.
 
 ## Canary account
 
@@ -87,7 +122,15 @@ that merely happens to exist in RC today is a future false page:
 
 | Journey | Requires | Guaranteed by |
 |---|---|---|
-| | | |
+| `login-and-search.spec.ts` | A search for `mathematics` returns at least one **course** | Nothing contractual — see below |
+
+That query is deliberately broad: MIT's catalogue not containing a single mathematics
+course is not a realistic content change, so the assertion is a real signal about search
+rather than a bet on one course's continued existence. It is still a content dependency,
+and the honest reading of a failure is "search returned nothing", which is a **failure
+worth paging on** — an emptied or half-rebuilt index looks exactly like this from a
+user's seat. Anything narrower, such as a named course or an exact result count, is a
+false page waiting for the next content sync.
 
 ## Prior art
 

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/sign-in.ts
@@ -1,0 +1,129 @@
+import { expect, type Page } from "@playwright/test"
+import { existsSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Realm `olapps` is permanentLockout=true, failureFactor=10, with a 12h counter
+// reset — so a credential that has drifted between Keycloak and Vault does not
+// settle into a harmless recurring failure, it disables the account for good in
+// about two hours at a 10-minute cadence. Playwright starts a fresh worker for a
+// retry, so refusing the second attempt has to be recorded somewhere outside the
+// process. Not under canary-results/, which is published as build artifacts;
+// tmpdir is per-container, so the refusal covers the run and nothing beyond it.
+const REJECTED_CREDENTIAL_MARKER = join(tmpdir(), "mit-learn-canary-credential-rejected")
+
+// Bounded so a rejected credential surfaces as itself. Left to the 90s test
+// timeout it would instead report as "test timeout", and the diagnosis below
+// would never run.
+const REDIRECT_TIMEOUT = 30_000
+
+function canaryCredentials(): { email: string; password: string } {
+  const email = process.env.CANARY_USER_EMAIL
+  const password = process.env.CANARY_USER_PASSWORD
+  if (!email || !password) {
+    throw new Error(
+      "CANARY_USER_EMAIL and CANARY_USER_PASSWORD are required. The pipeline " +
+        "sources them from Vault; locally, export them from SOPS. A canary never " +
+        "falls back to a default credential — see ../../../AGENTS.md.",
+    )
+  }
+  return { email, password }
+}
+
+// The realm ships a custom theme, so Keycloak's stock alert markup is not there
+// to key on — a refusal is ordinary visible text, which is also exactly what the
+// user is shown. Listed as whole phrases rather than as loose keywords so that
+// unrelated page copy cannot be read as a rejection and stop the canary.
+const REJECTION_MESSAGE =
+  /invalid username or password|invalid user credentials|account is (temporarily )?disabled|account is locked/i
+
+async function rejectionMessage(page: Page): Promise<string | null> {
+  const message = page.getByText(REJECTION_MESSAGE).first()
+  if (!(await message.isVisible().catch(() => false))) {
+    return null
+  }
+  return (await message.innerText()).trim()
+}
+
+/**
+ * Drive the real MIT Learn login, from the homepage through Keycloak.
+ *
+ * Fails with the actual cause rather than the visible symptom. The realm's flow
+ * is identity-first, so an account it does not recognise is never answered with
+ * a login error — the browser is simply sent somewhere else. See ../README.md.
+ */
+export async function signIn(page: Page): Promise<void> {
+  if (existsSync(REJECTED_CREDENTIAL_MARKER)) {
+    throw new Error(
+      "Refusing to re-submit a credential Keycloak already rejected in this run. " +
+        "Ten consecutive failures lock the canary account, and the next ten disable " +
+        "it permanently. Fix the credential in Keycloak and SOPS together.",
+    )
+  }
+  const { email, password } = canaryCredentials()
+
+  await page.goto("/")
+  // Step one of the journey, and the reason login starts here rather than at a
+  // deep link: a homepage that no longer offers a way in is a user-facing outage
+  // that a direct hop to the IdP would sail straight past.
+  await expect(page.locator("main")).toBeVisible()
+  const applicationOrigin = new URL(page.url()).origin
+
+  await page.getByRole("link", { name: "Log In" }).click()
+  await page.waitForURL((url) => url.origin !== applicationOrigin, {
+    timeout: REDIRECT_TIMEOUT,
+  })
+
+  const identityProvider = new URL(page.url()).origin
+  const emailScreen = page.url()
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  await page.waitForURL((url) => url.href !== emailScreen, { timeout: REDIRECT_TIMEOUT })
+
+  // Assert the local password screen positively, rather than testing for the
+  // known wrong destinations. An unrecognised account goes to whichever of them
+  // fits the address — measured: an @mit.edu one is handed off to Touchstone,
+  // any other domain gets the captcha'd signup form — and both mean the account
+  // is gone, not that login has grown a captcha or an SSO requirement. Guessing
+  // wrong here is not just a bad message: it would type the canary's password
+  // into whatever page happened to be showing.
+  const reached = new URL(page.url())
+  const onPasswordScreen =
+    reached.origin === identityProvider &&
+    reached.pathname.endsWith("/login-actions/authenticate")
+  if (!onPasswordScreen) {
+    throw new Error(
+      `After submitting the canary address, the flow reached ${reached.origin}` +
+        `${reached.pathname} instead of the password screen, so the account does ` +
+        "not exist in this realm. This is an account problem — not a captcha " +
+        "problem and not an SSO problem, whichever of those the page says.",
+    )
+  }
+
+  await page.getByLabel("Password", { exact: true }).fill(password)
+  await page.getByRole("button", { name: "Next", exact: true }).click()
+  try {
+    await page.waitForURL((url) => url.origin === applicationOrigin, {
+      timeout: REDIRECT_TIMEOUT,
+    })
+  } catch (error) {
+    const rejection = await rejectionMessage(page)
+    if (rejection) {
+      writeFileSync(REJECTED_CREDENTIAL_MARKER, rejection)
+      throw new Error(
+        `Keycloak rejected the canary credential: "${rejection}". Not retrying — ` +
+          "see the lockout note in ../README.md. Rotation must change Keycloak and " +
+          "the SOPS/Vault value together; the gap between the two is itself enough " +
+          "to disable the account.",
+      )
+    }
+    throw error
+  }
+
+  if (new URL(page.url()).pathname.startsWith("/onboarding")) {
+    throw new Error(
+      "Login landed on onboarding, which only a canary account that has never " +
+        "completed it does. Log the account in by hand once, then re-run.",
+    )
+  }
+}

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/helpers/signed-in-test.ts
@@ -1,0 +1,46 @@
+import { test as base, type BrowserContextOptions } from "@playwright/test"
+import { signIn } from "./sign-in"
+
+type SignedInWorkerFixtures = {
+  /** Session established once per worker, reused by every test in it. */
+  canarySession: BrowserContextOptions["storageState"]
+}
+
+/**
+ * `test` for journeys that need to be signed in.
+ *
+ * Import this instead of `@playwright/test` and the ordinary `page` fixture
+ * arrives authenticated, so a second journey reuses the login rather than
+ * re-implementing or re-running it. Journeys that should be anonymous — the
+ * homepage canary — keep importing `@playwright/test` directly.
+ *
+ * The session is held in memory and never written to disk: a storageState file
+ * carries live tokens, and this project's failure artifacts get published.
+ */
+export const test = base.extend<{}, SignedInWorkerFixtures>({
+  canarySession: [
+    async ({ browser }, use) => {
+      // A context built straight off `browser` inherits nothing from the project's
+      // `use`, so the config's required base URL has to be handed over explicitly
+      // or every `page.goto("/")` below is an invalid URL. Read from the project
+      // rather than the environment to keep playwright.config.ts the one place
+      // that decides what a canary targets.
+      const context = await browser.newContext({
+        baseURL: base.info().project.use.baseURL,
+      })
+      // Deliberately untraced, unlike the fixture-provided page: a trace of the
+      // login screens would embed the canary account's address, and traces are
+      // published as build artifacts. signIn() reports the cause in its message.
+      const page = await context.newPage()
+      await signIn(page)
+      const session = await context.storageState()
+      await context.close()
+      await use(session)
+    },
+    { scope: "worker" },
+  ],
+
+  storageState: ({ canarySession }, use) => use(canarySession),
+})
+
+export { expect } from "@playwright/test"

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/login-and-search.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./helpers/signed-in-test"
+
+// Broad enough that a working index cannot plausibly return nothing for it, and
+// specific enough that a result matching it means the query was actually applied.
+// Recorded in ../README.md's content-dependency table.
+const SEARCH_QUERY = "mathematics"
+
+test.describe("MIT Learn signed-in journey", () => {
+  test("signs in and reaches a page anonymous visitors cannot", async ({ page }) => {
+    await page.goto("/dashboard")
+
+    // Anonymous, this URL redirects to Keycloak, so arriving at the dashboard's
+    // own heading is proof of an authenticated session rather than proof that a
+    // redirect completed.
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole("heading", { name: "Your MIT Learning Journey" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "User Menu" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Log In" })).toHaveCount(0)
+  })
+
+  test("searches for courses and gets results relevant to the query", async ({ page }) => {
+    await page.goto("/")
+
+    // Retried as a unit because the header search box is in the server-rendered
+    // markup before React attaches a handler to it, so a keystroke can land in a
+    // box that is not listening yet and is silently dropped. Measured in WebKit;
+    // it is a race rather than a browser difference, and Chromium only wins it by
+    // being faster — which is the shape of a canary that passes until the day the
+    // target is slow, then pages someone at 3am.
+    const searchBox = page.getByRole("textbox", { name: "Search for" })
+    await expect(async () => {
+      await searchBox.fill(SEARCH_QUERY)
+      await searchBox.press("Enter")
+      await expect(page).toHaveURL(new RegExp(`/search\\?.*q=${SEARCH_QUERY}`), {
+        timeout: 5_000,
+      })
+    }).toPass({ timeout: 30_000 })
+
+    await expect(page.getByRole("heading", { name: "Search Results" })).toBeVisible()
+    await expect(page.getByRole("article").first()).toBeVisible()
+
+    // The tab set present but reading "Courses (0)" is what an emptied or
+    // half-rebuilt index looks like from a user's seat, so assert the count is
+    // non-zero separately from asserting the tab rendered at all.
+    const coursesTab = page.getByRole("tab", { name: /^Courses/ })
+    await expect(coursesTab).toBeVisible()
+    await expect(page.getByRole("tab", { name: /^Courses \([1-9]\d*\)/ })).toBeVisible()
+
+    await coursesTab.click()
+    // Relevance, not an exact count: any specific number is a false page waiting
+    // for the next content sync.
+    await expect(
+      page.getByRole("article", { name: new RegExp(`^Course:.*${SEARCH_QUERY}`, "i") }).first(),
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5592. Stacked on #5748 (→ #5747 → #5707); review those first, and GitHub will retarget this to `main` as the stack merges.

### Description (What does it do?)

Adds the first real canary journey for mit-learn: sign in through Keycloak as the dedicated canary account, reach a page anonymous visitors cannot, then search and assert the results are relevant to the query.

- `helpers/sign-in.ts` drives the real multi-screen login from the homepage — no bypass, no injected `storageState`. Starting at the homepage is deliberate: a homepage that no longer offers a way in is a user-facing outage a direct hop to the IdP would sail past.
- `helpers/signed-in-test.ts` exports a `test` whose ordinary `page` fixture is already authenticated. A second signed-in journey imports it and costs no extra login; anonymous journeys keep importing `@playwright/test`. The session is held in memory and never written to disk, because `storageState` carries live tokens and this project's failure artifacts get published. For the same reason the login context is not traced, so the helper puts the diagnosis in its error messages.
- **No pipeline change.** `CanaryParams.spec_paths` already defaults to the property's whole directory, so the new spec is picked up by the rendered `npx playwright test specs/mit-learn`.

Two guards carry most of the value here, and both were verified by making them fire:

**The login flow does not report the symptom it sees.** The realm is identity-first, so an account it does not recognise never produces a login error — it redirects, and *where* depends on the email domain. Measured against RC: an unknown `@mit.edu` address is handed off to Touchstone (`/broker/touchstone-idp/login` → `okta.mit.edu`), and only a non-MIT address gets the captcha'd signup form that was previously documented as the symptom to expect. Since the canary account *is* `@mit.edu`, the documented guard would have missed its actual failure mode. So the helper asserts the password screen positively rather than testing for known-wrong destinations — which also stops it typing the canary's password into MIT's own IdP.

**A rejected password is never retried.** Realm `olapps` is `failureFactor=10`, `permanentLockout=true`: ten consecutive failures lock the account and the next ten disable it permanently, so a credential that has drifted between Keycloak and Vault would otherwise be disabled by its own canary in roughly two hours. Playwright starts a fresh worker for a retry, so the refusal is recorded in `tmpdir` — per-container, so it covers the run and nothing beyond it. The realm's custom theme has no stock Keycloak alert markup, so the refusal is detected by the text the user is actually shown.

### How can this be tested?

Requires the canary credential; export `CANARY_USER_EMAIL` / `CANARY_USER_PASSWORD` from `src/bridge/secrets/concourse/operations.production.yaml`, then:

```bash
cd src/ol_concourse/pipelines/canaries
npm ci && npm run typecheck
CANARY_BASE_URL=https://rc.learn.mit.edu npx playwright test specs/mit-learn --project=chromium
```

What I ran against live RC in the pinned `mcr.microsoft.com/playwright:v1.62.1-noble` image:

- Five chromium runs, all green, no flakes.
- firefox and webkit, both green.
- The exact script `pipeline.py` renders (`npm ci` then `npx playwright test specs/mit-learn --project=chromium`), from a clean `git archive` checkout laid out as Concourse lays it out — 3 passed.
- `tests/ol_concourse/`: 386 passed. `pre-commit` clean on the changed files, including detect-secrets.

Both failure guards were exercised, not just reasoned about:

- Unknown `@mit.edu` address → `After submitting the canary address, the flow reached https://sso-qa.ol.mit.edu/realms/olapps/broker/touchstone-idp/login instead of the password screen, so the account does not exist in this realm. This is an account problem — not a captcha problem and not an SSO problem, whichever of those the page says.` No password was submitted.
- Wrong password → first attempt reports `Keycloak rejected the canary credential: "Invalid username or password."`, and the retry reports `Refusing to re-submit a credential Keycloak already rejected in this run.` One failed attempt spent instead of two. The account's failure counter was then reset by successful logins and the account is healthy.

### Additional Context

WebKit caught a hydration race: a keystroke into the header search box is silently dropped before React attaches a handler. It is a race, not a browser difference — Chromium passed every time and only wins by being faster, which is what this class of bug looks like right up until the target has a bad day. Fixed by retrying the action via `expect(...).toPass()` rather than sleeping, and recorded as a bullet in `AGENTS.md` since every future canary will meet it.

The search assertion is on relevance, not counts: at least one result, a non-zero `Courses (N)` tab, and at least one `Course:` card matching the query. "Search returned nothing" is a failure worth paging on — an emptied or half-rebuilt index looks exactly like this from a user's seat — while an exact count is a false page waiting for the next content sync. The `mathematics` content dependency is recorded in the property README's table.
