### PR TITLE
fix(local-dev)!: bump k3s to v1.35.8 (containerd 2.x) + Postgres backup/restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ canary-results/
 
 .pulumi
 local-dev/certs/
+# Postgres dumps written by local-dev/scripts/pg-backup.sh
+local-dev/.backups/
 tilt_config.json
 # Per-developer local-dev overrides (see "Local Configuration Overrides" in
 # local-dev/README.md). Broad on purpose: never track a real secret anywhere

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -18,11 +18,12 @@ This README covers getting up and running, day-to-day usage, and troubleshooting
 5. [Directory Structure](#directory-structure)
 6. [Working with Apps](#working-with-apps)
 7. [Seeding Data](#seeding-data)
-8. [Configuration Reference](#configuration-reference)
-9. [Disk Management](#disk-management)
-10. [Teardown](#teardown)
-11. [Customization & Advanced Setup](#customization--advanced-setup)
-12. [Troubleshooting](#troubleshooting)
+8. [Backing Up and Restoring Postgres](#backing-up-and-restoring-postgres)
+9. [Configuration Reference](#configuration-reference)
+10. [Disk Management](#disk-management)
+11. [Teardown](#teardown)
+12. [Customization & Advanced Setup](#customization--advanced-setup)
+13. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -310,6 +311,34 @@ tilt trigger seed-mit-learn-fixtures
 
 ---
 
+## Backing Up and Restoring Postgres
+
+Every PersistentVolume in the cluster lives inside the k3d node containers, so `k3d cluster delete` (what `teardown.sh` does, and what any `k3d-config.yaml` change to the node image needs) destroys all Postgres data. OpenSearch and Qdrant are rebuilt from Postgres by the `seed-mit-learn-opensearch` and `seed-mit-learn-qdrant` seeds; Postgres is the only store worth carrying across.
+
+```bash
+# 1. Before teardown: dump every app database to local-dev/.backups/<timestamp>/ (gitignored)
+./local-dev/scripts/pg-backup.sh
+
+# 2. Recreate the cluster
+./local-dev/scripts/teardown.sh
+./local-dev/scripts/setup.sh
+
+# 3. Start Tilt as usual and wait for local-infra-apps and kc-seed-users to go green
+./local-dev/scripts/start.sh
+
+# 4. In a second terminal: restore
+./local-dev/scripts/pg-restore.sh local-dev/.backups/<timestamp>
+
+# 5. Rebuild the derived stores
+tilt trigger seed-mit-learn-opensearch && tilt trigger seed-mit-learn-qdrant
+```
+
+`pg-restore.sh` prints its plan, asks for confirmation (`--yes` to skip the prompt), imports `keycloak-users.json` into the recreated realm, then replaces each database from its dump. The apps can stay running: each database is recreated with a connection limit that keeps the `app` role out until its archive has loaded, so an app pod that starts mid-restore is refused rather than allowed to run `migrate` against a half-loaded schema, and pods reconnect on their own once the limit lifts. If the dump predates your checkout's migrations, restart the app Deployments afterwards so `migrate` runs against the restored schema. `pg-backup.sh` records the realm's users alongside the database dumps; `pg-restore.sh` re-imports them under their original ids, so `users_user.global_id` in the restored data stays valid and hand-created users, passwords, and the admin role survive. A user that already exists in the new realm under the same email (the `kc-seed-users` trio, most often) is replaced by the backed-up one, keeping its old id and password.
+
+The `keycloak` database is deliberately never restored — Pulumi owns the realm, and restoring the old database underneath it is what causes the `404 Realm not found` failure described under [Teardown](#teardown). Both scripts run entirely through `kubectl exec` into the Postgres pod, so no Postgres client tools are needed on the host.
+
+---
+
 ## Configuration Reference
 
 `tilt_config.json` is your copy of [`tilt_config.json.example`](../tilt_config.json.example) — the example file is the canonical starting point (its image tags move over time; this doc doesn't repeat them). Keys:
@@ -429,6 +458,8 @@ One registry case zot cannot reclaim on its own is a repo left with no manifest 
 ```
 
 > **Note:** The teardown script calls `pulumi destroy` automatically to clean up Pulumi-managed resources before deleting the cluster, so no orphaned resources are left behind.
+
+> **Data:** deleting the cluster deletes every PersistentVolume, Postgres included. Run `./local-dev/scripts/pg-backup.sh` first if there is anything in the databases you want back — see [Backing Up and Restoring Postgres](#backing-up-and-restoring-postgres).
 
 Pulumi state must never outlive the cluster: everything these stacks manage
 lives inside the cluster, but the state lives in this checkout, so state that
@@ -570,6 +601,18 @@ mkcert -install   # Install the mkcert root CA into your OS trust store
 ```
 
 Then restart your browser. The cert was generated with the correct wildcard SANs but the root CA must be in your OS trust store.
+
+### App pods stuck in `ImagePullBackOff` with `number of layers and diffIDs don't match`
+
+```bash
+kubectl -n mit-learn describe pods | grep diffIDs
+# Failed to pull image "k3d-registry.localhost:5000/mitodl_mit-learn-app:tilt-...":
+#   ... number of layers and diffIDs don't match: 17 != 22
+```
+
+The cluster's nodes run a k3s image with containerd 1.7, which does not understand the zstd layer media type that Tilt's `docker_build` emits for images based on `mitodl/ol-python-base` (see the comment on `image:` in `local-dev/cluster/k3d-config.yaml`). Nothing about the registry or the build is wrong; the node image is too old. k3d cannot change a running cluster's node image, so recreate it: follow [Backing Up and Restoring Postgres](#backing-up-and-restoring-postgres), which covers the teardown, `setup.sh` picking up the new image, and carrying your Postgres data across.
+
+Already-pushed images pull fine on the new nodes without a rebuild — the registry volume is separate from the cluster and survives teardown.
 
 ### Docker image build fails (Next.js)
 

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -11,7 +11,16 @@ metadata:
 servers: 1
 agents: 2
 
-image: docker.io/rancher/k3s:v1.31.4-k3s1
+# The node image fixes the containerd version, and containerd 2.x is required.
+# mitodl/ol-python-base is built on Docker Hardened Images whose base layers
+# are zstd-compressed, and Tilt's docker_build exports them with the media type
+# application/vnd.docker.image.rootfs.diff.tar.zstd. containerd 1.7 (k3s up to
+# v1.32) does not recognise that type as a layer, so it drops those layers and
+# rejects every app image with "number of layers and diffIDs don't match".
+# k3s v1.33 and later ship containerd 2.x. CI builds sidestep this with
+# OUTPUT_OCI=true on oci-build-task; docker_build has no equivalent.
+# k3d cannot swap a node image in place: changing this recreates the cluster.
+image: docker.io/rancher/k3s:v1.35.8-k3s1
 
 # Local image registry — images built by Tilt are pushed here.
 # The registry container itself is created by setup.sh (`k3d registry create

--- a/local-dev/scripts/pg-backup.sh
+++ b/local-dev/scripts/pg-backup.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# pg-backup.sh — dump the local-dev app databases before a cluster recreate
+#
+# Every PersistentVolume in the k3d cluster is local-path storage inside a node
+# container, so teardown.sh (and any k3d-config.yaml node-image change, which
+# needs a teardown) deletes all Postgres data. This writes one `pg_dump -Fc`
+# archive per app database plus a manifest of byte counts into DIR, for
+# pg-restore.sh to load into the new cluster.
+#
+# Dumped: every database except postgres, the templates, and
+#   keycloak  — Pulumi recreates the realm; restoring the old database under
+#               it is the "404 Realm not found" failure teardown.sh describes.
+#               Its users are carried separately, in keycloak-users.json.
+#   litellm   — config-file driven; its tables hold only runtime rows
+#   app       — CNPG's bootstrap database, always empty
+#   test_*    — pytest's leftover test databases
+#
+# Keycloak assigns each user its id at creation, and the apps store that id in
+# users_user.global_id. keycloak-users.json exports the olapps realm's users
+# (with ids, hashed passwords, attributes, realm roles) so pg-restore.sh can
+# re-import them under the same ids before loading the databases, keeping
+# users_user.global_id valid with no reconciliation step.
+#
+# pg_dump runs inside the local-pg-1 pod through `kubectl exec`, so the host
+# needs no Postgres client tools.
+#
+# Usage:
+#   ./local-dev/scripts/pg-backup.sh [--out DIR]
+#
+# DIR defaults to local-dev/.backups/<UTC timestamp>/ (gitignored).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log()  { echo "▶ $*"; }
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*"; }
+err()  { echo "  ✗ $*" >&2; exit 1; }
+
+OUT="${REPO_ROOT}/local-dev/.backups/$(date -u +%Y%m%dT%H%M%SZ)"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) OUT="${2:?--out needs a directory}"; shift 2 ;;
+        *) err "unknown argument: $1 (usage: pg-backup.sh [--out DIR])" ;;
+    esac
+done
+
+PG=(kubectl -n local-infra exec local-pg-1 -c postgres --)
+
+if [ -e "$OUT" ] && [ -n "$(ls -A "$OUT")" ]; then
+    err "refusing to write into non-empty $OUT"
+fi
+mkdir -p "$OUT"
+
+log "Listing databases"
+dbs=$("${PG[@]}" psql -U postgres -At -c \
+    "SELECT datname FROM pg_database
+      WHERE NOT datistemplate
+        AND datname NOT IN ('postgres', 'keycloak', 'litellm', 'app')
+        AND datname NOT LIKE 'test\_%'
+      ORDER BY 1")
+[ -n "$dbs" ] || err "no databases to dump"
+
+for db in $dbs; do
+    # pg-restore.sh refuses any other name; better to hear that before the teardown.
+    [[ "$db" =~ ^[a-z_][a-z0-9_]*$ ]] || err "$db cannot be restored by pg-restore.sh; drop or rename it, then re-run"
+    log "Dumping $db"
+    "${PG[@]}" pg_dump -U postgres --no-password -Fc "$db" > "$OUT/$db.dump.part"
+    [ "$(head -c 5 "$OUT/$db.dump.part")" = "PGDMP" ] || err "$db.dump.part is not a pg_dump custom-format archive"
+    mv "$OUT/$db.dump.part" "$OUT/$db.dump"
+    bytes=$(wc -c < "$OUT/$db.dump" | tr -d ' ')
+    echo "$db $bytes" >> "$OUT/manifest.txt"
+    ok "$db: $bytes bytes"
+done
+
+log "Exporting olapps realm users"
+# Service-account users are excluded because Pulumi recreates the clients that
+# own them. Realm roles are exported by name, default-roles-olapps included:
+# partialImport grants only the roles listed, so leaving it out would strip
+# the imported users of it.
+kubectl -n local-infra exec -i local-pg-1 -c postgres -- \
+    psql -U postgres -qAt -v ON_ERROR_STOP=1 -d keycloak -f - > "$OUT/keycloak-users.json" <<'SQL'
+SELECT coalesce(json_agg(json_build_object(
+  'id', u.id,
+  'username', u.username,
+  'email', u.email,
+  'emailVerified', u.email_verified,
+  'enabled', u.enabled,
+  'firstName', u.first_name,
+  'lastName', u.last_name,
+  'createdTimestamp', u.created_timestamp,
+  'attributes', (SELECT coalesce(json_object_agg(a.name, a.vals), '{}'::json)
+                   FROM (SELECT name, json_agg(coalesce(long_value, value)) AS vals
+                           FROM user_attribute WHERE user_id = u.id GROUP BY name) a),
+  'credentials', (SELECT coalesce(json_agg(json_build_object(
+                    'type', c.type, 'userLabel', c.user_label, 'priority', c.priority,
+                    'createdDate', c.created_date, 'secretData', c.secret_data,
+                    'credentialData', c.credential_data)), '[]'::json)
+                    FROM credential c WHERE c.user_id = u.id),
+  'realmRoles', (SELECT coalesce(json_agg(k.name), '[]'::json)
+                   FROM user_role_mapping m JOIN keycloak_role k ON k.id = m.role_id
+                  WHERE m.user_id = u.id AND NOT k.client_role)
+) ORDER BY u.email), '[]'::json)
+FROM user_entity u JOIN realm r ON r.id = u.realm_id
+WHERE r.name = 'olapps' AND u.service_account_client_link IS NULL;
+SQL
+jq -e 'type == "array"' "$OUT/keycloak-users.json" > /dev/null || err "keycloak-users.json is not a JSON array"
+n=$(jq 'length' "$OUT/keycloak-users.json")
+if [ "$n" -eq 0 ]; then
+    warn "keycloak-users.json: 0 users"
+else
+    ok "keycloak-users.json: $n users"
+fi
+
+ok "Wrote $OUT"
+echo "  Restore with: ./local-dev/scripts/pg-restore.sh $OUT"

--- a/local-dev/scripts/pg-restore.sh
+++ b/local-dev/scripts/pg-restore.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# pg-restore.sh — load pg-backup.sh archives into the local-dev Postgres
+#
+# Imports keycloak-users.json into the olapps realm, then replaces every
+# database that has a <db>.dump in DIR: DROP ... WITH (FORCE),
+# CREATE DATABASE ... OWNER app, pg_restore --exit-on-error. A failed restore
+# drops the incomplete database; re-running the script is the recovery.
+#
+# Keycloak's partialImport endpoint preserves the id on each imported user,
+# and ifResourceExists: OVERWRITE deletes and recreates a same-email user
+# under that id. Importing users before restoring the databases means
+# users_user.global_id — the Keycloak user id the apps store — still points
+# at a real user with no reconciliation step. A user that already exists in
+# the new realm under the same email (the kc-seed-users trio, most often) is
+# replaced by the backed-up one, keeping its old id and password.
+#
+# The apps may be running. They connect as `app` and run `migrate` on startup,
+# so each database is created with CONNECTION LIMIT 0 (superusers are exempt,
+# so pg_restore is not) and the limit is lifted only once its archive has
+# loaded; an app that connects mid-restore is refused rather than allowed to
+# migrate a half-loaded schema. DROP ... WITH (FORCE) ends the apps' existing
+# sessions, and their pods reconnect once the limit lifts. A pod that was
+# already serving does not re-run migrate, so if the archive predates the
+# checkout's migrations, restart the app Deployments afterwards.
+#
+# Usage:
+#   ./local-dev/scripts/pg-restore.sh DIR [--yes]
+#
+# --yes skips the confirmation prompt (needed when stdin is not a terminal).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log()  { echo "▶ $*"; }
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*"; }
+err()  { echo "  ✗ $*" >&2; exit 1; }
+
+DIR=""
+YES=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --yes) YES=1; shift ;;
+        -*) err "unknown argument: $1 (usage: pg-restore.sh DIR [--yes])" ;;
+        *) [ -z "$DIR" ] || err "unexpected argument: $1 (usage: pg-restore.sh DIR [--yes])"; DIR="$1"; shift ;;
+    esac
+done
+[ -n "$DIR" ] && [ -d "$DIR" ] || err "usage: pg-restore.sh DIR [--yes] (DIR must be a pg-backup.sh output directory)"
+
+PG=(kubectl -n local-infra exec local-pg-1 -c postgres --)
+PGI=(kubectl -n local-infra exec -i local-pg-1 -c postgres --)
+# sql DB "STATEMENT" — quiet, unaligned, tuples-only; every error is fatal.
+sql() { "${PG[@]}" psql -U postgres -qAt -v ON_ERROR_STOP=1 -d "$1" -c "$2"; }
+
+kubectl -n local-infra wait --for=condition=Ready pod/local-pg-1 --timeout=60s > /dev/null \
+    || err "pod local-pg-1 is not Ready"
+
+# --- Validate every archive before touching the cluster ---------------------
+DBS=()
+[ -f "$DIR/manifest.txt" ] || warn "no manifest.txt in $DIR; skipping the size check"
+for f in "$DIR"/*.dump; do
+    [ -e "$f" ] || err "no *.dump files in $DIR"
+    db=$(basename "$f" .dump)
+    [[ "$db" =~ ^[a-z_][a-z0-9_]*$ ]] || err "refusing unsafe database name in $f"
+    case "$db" in
+        keycloak | postgres | template*) err "refusing to restore $db (see header comment)" ;;
+    esac
+    [ "$(head -c 5 "$f")" = "PGDMP" ] || err "$f is not a pg_dump custom-format archive"
+    if [ -f "$DIR/manifest.txt" ]; then
+        want=$(awk -v d="$db" '$1 == d { print $2 }' "$DIR/manifest.txt")
+        have=$(wc -c < "$f" | tr -d ' ')
+        [ "$want" = "$have" ] || err "$f is $have bytes but manifest.txt says ${want:-<not listed>}; truncated or partial backup?"
+    fi
+    DBS+=("$db")
+done
+if [ -f "$DIR/manifest.txt" ]; then
+    listed=$(wc -l < "$DIR/manifest.txt" | tr -d ' ')
+    [ "$listed" = "${#DBS[@]}" ] || err "manifest.txt lists $listed databases but $DIR has ${#DBS[@]} dumps; incomplete copy?"
+fi
+
+# --- Keycloak preconditions ---------------------------------------------------
+command -v curl > /dev/null || err "curl not found"
+command -v jq > /dev/null || err "jq not found"
+
+_ROOT_DOMAIN="${LOCAL_DEV_ROOT_DOMAIN:-mit.dev}"
+KC_URL="${KC_URL:-https://sso.ol.${_ROOT_DOMAIN}}"
+# The ingress serves an mkcert-issued cert whose root CA is not in the system
+# trust store, so curl needs it explicitly or the handshake fails (exit 60)
+# and get_token's retry loop misreports a healthy Keycloak as still starting.
+KC_CACERT="${KC_CACERT:-${REPO_ROOT}/local-dev/certs/rootCA.pem}"
+[ -f "$KC_CACERT" ] || err "CA certificate not found at $KC_CACERT (run local-dev/scripts/setup.sh to generate local certs)"
+KC_USER="admin"
+KC_PASS="admin"  # pragma: allowlist secret
+
+get_token() {
+    local token attempt
+    for attempt in 1 2 3 4 5; do
+        token=$(curl -sf --cacert "$KC_CACERT" --max-time 10 \
+            -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+            -d client_id=admin-cli -d grant_type=password \
+            -d "username=$KC_USER" -d "password=$KC_PASS" 2>/dev/null \
+            | jq -r '.access_token // empty' 2>/dev/null || true)
+        [ -n "$token" ] && [ "$token" != "null" ] && { echo "$token"; return 0; }
+        echo "  … attempt $attempt/5: waiting for Keycloak" >&2
+        sleep 5
+    done
+    err "could not obtain an admin token from $KC_URL"
+}
+
+KC_USERS_FILE="$DIR/keycloak-users.json"
+if [ -f "$KC_USERS_FILE" ]; then
+    jq -e 'type == "array"' "$KC_USERS_FILE" > /dev/null || err "$KC_USERS_FILE must be a JSON array"
+    KC_N=$(jq 'length' "$KC_USERS_FILE")
+fi
+if [ -f "$KC_USERS_FILE" ] && [ "$KC_N" -gt 0 ]; then
+    # Fetched before the prompt so an unreachable Keycloak fails the run before
+    # you commit to it; the import fetches a fresh one, the token is short-lived.
+    get_token > /dev/null
+else
+    warn "no users in $DIR/keycloak-users.json; users will not be imported"
+    KC_USERS_FILE=""
+fi
+
+# --- Plan + confirm ----------------------------------------------------------
+log "Plan (archives from $DIR):"
+for db in "${DBS[@]}"; do
+    cur=$(sql postgres "SELECT pg_size_pretty(pg_database_size(datname)) FROM pg_database WHERE datname = '$db'")
+    echo "    $db: replace ${cur:-<absent>} with $(wc -c < "$DIR/$db.dump" | tr -d ' ')-byte archive"
+done
+if [ -n "$KC_USERS_FILE" ]; then
+    echo "    Keycloak: import $KC_N users into realm olapps (existing users with the same email are replaced, keeping their old ids)"
+fi
+if [ "$YES" -ne 1 ]; then
+    [ -t 0 ] || err "stdin is not a terminal; pass --yes to skip the confirmation"
+    read -r -p "Type 'restore' to replace these databases: " answer || err "aborted"
+    [ "$answer" = "restore" ] || err "aborted"
+fi
+
+# --- Import Keycloak users ----------------------------------------------------
+if [ -n "$KC_USERS_FILE" ]; then
+    log "Importing users into realm olapps"
+    TOKEN=$(get_token)
+    body=$(jq -c '{ifResourceExists: "OVERWRITE", users: .}' "$KC_USERS_FILE" \
+        | curl -sS --fail-with-body --cacert "$KC_CACERT" -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' -X POST "$KC_URL/admin/realms/olapps/partialImport" -d @-) \
+        || { echo "$body" >&2; err "Keycloak partialImport failed"; }
+    got=$(jq -r '.added + .overwritten + .skipped' <<< "$body")
+    [ "$got" = "$KC_N" ] || err "Keycloak applied $got of $KC_N users: $body"
+    ok "Keycloak: $(jq -r '"\(.added) added, \(.overwritten) overwritten, \(.skipped) skipped"' <<< "$body")"
+fi
+
+# --- Restore -----------------------------------------------------------------
+for db in "${DBS[@]}"; do
+    log "Restoring $db"
+    sql postgres "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE)"
+    sql postgres "CREATE DATABASE \"$db\" OWNER app TEMPLATE template0 CONNECTION LIMIT 0"
+    if ! "${PGI[@]}" pg_restore -U postgres --no-password -d "$db" --exit-on-error < "$DIR/$db.dump"; then
+        sql postgres "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE)" || warn "could not drop the incomplete $db"
+        err "pg_restore failed for $db; the incomplete database was dropped. Fix the cause and re-run."
+    fi
+    sql postgres "ALTER DATABASE \"$db\" CONNECTION LIMIT -1"
+    ok "$db restored"
+done
+
+ok "Done. The apps reconnect on their own; then: tilt trigger seed-mit-learn-opensearch && tilt trigger seed-mit-learn-qdrant"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

local-dev has been broken since the recent [hardened-image PR](https://github.com/mitodl/ol-infrastructure/pull/5722) updated `ol-python-base`. This fixes that situation.

- **One-Line Fix, Bump k3s**: The fix is a one-line version bump to k3s. Notes:
    - Because this changes the k3s nodes themselves (not just the application images that run within them) *people will lose all local data*. See next bullet.
    - Our previous version v1.31 reached EOL in 2025 anyway (see https://kubernetes.io/releases/patch-releases/)
- **Dump/Restore:** This PR also adds a dump/restore script for local data. This reduces friction when updating cluster-affecting dependencies, making us more likely to do it. Roughly, the script:
    - dumps and restores all local app dbs
    - the keycloak db is not restored because Pulumi owns it, but its users are exported and re-created under their OLD guids

<details>

<summary>More Details</summary>

**Why the pulls fail.** `ol-python-base` is now built on Docker Hardened Images, whose base layers are zstd. Tilt's `docker_build` pushes them into the k3d registry as `application/vnd.docker.image.rootfs.diff.tar.zstd`, a layer type containerd 1.7 (k3s ≤ 1.32) does not accept, so every `mit-learn`/`mitxonline` pod sits in `ImagePullBackOff` with `number of layers and diffIDs don't match`. CI got the equivalent fix in #5722 via `OUTPUT_OCI=true`, which Tilt has no counterpart for. k3s v1.33+ ships containerd 2.x; this PR goes to `rancher/k3s:v1.35.8-k3s1`.

**Why a recreate loses data.** k3d nodes are Docker containers, and every PersistentVolume is `local-path` storage under the node's `/var/lib/rancher/k3s` volume, which `k3d cluster delete` removes. k3d cannot swap a node image in place, so the bump is `teardown.sh` + `setup.sh`. The image registry is a separate named volume and survives, so already-built images pull fine on the new nodes.

**`pg-backup.sh`** dumps every app database (`pg_dump -Fc` via `kubectl exec`, no host Postgres tools) into a gitignored `local-dev/.backups/<timestamp>/`, plus a JSON export of the `olapps` realm's users: ids, hashed passwords, attributes, realm roles.

**`pg-restore.sh <dir>`** re-imports those users through Keycloak's `partialImport`, which keeps their ids so `users_user.global_id` in the restored databases still resolves, then drops and reloads each database. The apps can stay running: each database is created with `CONNECTION LIMIT 0` until its archive has loaded.

**Why not restore the `keycloak` database too.** Pulumi recreates the realm and clients with new ids and secrets, so an old `keycloak` database underneath it gives `404 Realm not found`. Users are the only thing Pulumi doesn't manage, so they are the only thing carried over.

</details>


### How can this be tested?
Full details are in the README's [Backing Up and Restoring Postgres](https://github.com/mitodl/ol-infrastructure/blob/chudzick/local-dev-k3s-containerd2/local-dev/README.md#backing-up-and-restoring-postgres) section. Roughly:

1. Back up local data: `./local-dev/scripts/pg-backup.sh`
2. `./local-dev/scripts/teardown.sh`
3. `./local-dev/scripts/setup.sh`
4. `./local-dev/scripts/start.sh`, and wait for `local-infra-apps` and `kc-seed-users` to go green
5. Restore local data: `./local-dev/scripts/pg-restore.sh local-dev/.backups/<timestamp>`
6. Rebuild the derived stores: `tilt trigger seed-mit-learn-opensearch && tilt trigger seed-mit-learn-qdrant`

The app pods should then pull and run on the new nodes, and your users, logins, and data should be as they were before the teardown.

### Additional Context
- Not in scope: the CNPG chart is also behind (0.23.0 / operator 1.25.0, EOL), but newer charts default to Postgres 18 and the cluster pins no image, so that is its own change.
- Found while recreating: on a fresh cluster, Tilt's `uncategorized` resource (app ConfigMaps/Secrets/Apisix objects) has no `resource_deps` and can apply before Pulumi has created the namespaces; it is never retried. Re-triggering `uncategorized` in the Tilt UI fixes it. Pre-existing, separate fix.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
