### PR TITLE
feat(edxapp): give xPRO's MFE footer its logo and the header a marketing base URL

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -377,8 +377,21 @@ def _build_interpolated_config_dict(
                 "aboutUrl": f"https://{marketing_domain}/about-us",
                 "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
                 "copyrightText": "\u00a9 MIT xPRO. All rights reserved except where noted.",
+                # The xPRO logo linked to the marketing site, the pairing the
+                # legacy footer used (LOGO_URL + MARKETING_SITE_BASE_URL in
+                # xpro/common-mfe-config.env.jsx). Unset, the Site Project footer
+                # falls back to headerLogoImageUrl and renders it unlinked.
+                "footerLogoUrl": config["LOGO_URL"],
+                "footerLogoDestination": f"https://{marketing_domain}",
             }
         )
+        # Dashboard / Profile / Settings in the xPRO user menu are built as
+        # `${marketingSiteBaseUrl}/dashboard` etc. Unset, that resolves to a
+        # relative "/dashboard" on the LMS host. No trailing slash: the
+        # components append their own path segment.
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolHeader"] = {
+            "marketingSiteBaseUrl": f"https://{marketing_domain}",
+        }
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":


### PR DESCRIPTION
## What

Two `FRONTEND_SITE_CONFIG.commonAppConfig` keys the xPRO Site Project config never set. On Production they resolve to:

| Key | Value |
|---|---|
| `mitolFooter.footerLogoUrl` | `https://courses.xpro.mit.edu/static/xpro/images/logo.svg` (`LOGO_URL`) |
| `mitolFooter.footerLogoDestination` | `https://xpro.mit.edu` |
| `mitolHeader.marketingSiteBaseUrl` | `https://xpro.mit.edu` |

## Why

- **No footer logo.** The shared footer component falls back to `headerLogoImageUrl` and renders it without a link. The legacy xPRO footer paired `LOGO_URL` with `MARKETING_SITE_BASE_URL` (`xpro/common-mfe-config.env.jsx`) — note xPRO uses `LOGO_URL`, not the trademark mark that mitx and mitxonline use.
- **No header base URL.** `mitolHeader` was absent entirely, and the xPRO user menu builds `${marketingSiteBaseUrl}/dashboard`, `/profile/` and `/account-settings/` — so those resolved to relative paths on the LMS host instead of `xpro.mit.edu`. No trailing slash on either value; the components append their own segment.

Split out of #4893, which is scoped to the MITx and MITxOnline footers, so this gets its own review from whoever owns xPRO.

## Two things worth knowing before merging

**This is a no-op on xPRO today.** Both MFE config endpoints 404 there — `/api/frontend_site_config/v1/` and `/api/mfe_config/v1` — while mitx, mitxonline and RC all return 200. Nothing consumes `FRONTEND_SITE_CONFIG` on xPRO yet, so this lands the config for when the Site Project ships there rather than changing anything now. Worth confirming why those endpoints are off, separately from this PR.

**Conflicts with #4893.** That PR rewrites xPRO's `copyrightText` on the line immediately above these additions, so whichever merges second needs a one-line rebase. No logical overlap.

## How to test

Config-only; no code paths change.

1. `pulumi preview` on `applications.edxapp.xpro.Production` (or QA/CI) → the only diff is the three keys above inside `FRONTEND_SITE_CONFIG.commonAppConfig`. Confirm no other deployment's configmap moves.
2. Once the config API is enabled on xPRO, after applying:
   ```bash
   curl -s https://courses.xpro.mit.edu/api/frontend_site_config/v1/ | jq .commonAppConfig
   ```
   `mitolFooter` should carry both logo keys and `mitolHeader` should no longer be `null`.
3. Then open an xPRO frontend-base MFE and check the footer logo is the xPRO mark, clicking it goes to `xpro.mit.edu`, and the user menu's Dashboard / Profile / Settings point at `xpro.mit.edu` rather than the LMS host.
