### PR TITLE
feat(release-bot): refuse commands for apps still on the legacy pipeline

### DIFF
--- a/src/bridge/settings/apps.py
+++ b/src/bridge/settings/apps.py
@@ -35,11 +35,22 @@ class AppRegistration:
         needs groups:read on the bot token and, for a private channel, the bot
         to have been invited to it. Unset means notifications are skipped for
         this app unless RELEASE_ANNOUNCE_CHANNEL provides a fallback.
+    :param release_resource_workflow: Whether this app runs the modernized
+        release-resource pipeline (calver tags, ``releases/<version>`` branch,
+        release issue, GitHub Deployments) rather than the legacy
+        release-candidate/release branch pattern Doof drives. THE ROLLOUT
+        SWITCH: flipping this one field is what migrates an app, because both
+        control surfaces read it. The pipeline generator emits
+        ``_build_release_resource_app_pipeline`` instead of the legacy shape,
+        and the release bot starts accepting commands for the app -- until
+        then it refuses them, since every command it offers targets a job or
+        an artifact only the modernized pipeline produces.
     """
 
     github_repo: str | None = None
     repo_main_branch: str = "main"
     slack_channel: str | None = None
+    release_resource_workflow: bool = False
 
 
 APPS: dict[str, AppRegistration] = {
@@ -65,7 +76,7 @@ APPS: dict[str, AppRegistration] = {
         repo_main_branch="master", slack_channel="product-ovs"
     ),
     # No app-specific channel given -- falls back to RELEASE_ANNOUNCE_CHANNEL.
-    "ol-analytics-api": AppRegistration(),
+    "ol-analytics-api": AppRegistration(release_resource_workflow=True),
     "xpro": AppRegistration(
         github_repo="mitodl/mitxpro",
         repo_main_branch="master",
@@ -94,6 +105,12 @@ def slack_channel(app_name: str) -> str | None:
     return entry.slack_channel if entry else None
 
 
+def release_resource_workflow(app_name: str) -> bool:
+    """Return whether the given app runs the modernized release-resource pipeline."""
+    entry = APPS.get(app_name)
+    return bool(entry and entry.release_resource_workflow)
+
+
 #: GitHub App id for `ol-release-bot`, the identity the Concourse `release`,
 #: `github-issues` and `github-deployments` resources authenticate as. This is the
 #: APP id (`app_id`), not the installation id -- ruleset bypass actors key on the
@@ -113,8 +130,7 @@ def release_workflow_repos() -> frozenset[str]:
 
     EVERY REGISTERED APP, NOT ONLY THE ONES ALREADY RUNNING THE NEW WORKFLOW. That
     is deliberate and it over-grants on purpose (decision: Tobias, 2026-09-01). The
-    actual opt-in is ``AppPipelineParams.use_release_resource_workflow`` in
-    ``src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py``, which
+    actual opt-in is ``AppRegistration.release_resource_workflow`` above, which
     defaults to ``False`` and today is set on ``ol-analytics-api`` alone -- so the
     consumer below grants a bypass on ``mit-learn`` and ``mitxonline`` for an App
     that does not yet finish their releases.

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
@@ -74,6 +74,11 @@ def meta_pipeline(app_names: list[str]) -> Pipeline:
             "src/ol_concourse/pipelines/constants.py",
             "src/ol_concourse/pipelines/jobs.py",
             "src/ol_concourse/pipelines/secrets_map.py",
+            # build_app_pipeline reads AppRegistration.release_resource_workflow
+            # from here to choose the pipeline shape, so a registry-only edit
+            # has to regenerate. Without this the documented one-field rollout
+            # switch changes nothing that is deployed.
+            "src/bridge/settings/apps.py",
         ],
     )
     pipeline_jobs = [meta_job(app_name) for app_name in app_names]

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -43,6 +43,9 @@ from ol_concourse.lib.tasks import bump_version_task
 from pydantic import BaseModel, model_validator
 
 from bridge.settings.apps import github_repo as app_github_repo
+from bridge.settings.apps import (
+    release_resource_workflow as app_release_resource_workflow,
+)
 from bridge.settings.apps import repo_main_branch as app_repo_main_branch
 from ol_concourse.pipelines.constants import (
     ECR_REGION,
@@ -108,10 +111,6 @@ class AppPipelineParams(BaseModel):
         github_repo (Optional[str]): The GitHub repository in ``owner/repo`` form used for release
             resources and GitHub Deployments. Defaults to ``mitodl/{repo_name}``. Only used by the
             release-resource workflow.
-        use_release_resource_workflow (bool): Opt an app into the modernized GitHub
-            Release/Deployment-based pipeline shape instead of the legacy release-candidate/
-            release git-branch pattern. Defaults to False so existing apps are unaffected;
-            flip per-app once each has been validated on the new shape.
         sentry_sourcemaps (Optional[SentrySourcemapsConfig]): When set, the app's
             image build unpacks its rootfs and a decoupled task uploads the built
             source maps to Sentry with an auth token -- the token never enters the
@@ -139,7 +138,6 @@ class AppPipelineParams(BaseModel):
     version_file: str | None = None
     enable_ci_deploy: bool = True
     github_repo: str | None = None
-    use_release_resource_workflow: bool = False
     sentry_sourcemaps: SentrySourcemapsConfig | None = None
     refresh_stack: bool = True
 
@@ -234,10 +232,7 @@ pipeline_params = {
         build_target="production",
         settings_dir="odl_video",
     ),
-    "ol-analytics-api": AppPipelineParams(
-        app_name="ol-analytics-api",
-        use_release_resource_workflow=True,
-    ),
+    "ol-analytics-api": AppPipelineParams(app_name="ol-analytics-api"),
 }
 
 
@@ -342,7 +337,8 @@ def _ensure_ecr_repository_step(ecr_registry_image_resource: Resource) -> TaskSt
 
 # ============================================================================
 # Legacy workflow: release-candidate/release git-branch pattern.
-# Used by every app except those with use_release_resource_workflow=True.
+# Used by every app whose bridge.settings.apps entry leaves
+# release_resource_workflow False.
 # ============================================================================
 
 
@@ -836,7 +832,9 @@ def _build_legacy_app_pipeline(
 
 # ============================================================================
 # Modernized workflow: GitHub Release resource + GitHub Deployments.
-# Opt in per-app via AppPipelineParams.use_release_resource_workflow.
+# Opt in per-app via AppRegistration.release_resource_workflow in
+# bridge.settings.apps -- the same field the release bot reads to decide
+# whether it will accept commands for the app.
 # ============================================================================
 
 
@@ -1503,13 +1501,17 @@ def build_app_pipeline(app_name: str) -> Pipeline:
     """Generate the full Concourse pipeline for a given application.
 
     Dispatches to the modernized release-resource pipeline shape for apps that
-    have opted in via ``AppPipelineParams.use_release_resource_workflow``, and
-    to the legacy release-candidate/release-branch shape for everyone else.
+    have opted in via ``AppRegistration.release_resource_workflow`` in
+    ``bridge.settings.apps``, and to the legacy release-candidate/release-branch
+    shape for everyone else. The opt-in lives in the shared registry rather than
+    in ``pipeline_params`` because the release bot has to make the same call, and
+    a per-app flag duplicated across the two would let a pipeline be migrated
+    while the bot still refuses to drive it.
     """
     pipeline_parameters = pipeline_params.get(app_name) or AppPipelineParams(
         app_name=app_name
     )
-    if pipeline_parameters.use_release_resource_workflow:
+    if app_release_resource_workflow(app_name):
         return _build_release_resource_app_pipeline(app_name, pipeline_parameters)
     return _build_legacy_app_pipeline(app_name, pipeline_parameters)
 

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -665,6 +665,18 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-infrastructure-release-bot",
         stages=["default"],
         topology="preview-gated",
+        # __main__.py builds REPOS_CONFIG out of bridge.settings.apps, so an
+        # edit there (an app's channel, or the release_resource_workflow flag
+        # that migrates it) has to redeploy the bot. Nothing else watched here
+        # covers it: the registry is outside PULUMI_WATCHED_PATHS and outside
+        # this app's own project path.
+        #
+        # This also re-triggers the image build, which does not need it -- the
+        # Dockerfile copies only release_bot/*.py, so the registry is not in
+        # the image. Accepted rather than adding a deploy-only path list for
+        # one app: the cost is one redundant build per registry edit, and the
+        # deploy that follows was going to happen anyway.
+        additional_watched_paths=["src/bridge/settings/apps.py"],
         # __main__.py is a singleton (stack "default") and always creates the
         # ECR repository named "release-bot-production" regardless of stage.
         docker_image=DockerImageConfig(

--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -21,6 +21,9 @@ from pulumi import Config, export, log
 from bridge.secrets.sops import read_yaml_secrets
 from bridge.settings.apps import APPS
 from bridge.settings.apps import github_repo as app_github_repo
+from bridge.settings.apps import (
+    release_resource_workflow as app_release_resource_workflow,
+)
 from bridge.settings.apps import repo_main_branch as app_repo_main_branch
 from bridge.settings.apps import slack_channel as app_slack_channel
 from ol_infrastructure.lib import pulumi_projects as projects
@@ -87,6 +90,13 @@ default_repos_config = {
         "pipeline": f"{app_name}-pipeline",
         "repo": app_github_repo(app_name),
         "branch": app_repo_main_branch(app_name),
+        # Apps still on the legacy release-candidate/release pipeline are
+        # published here too, and the bot refuses their release commands
+        # rather than dropping them from its vocabulary: "still on the legacy
+        # pipeline" is the answer someone typing `/doof release <app>` needs,
+        # and it is also what makes the rollout a one-field change in
+        # bridge.settings.apps.
+        "release_workflow": app_release_resource_workflow(app_name),
         **(
             {"channel": app_slack_channel(app_name)}
             if app_slack_channel(app_name)

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -59,13 +59,39 @@ def _describe_in_flight(in_flight: dict[str, Any]) -> str:
     return f"<{in_flight['url']}|{in_flight['version']}>{when}"
 
 
+def _resolve_app(repos, app_name):
+    """Return (cfg, None) for an app this bot can drive, else (None, error).
+
+    Refusing a legacy-pipeline app here is the whole point. Every registered
+    app is offered in the command surface, but the jobs and artifacts these
+    handlers reach for -- `build-<app>-release-image`, `<app>-release-gate`,
+    the `releases/<version>` branch, the release issue, the calver tags
+    `release_preview` counts commits against -- exist only in the modernized
+    pipeline shape. Against a legacy app the mutating commands 404 in
+    Concourse with no hint as to why, and the read-only ones are worse: they
+    return confidently wrong answers, because a repo with no calver tag reads
+    as "never released" and `/doof preview` then reports the entire history as
+    the next release's contents.
+    """
+    if app_name not in repos:
+        return None, f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}"
+    cfg = repos[app_name]
+    if not cfg.release_workflow:
+        return None, (
+            f"`{app_name}` is still on the legacy release-candidate/release "
+            "pipeline, which this bot does not drive. Doof still owns its "
+            "releases until the pipeline is migrated."
+        )
+    return cfg, None
+
+
 async def _cmd_release(repos, ack, respond, command, context):
     await ack()
     app_name = command["text"].strip()
-    if app_name not in repos:
-        await respond(f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
         return
-    cfg = repos[app_name]
 
     # Report a release that was cut but never finished. Cutting a new one
     # supersedes it on action=create, so say so rather than letting a branch
@@ -125,10 +151,10 @@ async def _cmd_preview(repos, ack, respond, command, _context):
     """Show what the next release would contain, without triggering anything."""
     await ack()
     app_name = command["text"].strip()
-    if app_name not in repos:
-        await respond(f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
         return
-    cfg = repos[app_name]
     try:
         preview = await github.release_preview(cfg.repo)
     except Exception:
@@ -162,10 +188,10 @@ async def _cmd_preview(repos, ack, respond, command, _context):
 async def _cmd_release_notes(repos, ack, respond, command, _context):
     await ack()
     app_name = command["text"].strip()
-    if app_name not in repos:
-        await respond(f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
         return
-    cfg = repos[app_name]
     try:
         commits = await github.commits_since_last_tag(cfg.repo)
     except Exception:
@@ -184,10 +210,22 @@ async def _cmd_release_notes(repos, ack, respond, command, _context):
 async def _cmd_release_status(repos, ack, respond, command, _context):
     await ack()
     app_filter = command["text"].strip() or None
-    if app_filter and app_filter not in repos:
-        await respond(f"Unknown app `{app_filter}`. Known apps: {', '.join(repos)}")
+    if app_filter:
+        cfg, error = _resolve_app(repos, app_filter)
+        if cfg is None:
+            await respond(error)
+            return
+        targets = {app_filter: cfg}
+    else:
+        targets = config.release_workflow_apps(repos)
+    legacy = [name for name, cfg in repos.items() if not cfg.release_workflow]
+    if not targets:
+        await respond(
+            "No apps are on the release-resource workflow yet, so there is no "
+            f"release status to report. Still on the legacy pipeline: "
+            f"{', '.join(legacy)}."
+        )
         return
-    targets = {app_filter: repos[app_filter]} if app_filter else repos
     lines = []
     for name, cfg in targets.items():
         try:
@@ -212,16 +250,22 @@ async def _cmd_release_status(repos, ack, respond, command, _context):
         if in_flight:
             status += f" · 🚧 in flight: {_describe_in_flight(in_flight)}"
         lines.append(f"• *{name}*: {status}")
+    if legacy and not app_filter:
+        # Naming them keeps a silently short list from reading as "everything
+        # is quiet" during the rollout, when most apps are still on Doof.
+        lines.append(
+            f"_Not shown -- still on the legacy pipeline: {', '.join(legacy)}._"
+        )
     await respond("\n".join(lines))
 
 
 async def _cmd_promote(repos, ack, respond, command, context):
     await ack()
     app_name = command["text"].strip()
-    if app_name not in repos:
-        await respond(f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
         return
-    cfg = repos[app_name]
     try:
         issues = await github.open_release_issues(cfg.repo)
     except Exception:
@@ -273,10 +317,10 @@ async def _cmd_publish(repos, ack, respond, command, _context):
 async def _cmd_abandon(repos, ack, respond, command, _context):
     await ack()
     app_name = command["text"].strip()
-    if app_name not in repos:
-        await respond(f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
         return
-    cfg = repos[app_name]
     try:
         build_url = await concourse.trigger_job(
             cfg.pipeline, f"abandon-{app_name}-release"
@@ -293,10 +337,10 @@ async def _handle_promote_button(repos, ack, body, say):
     await ack()
     value = body["actions"][0]["value"]
     app_name, version = value.split(":", 1)
-    if app_name not in repos:
-        await say(f"⚠️ Unknown app `{app_name}`.")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await say(f"⚠️ {error}")
         return
-    cfg = repos[app_name]
     user_id = body["user"]["id"]
     try:
         issues = await github.open_release_issues(cfg.repo)
@@ -418,9 +462,10 @@ def _checkbox_watch_preflight(repos, app_name):
     caller, so the `_slack_app is None` check below is what narrows the type
     for everything downstream.
     """
-    if app_name not in repos:
-        return None, None, f"Unknown app `{app_name}`. Known apps: {', '.join(repos)}"
-    channel = repos[app_name].channel or os.environ.get("RELEASE_ANNOUNCE_CHANNEL")
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        return None, None, error
+    channel = cfg.channel or os.environ.get("RELEASE_ANNOUNCE_CHANNEL")
     if not channel:
         return (
             None,
@@ -921,9 +966,19 @@ async def _report_unreachable_channels(app, repos) -> None:
 
 async def main():
     app, repos = create_app()
+    # Channel reachability is checked across every registered app, including
+    # the legacy ones: an unresolvable channel is the kind of thing you want
+    # to have found before the app is migrated, not on its first release.
     await _report_unreachable_channels(app, repos)
-    asyncio.create_task(_poll_ready_to_promote_loop(app, repos))  # noqa: RUF006
-    asyncio.create_task(_poll_release_progress_loop(app, repos))  # noqa: RUF006
+    watched = config.release_workflow_apps(repos)
+    log.info(
+        "Polling %s of %s registered app(s) on the release-resource workflow: %s",
+        len(watched),
+        len(repos),
+        ", ".join(watched) or "none",
+    )
+    asyncio.create_task(_poll_ready_to_promote_loop(app, watched))  # noqa: RUF006
+    asyncio.create_task(_poll_release_progress_loop(app, watched))  # noqa: RUF006
     handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
     await handler.start_async()
 

--- a/src/ol_infrastructure/applications/release_bot/bot_config.py
+++ b/src/ol_infrastructure/applications/release_bot/bot_config.py
@@ -13,6 +13,20 @@ class AppConfig:
     # Slack channel ID for proactive (non-slash-command) notifications, e.g.
     # "ready to promote". Falls back to RELEASE_ANNOUNCE_CHANNEL if unset.
     channel: str | None = None
+    # Whether the app's Concourse pipeline is the modernized release-resource
+    # shape. Mirrors AppRegistration.release_resource_workflow in
+    # bridge.settings.apps, which __main__.py copies into REPOS_CONFIG. False
+    # means every release command the bot offers would target a job or an
+    # artifact that app's pipeline does not have, so the handlers refuse
+    # instead. Defaults False: an app absent from a hand-written repos_config
+    # override gets the refusal, which says what is wrong, rather than an
+    # opaque Concourse 404.
+    release_workflow: bool = False
+
+
+def release_workflow_apps(repos: dict[str, AppConfig]) -> dict[str, AppConfig]:
+    """Return only the apps whose pipeline the bot can actually drive."""
+    return {name: cfg for name, cfg in repos.items() if cfg.release_workflow}
 
 
 def load_repos_config() -> dict[str, AppConfig]:

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -214,7 +214,7 @@ def _required_checks_bypass(
     never pushes to it.
 
     THAT SET IS WIDER THAN THE REPOS ACTUALLY ON THE NEW WORKFLOW, deliberately.
-    `AppPipelineParams.use_release_resource_workflow` is the real opt-in and today
+    `AppRegistration.release_resource_workflow` is the real opt-in and today
     only `ol-analytics-api` sets it, so `mit-learn` and `mitxonline` get a bypass here
     before the App releases them. `release_workflow_repos()` carries the reasoning and
     the conditions for narrowing it later; the short version is that pre-granting

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -4,6 +4,7 @@ The handlers take their Slack callables (ack/respond) as arguments, so they
 can be driven directly with async stubs -- no Slack app or socket needed.
 """
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -1314,12 +1315,60 @@ async def test_release_status_queries_only_migrated_apps(
     assert queried == ["mitodl/my-app"]
 
 
-async def test_ready_to_promote_poll_skips_legacy_apps(mixed_repos):
+async def test_main_polls_only_migrated_apps(mixed_repos, monkeypatch):
     """Polling a legacy repo every 120s is a guaranteed miss on rate limit.
 
-    `main()` is what narrows the polled set, so this asserts the filter the
-    two poll loops are handed rather than the loops themselves.
+    Driven through `main()` rather than through the filter helper, because
+    the helper being correct proves nothing if `main()` hands either loop the
+    unfiltered mapping -- which is the wiring that would actually regress.
     """
-    watched = bot_config.release_workflow_apps(mixed_repos)
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
+    app = MagicMock()
+    monkeypatch.setattr(bot, "create_app", lambda: (app, mixed_repos))
+    monkeypatch.setattr(bot, "_report_unreachable_channels", AsyncMock())
 
-    assert list(watched) == ["my-app"]
+    polled: list[list[str]] = []
+
+    async def _loop(_app, repos):
+        polled.append(list(repos))
+
+    monkeypatch.setattr(bot, "_poll_ready_to_promote_loop", _loop)
+    monkeypatch.setattr(bot, "_poll_release_progress_loop", _loop)
+    handler = MagicMock()
+    handler.start_async = AsyncMock()
+    monkeypatch.setattr(bot, "AsyncSocketModeHandler", MagicMock(return_value=handler))
+
+    await bot.main()
+    # main() starts the loops with create_task and then blocks on the socket
+    # handler; yield once so both scheduled tasks actually run.
+    await asyncio.sleep(0)
+
+    assert polled == [["my-app"], ["my-app"]]
+    handler.start_async.assert_awaited_once()
+
+
+async def test_startup_channel_check_still_covers_legacy_apps(mixed_repos, monkeypatch):
+    """Narrowing the pollers must not narrow the boot-time channel check.
+
+    An unreachable channel is worth finding before an app is migrated, not on
+    its first release.
+    """
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
+    checked = AsyncMock()
+    monkeypatch.setattr(bot, "create_app", lambda: (MagicMock(), mixed_repos))
+    monkeypatch.setattr(bot, "_report_unreachable_channels", checked)
+
+    async def _loop(_app, _repos):
+        return
+
+    monkeypatch.setattr(bot, "_poll_ready_to_promote_loop", _loop)
+    monkeypatch.setattr(bot, "_poll_release_progress_loop", _loop)
+    handler = MagicMock()
+    handler.start_async = AsyncMock()
+    monkeypatch.setattr(bot, "AsyncSocketModeHandler", MagicMock(return_value=handler))
+
+    await bot.main()
+    await asyncio.sleep(0)
+
+    checked.assert_awaited_once()
+    assert list(checked.await_args_list[0].args[1]) == ["my-app", "legacy-app"]

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -22,8 +22,25 @@ def repos():
             repo="mitodl/my-app",
             branch="main",
             channel="C123",
+            release_workflow=True,
         )
     }
+
+
+@pytest.fixture
+def mixed_repos(repos):
+    """One migrated app alongside one still on the legacy pipeline."""
+    return dict(
+        repos,
+        **{
+            "legacy-app": bot_config.AppConfig(
+                pipeline="legacy-app-pipeline",
+                repo="mitodl/legacy-app",
+                branch="master",
+                channel="C456",
+            )
+        },
+    )
 
 
 @pytest.fixture
@@ -1152,3 +1169,157 @@ async def test_startup_check_survives_a_slack_failure(repos, monkeypatch):
     )
 
     await bot._report_unreachable_channels(MagicMock(), repos)
+
+
+async def test_release_refuses_an_app_still_on_the_legacy_pipeline(
+    mixed_repos, slack, monkeypatch
+):
+    """`build-<app>-release-image` does not exist in the legacy pipeline.
+
+    Triggering it 404s in Concourse with nothing in the message that explains
+    why, so the refusal has to happen before the call.
+    """
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(bot.concourse, "check_resource", AsyncMock())
+    monkeypatch.setattr(
+        bot.concourse, "trigger_job", AsyncMock(side_effect=_record_trigger(calls))
+    )
+    monkeypatch.setattr(bot.github, "in_flight_release", AsyncMock(return_value=None))
+
+    await bot._cmd_release(
+        mixed_repos, slack.ack, slack.respond, _command("legacy-app"), {}
+    )
+
+    assert calls == []
+    assert "legacy" in slack.said
+    assert "Doof" in slack.said
+
+
+async def test_preview_refuses_a_legacy_app_rather_than_answering_wrongly(
+    mixed_repos, slack, monkeypatch
+):
+    """A repo with no calver tag reads as never-released.
+
+    `release_preview` would then report the whole commit history as the next
+    release's contents -- a confidently wrong answer, which is worse than the
+    404 the mutating commands get.
+    """
+    preview = AsyncMock()
+    monkeypatch.setattr(bot.github, "release_preview", preview)
+
+    await bot._cmd_preview(
+        mixed_repos, slack.ack, slack.respond, _command("legacy-app"), {}
+    )
+
+    preview.assert_not_awaited()
+    assert "legacy" in slack.said
+
+
+async def test_promote_refuses_a_legacy_app(mixed_repos, slack, monkeypatch):
+    """Closing a release issue is only half of promote; the gate is the rest."""
+    close = AsyncMock()
+    monkeypatch.setattr(bot.github, "open_release_issues", AsyncMock(return_value=[]))
+    monkeypatch.setattr(bot.github, "close_release_issue", close)
+
+    await bot._cmd_promote(
+        mixed_repos, slack.ack, slack.respond, _command("legacy-app"), {"user_id": "U1"}
+    )
+
+    close.assert_not_awaited()
+    assert "legacy" in slack.said
+
+
+async def test_abandon_refuses_a_legacy_app(mixed_repos, slack, monkeypatch):
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        bot.concourse, "trigger_job", AsyncMock(side_effect=_record_trigger(calls))
+    )
+
+    await bot._cmd_abandon(
+        mixed_repos, slack.ack, slack.respond, _command("legacy-app"), {}
+    )
+
+    assert calls == []
+    assert "legacy" in slack.said
+
+
+async def test_promote_button_refuses_a_legacy_app(mixed_repos, monkeypatch):
+    """The button carries an app name from a message, so it is not trusted."""
+    close = AsyncMock()
+    monkeypatch.setattr(bot.github, "open_release_issues", AsyncMock(return_value=[]))
+    monkeypatch.setattr(bot.github, "close_release_issue", close)
+    say = AsyncMock()
+
+    await bot._handle_promote_button(
+        mixed_repos,
+        AsyncMock(),
+        {"actions": [{"value": "legacy-app:2026.9.5.1"}], "user": {"id": "U1"}},
+        say,
+    )
+
+    close.assert_not_awaited()
+    assert "legacy" in str(say.call_args.args[0])
+
+
+async def test_wait_for_checkboxes_refuses_a_legacy_app(
+    mixed_repos, slack, monkeypatch
+):
+    """No release issue is ever created for a legacy app, so nothing to watch."""
+    monkeypatch.setattr(bot, "_slack_app", MagicMock())
+    issues = AsyncMock(return_value=[])
+    monkeypatch.setattr(bot.github, "open_release_issues", issues)
+
+    await bot._cmd_wait_for_checkboxes(
+        mixed_repos, slack.ack, slack.respond, _command("legacy-app"), {}
+    )
+
+    issues.assert_not_awaited()
+    assert "legacy-app" not in bot._checkbox_watchers
+    assert "legacy" in slack.said
+
+
+async def test_release_status_names_the_apps_it_left_out(
+    mixed_repos, slack, monkeypatch
+):
+    """A short list must not read as "everything is quiet" during the rollout."""
+    monkeypatch.setattr(bot.github, "open_release_issues", AsyncMock(return_value=[]))
+    monkeypatch.setattr(bot.github, "in_flight_release", AsyncMock(return_value=None))
+
+    await bot._cmd_release_status(
+        mixed_repos, slack.ack, slack.respond, _command(""), {}
+    )
+
+    said = slack.said
+    assert "my-app" in said
+    assert "legacy-app" in said
+    assert "legacy pipeline" in said
+
+
+async def test_release_status_queries_only_migrated_apps(
+    mixed_repos, slack, monkeypatch
+):
+    queried: list[str] = []
+
+    async def _issues(repo_slug):
+        queried.append(repo_slug)
+        return []
+
+    monkeypatch.setattr(bot.github, "open_release_issues", _issues)
+    monkeypatch.setattr(bot.github, "in_flight_release", AsyncMock(return_value=None))
+
+    await bot._cmd_release_status(
+        mixed_repos, slack.ack, slack.respond, _command(""), {}
+    )
+
+    assert queried == ["mitodl/my-app"]
+
+
+async def test_ready_to_promote_poll_skips_legacy_apps(mixed_repos):
+    """Polling a legacy repo every 120s is a guaranteed miss on rate limit.
+
+    `main()` is what narrows the polled set, so this asserts the filter the
+    two poll loops are handed rather than the loops themselves.
+    """
+    watched = bot_config.release_workflow_apps(mixed_repos)
+
+    assert list(watched) == ["my-app"]


### PR DESCRIPTION
## What are the relevant tickets?

Part of the release-workflow rollout under mitodl/hq#7185. Directly addresses the open note on the rollout: *"Consider whether the bot should refuse commands for legacy-pipeline apps in the meantime rather than failing at the Concourse call."*

## Description (What does this do?)

Eight of the nine apps in `src/bridge/settings/apps.py` still run the legacy release-candidate/release pipeline, but all nine are offered in the release bot's command surface. The jobs and artifacts the handlers reach for — `build-<app>-release-image`, `<app>-release-gate`, the `releases/<version>` branch, the release issue, the calver tags `release_preview` counts commits against — exist only in the modernized release-resource pipeline.

So today:

- `/doof release mit-learn` triggers a job no legacy pipeline defines. Concourse 404s, and the bot answers `❌ Failed to trigger release for mit-learn. Check logs.`
- `/doof preview mit-learn` is worse, because it fails silently rather than loudly. `_RELEASE_TAG_RE` (`github_client.py:31`) matches calver only, so a repo tagged with semver reads as never-released. `_commits_since_last_tag_sync` then falls back to `repo.get_commits()`, truncated at `_COMMIT_LIST_LIMIT = 50` with no notice, and the reply presents the 50 most recent commits on the default branch as the next release's contents under a confident "next version would be `2026.9.5.1`".

This adds a single guard (`_resolve_app`) in front of the app-scoped handlers, and moves the opt-in into the shared registry so one field drives both control surfaces.

### The registry field

`AppPipelineParams.use_release_resource_workflow` → `AppRegistration.release_resource_workflow` in `bridge.settings.apps`.

The bot's Pulumi program cannot import `pipeline_params`, and duplicating the flag would let an app be migrated while the bot still refused to drive it. `bridge.settings.apps` is already documented as the one place an app's repo, branch and channel live; the workflow it runs belongs there too. Flipping an app in the rollout is now a one-field change that moves the pipeline shape *and* the bot together.

`release_workflow_repos()` and `rulesets.py` both had docstrings naming the old field as "the real opt-in"; both now point at the new one.

**The registry had to be added to both control surfaces' trigger paths for any of this to be true** (thanks @copilot-pull-request-reviewer — this was a regression the first push introduced, not a pre-existing gap). The opt-in used to live in `k8s_apps/pipeline.py`, which is under the meta pipeline's git-resource paths; moving it to `src/bridge/settings/apps.py` took pipeline regeneration out of every trigger set, and the release-bot's `SimplePulumiParams` entry never watched the registry either. A flip would have changed nothing that is deployed, on either surface. Fixed in 4c7679a09:

- `k8s_apps/meta.py` paths gained `src/bridge/settings/apps.py`
- the release-bot entry gained `additional_watched_paths=["src/bridge/settings/apps.py"]`

Verified by building the resources rather than reading the literals. That field also feeds `release-bot-docker-source`, so a registry edit re-triggers an image build the Dockerfile does not need (it copies only `release_bot/*.py`); accepted over adding a deploy-only path list for one app, and documented in the code.

A third consumer — `saas/github/repositories/rulesets.py`, via `release_workflow_repos()` — has the same gap. Deliberately **not** fixed here: it applies GitHub rulesets, which does not belong in a release-bot PR. Tracked separately.

### Behavior changes

| Command | Legacy app, before | Legacy app, after |
|---|---|---|
| `release` / `promote` / `abandon` | Concourse 404, "Check logs" | Refused, names the reason |
| `preview` / `release-notes` | Up to 50 commits, wrong version | Refused |
| `wait-for-checkboxes` | "No open release issue found" | Refused |
| `release-status <app>` | "✅ no open release" | Refused |
| `release-status` (all) | Reports every app as clean | Reports migrated apps; names the omitted ones |
| promote button | "Unknown app" only | Refused |

`release-status` with no argument gets the extra line deliberately. A list showing one app during a nine-app rollout reads as "everything is quiet" unless it says what it left out.

`/doof publish` is deliberately untouched — it targets the library publish pipelines rather than an app's release pipeline, and has its own fix in flight in #5751.

### Poller scope

`_poll_ready_to_promote_loop` and `_poll_release_progress_loop` now run over migrated apps only. A legacy repo has no release issue, no GitHub Deployment and no `releases/` branch, so each cycle spent eight guaranteed misses against the GitHub rate limit.

Startup channel validation still covers every registered app. An unreachable channel is worth finding before an app is migrated, not on its first release — that is the check #5740 added.

## How can this be tested?

Automated: 9 new tests in `tests/ol_infrastructure/applications/release_bot/test_bot.py`, one per refusal path plus the poller filter. 132 pass in that package, 980 in the rest of the suite. `pre-commit` (ruff format, ruff check, mypy) clean.

Pipeline generator is provably inert. All nine app pipelines were generated on the base branch and on this branch and diffed:

```
diff -rq before/ after/   ->   no differences
```

Bot side verified with `pulumi preview` against the live `default` stack, image pinned to the currently-deployed digest so the diff is the config alone:

```
~ 1 to update, 3 unchanged
  REPOS_CONFIG:
    + release_workflow: true    (ol-analytics-api)
    + release_workflow: false   (the other eight)
```

One Deployment update, no image change, no secret change. The rollout it causes is expected: `REPOS_CONFIG` is an env var in the pod spec.

## Additional Notes

This does **not** migrate any app. `ol-analytics-api` remains the only one on the new workflow.

**Correcting an earlier version of this section**, which listed two outstanding preconditions for the next flip. One is now proven, and the other is what merging this PR resolves.

**`action: finish` works.** It ran automatically and succeeded on 2026-09-03, two days after the org ruleset bypass was added, so the "not proven end-to-end" caveat is closed:

- `deploy-ol-application-ol-analytics-api-production` builds 15 and 16 both **succeeded** (11 through 14 had all failed).
- Commit `80a2cc21 Merge releases/2026.9.3.1`, authored *and* committed by `Concourse CI <concourse@example.com>` at 20:40:16Z — inside build 16's 20:37:44–20:40:58Z window — with parents `f7a70fb8` (main) and `39b9143c` (`Release 2026.9.3.1`). That is `_finish_release`'s merge-and-push, not a human.
- No `releases/*` branch survives on the repo, and `current_version` on `main` is now `2026.9.3.1`, so the version bump propagated back.

Contrast `2026.8.28.2`, whose merge-back (`14b644e0`) had to be done by hand as PR #43 on 2026-09-01.

**The pipeline regeneration is the one thing left, and this PR is the trigger for it.** Confirmed against the live pipelines with `fly -t odl-inf get-pipeline`:

| pipeline | `PYPROJECT_TABLE` | `NEEDS_SEED` | has `bump-version` |
|---|---|---|---|
| ol-analytics-api | 0 | 0 | yes |
| other eight | 0 | 0 | no (legacy shape) |

`ol-analytics-api-pipeline` still carries the pre-fix task: the naive `content.replace('current_version = "<candidate>"', ...)` that no-ops when the key is absent, followed by an unconditional `print("Updated pyproject.toml current_version tracking")`. That is exactly the shape that fails on the six repos with no `current_version`.

It has not regenerated because `k8s_apps/meta.py:71-77` triggers on `pyproject.toml` and not `uv.lock`, so #5742's lock-only bump fired nothing. This PR edits a file under the `src/ol_concourse/pipelines/infrastructure/k8s_apps/` trigger path, so merging it regenerates all nine through the 0.18.1 image.

Note the discriminator only means anything for an app on the new workflow — the eight legacy pipelines have no `bump-version` task at all, so their `0` is not evidence of anything until they are flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUs4cSDFJyV1wHJYm6zgYs


