### PR TITLE
feat(local-dev): add analytics-api stub for testing B2B dashboard PRs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -228,6 +228,18 @@ APPS = [
             },
         ],
     },
+    {
+        # Stub for ol-analytics-api (B2B analytics gateway). No sibling repo /
+        # image — the Tiltfile runs a stdlib HTTP server serving fixture data.
+        # Lives in the mit-learn namespace (reuses its OIDC secret + CORS
+        # plugin config). No backend pod, so no seed commands.
+        "name": "analytics-api",
+        "dir": "analytics-api",
+        "namespace": "mit-learn",
+        "deploy_name": "analytics-api",
+        "tiltfile": "./local-dev/apps/analytics-api/Tiltfile",
+        "seed_commands": [],
+    },
 ]
 
 # ---------------------------------------------------------------------------

--- a/local-dev/apps/analytics-api/Tiltfile
+++ b/local-dev/apps/analytics-api/Tiltfile
@@ -1,0 +1,37 @@
+# analytics-api (stub) Tiltfile
+#
+# Stands in for ol-analytics-api (the B2B analytics gateway) in local dev. There
+# is no sibling repo checkout and no published image: the "service" is a
+# zero-dependency stdlib HTTP server (stub_app.py) that returns fixture data for
+# the mit-learn b2b_dashboard endpoints. See stub_app.py for why it's a stub.
+#
+# The stub source is shipped as a ConfigMap generated here from stub_app.py, so
+# stub_app.py stays a normal, editable file and the two never drift. Editing
+# stub_app.py triggers Tilt to re-apply the ConfigMap; restart the deployment to
+# pick it up (Tilt does this automatically on ConfigMap change).
+
+load("../../tiltlib.star", "k8s_yaml_local")
+
+# Generate the ConfigMap holding the stub source from the .py file (single
+# source of truth — the deployment mounts it at /app/stub_app.py).
+stub_src = str(read_file("stub_app.py"))
+k8s_yaml(encode_yaml({
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+        "name": "analytics-api-stub-src",
+        "namespace": "mit-learn",
+        "labels": {"app": "analytics-api"},
+    },
+    "data": {"stub_app.py": stub_src},
+}))
+
+# Route host (api.learn.mit.dev) is rewritten when LOCAL_DEV_ROOT_DOMAIN != mit.dev.
+k8s_yaml_local(["deployment.yaml", "apisix-routes.yaml"])
+
+k8s_resource(
+    "analytics-api",
+    port_forwards=["8070:8070"],
+    labels=["mit-learn"],
+    resource_deps=["local-infra-apps"],
+)

--- a/local-dev/apps/analytics-api/apisix-routes.yaml
+++ b/local-dev/apps/analytics-api/apisix-routes.yaml
@@ -1,0 +1,68 @@
+---
+# APISIX route for the (stubbed) ol-analytics-api.
+#
+# Modeled on mit-learn's `mitlearn-route-prefix`: it lives on the same host
+# (api.learn.mit.dev) so the `.mit.dev` session cookie is sent, strips the
+# `/analytics/` prefix before forwarding, and carries the exact same
+# `openid-connect` plugin config the other authed mit-learn routes use so the
+# session cookie is resolved into the JWT the analytics API expects.
+#
+# Frontend base URL: NEXT_PUBLIC_ANALYTICS_API_BASE_URL=https://api.learn.mit.dev/analytics/
+# so a client call to `/api/v1/analytics/organizations/<uuid>/<resource>` hits
+# `/analytics/api/v1/analytics/organizations/<uuid>/<resource>` here, and the
+# proxy-rewrite strips `/analytics/` back to what the stub serves.
+#
+# Reuses mit-learn's `mitlearn-shared-plugins` (CORS for https://learn.mit.dev,
+# HTTP->HTTPS redirect, Referrer-Policy, prometheus) and `ol-mitlearn-oidc`
+# secret, both created in the mit-learn namespace. This route therefore must
+# live in the mit-learn namespace too.
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: analytics-route-prefix
+  namespace: mit-learn
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: passauth
+    # Higher than the mit-learn no-prefix `/*` passauth route (priority 0) so
+    # /analytics/* is always matched here rather than falling through to the
+    # Django backend.
+    priority: 10
+    match:
+      hosts:
+      - api.learn.mit.dev
+      paths:
+      - "/analytics/*"
+    backends:
+    - serviceName: analytics-api
+      servicePort: 8070
+    plugin_config_name: mitlearn-shared-plugins
+    plugins:
+    - name: proxy-rewrite
+      enable: true
+      config:
+        regex_uri:
+        - "/analytics/(.*)"
+        - "/$1"
+    - name: openid-connect
+      enable: true
+      secretRef: ol-mitlearn-oidc  # pragma: allowlist secret
+      config:
+        discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
+        use_jwks: true
+        bearer_only: false
+        realm: olapps
+        introspection_endpoint_auth_method: client_secret_post
+        scope: "openid profile email ol-profile"
+        # Reuse the no-prefix callback (a valid registered redirect URI). With
+        # unauth_action=pass the callback is not exercised for this read-only
+        # route — the session cookie set by the main api.learn.mit.dev login
+        # (same session secret) is read directly.
+        redirect_uri: "https://api.learn.mit.dev/login/ol-oidc/callback/"
+        logout_path: "/logout/oidc"
+        post_logout_redirect_uri: "https://api.learn.mit.dev/logout/"
+        unauth_action: pass
+        session:
+          secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+        ssl_verify: false

--- a/local-dev/apps/analytics-api/deployment.yaml
+++ b/local-dev/apps/analytics-api/deployment.yaml
@@ -1,0 +1,80 @@
+---
+# Local-dev stub for ol-analytics-api (the B2B analytics gateway).
+#
+# The real service reads dbt-materialized views out of StarRocks, which is not
+# run in this stack. This Deployment runs a zero-dependency stdlib HTTP server
+# (see stub_app.py) that serves the same endpoints/envelope the mit-learn
+# b2b_dashboard frontend expects, with fixture data.
+#
+# The stub source is delivered by the `analytics-api-stub-src` ConfigMap, which
+# the Tiltfile generates from stub_app.py (single source of truth). It is not
+# defined here so the two never drift.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analytics-api
+  namespace: mit-learn
+  labels:
+    app: analytics-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: analytics-api
+  template:
+    metadata:
+      labels:
+        app: analytics-api
+    spec:
+      containers:
+        - name: analytics-api
+          image: python:3.13-slim
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/app/stub_app.py"]
+          ports:
+            - containerPort: 8070
+              name: http
+          env:
+            - name: PORT
+              value: "8070"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8070
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8070
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          volumeMounts:
+            - name: stub-src
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: stub-src
+          configMap:
+            name: analytics-api-stub-src
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: analytics-api
+  namespace: mit-learn
+  labels:
+    app: analytics-api
+spec:
+  selector:
+    app: analytics-api
+  ports:
+    - name: http
+      port: 8070
+      targetPort: http

--- a/local-dev/apps/analytics-api/deployment.yaml
+++ b/local-dev/apps/analytics-api/deployment.yaml
@@ -27,42 +27,42 @@ spec:
         app: analytics-api
     spec:
       containers:
-        - name: analytics-api
-          image: python:3.13-slim
-          imagePullPolicy: IfNotPresent
-          command: ["python", "/app/stub_app.py"]
-          ports:
-            - containerPort: 8070
-              name: http
-          env:
-            - name: PORT
-              value: "8070"
-          resources:
-            requests:
-              cpu: 25m
-              memory: 32Mi
-            limits:
-              memory: 128Mi
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8070
-            initialDelaySeconds: 3
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8070
-            initialDelaySeconds: 5
-            periodSeconds: 20
-          volumeMounts:
-            - name: stub-src
-              mountPath: /app
-              readOnly: true
-      volumes:
+      - name: analytics-api
+        image: python:3.13-slim
+        imagePullPolicy: IfNotPresent
+        command: ["python", "/app/stub_app.py"]
+        ports:
+        - containerPort: 8070
+          name: http
+        env:
+        - name: PORT
+          value: "8070"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8070
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8070
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        volumeMounts:
         - name: stub-src
-          configMap:
-            name: analytics-api-stub-src
+          mountPath: /app
+          readOnly: true
+      volumes:
+      - name: stub-src
+        configMap:
+          name: analytics-api-stub-src
 ---
 apiVersion: v1
 kind: Service
@@ -75,6 +75,6 @@ spec:
   selector:
     app: analytics-api
   ports:
-    - name: http
-      port: 8070
-      targetPort: http
+  - name: http
+    port: 8070
+    targetPort: http

--- a/local-dev/apps/analytics-api/stub_app.py
+++ b/local-dev/apps/analytics-api/stub_app.py
@@ -299,7 +299,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def do_GET(self):  # noqa: N802
+    def do_GET(self):
         parsed = urlparse(self.path)
         path = parsed.path
 

--- a/local-dev/apps/analytics-api/stub_app.py
+++ b/local-dev/apps/analytics-api/stub_app.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Local-dev stub for `ol-analytics-api` (the B2B analytics gateway).
+
+The real service (mitodl/ol-analytics-api) is a FastAPI app that reads
+dbt-materialized views out of StarRocks. Neither StarRocks nor the data
+pipeline is realistic to run in the k3d local-dev stack, so this stub stands in
+for it: it serves the exact endpoints and response envelope the mit-learn
+frontend's b2b_dashboard client expects (see mit-learn
+`frontends/api/src/analytics/{clients,types}.ts`) with plausible fixture data,
+so the dashboard renders instead of reporting itself unavailable.
+
+Deliberately zero-dependency (stdlib `http.server` only) so the pod starts
+instantly with no PyPI/registry access and survives cluster restarts.
+
+Auth is handled entirely by APISIX in front of this service (the same
+`openid-connect` plugin the other authed routes use). This stub does not verify
+anything — it just echoes any `X-Userinfo` it receives for debugging and always
+returns data for whatever organization UUID is in the path. The real API keys
+every endpoint on the Keycloak organization UUID (`sso_organization_id`); the
+stub ignores which UUID it is and returns the same fixtures for all of them.
+"""
+
+import json
+import os
+import re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = int(os.environ.get("PORT", "8070"))
+
+# Path shape after APISIX strips the `/analytics/` prefix:
+#   /api/v1/analytics/organizations/<org_uuid>/<resource>
+#   /api/v1/analytics/organizations/<org_uuid>/contracts/<contract_id>/<resource>
+# The contract-scoped route was added later (mit-learn's org dashboard nests
+# analytics under a contract now); CONTRACT_PATH is tried first since its
+# extra path segment means ORG_PATH's anchored pattern never matches it.
+ORG_PATH = re.compile(
+    r"^/api/v1/analytics/organizations/(?P<org>[^/]+)/(?P<resource>[^/?]+)/?$"
+)
+CONTRACT_PATH = re.compile(
+    r"^/api/v1/analytics/organizations/(?P<org>[^/]+)/contracts/(?P<contract>[^/]+)/(?P<resource>[^/?]+)/?$"
+)
+
+# A fixed "last refresh" timestamp per section. Static so the stub is
+# deterministic (the runtime forbids wall-clock reads in some contexts, and a
+# frozen value keeps snapshot tests / screenshots stable).
+AS_OF = "2026-07-01T00:00:00Z"
+
+ORG_KEY = "b2b-org-localdev"
+ORG_NAME = "Local Dev Organization"
+
+# --- Fixtures: one list per resource, columns matching mit-learn types.ts. ---
+
+CONTRACT_UTILIZATION = [
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "1",
+        "contract_id": "1",
+        "b2b_contract_name": "FY26 Site License — Data Science Track",
+        "b2b_contract_is_active": True,
+        "b2b_contract_start_date": "2025-09-01",
+        "b2b_contract_end_date": "2026-08-31",
+        "seat_limit": 250,
+        "b2b_contract_membership_type": "seat_limited",
+        "seats_consumed": 187,
+        "active_learners": 142,
+        "learners_certified": 61,
+        "seat_utilization_pct": 74.8,
+        "completion_rate_pct": 42.9,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "2",
+        "contract_id": "2",
+        "b2b_contract_name": "FY26 Site License — Leadership Track",
+        "b2b_contract_is_active": True,
+        "b2b_contract_start_date": "2025-09-01",
+        "b2b_contract_end_date": "2026-08-31",
+        "seat_limit": 100,
+        "b2b_contract_membership_type": "seat_limited",
+        "seats_consumed": 54,
+        "active_learners": 38,
+        # k-anonymity floor: a small certified count is suppressed to null.
+        "learners_certified": None,
+        "seat_utilization_pct": 54.0,
+        "completion_rate_pct": None,
+    },
+]
+
+ENROLLMENT_FUNNEL = [
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "1",
+        "contract_id": "1",
+        "b2b_contract_name": "FY26 Site License — Data Science Track",
+        "courserun_pk": 101,
+        "courserun_readable_id": "course-v1:MITx+14.310x+2026_Spring",
+        "courserun_title": "Data Analysis for Social Scientists",
+        "enrolled_learners": 96,
+        "active_learners": 81,
+        "passing_learners": 44,
+        "certified_learners": 39,
+        "active_rate_pct": 84.4,
+        "completion_rate_pct": 45.8,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "1",
+        "contract_id": "1",
+        "b2b_contract_name": "FY26 Site License — Data Science Track",
+        "courserun_pk": 102,
+        "courserun_readable_id": "course-v1:MITx+6.86x+2026_Spring",
+        "courserun_title": "Machine Learning with Python",
+        "enrolled_learners": 91,
+        "active_learners": 67,
+        "passing_learners": 22,
+        "certified_learners": 22,
+        "active_rate_pct": 73.6,
+        "completion_rate_pct": 24.2,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "2",
+        "contract_id": "2",
+        "b2b_contract_name": "FY26 Site License — Leadership Track",
+        "courserun_pk": 201,
+        "courserun_readable_id": "course-v1:MITx+15.031x+2026_Spring",
+        "courserun_title": "Energy Economics and Policy",
+        "enrolled_learners": 54,
+        "active_learners": 38,
+        "passing_learners": None,
+        "certified_learners": None,
+        "active_rate_pct": 70.4,
+        "completion_rate_pct": None,
+    },
+]
+
+ENGAGEMENT_TREND = [
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "activity_year_and_month": ym,
+        "monthly_active_learners": mal,
+        "new_enrollments": newe,
+        "certificates_earned": certs,
+        "total_videos_watched": vids,
+        "total_problems_attempted": probs,
+        "total_chatbot_interactions": chats,
+    }
+    for (ym, mal, newe, certs, vids, probs, chats) in [
+        ("2025-09", 41, 41, None, 512, 883, 120),
+        ("2025-10", 88, 52, None, 1340, 2110, 402),
+        ("2025-11", 121, 39, 12, 2015, 3488, 690),
+        ("2025-12", 104, 18, 21, 1789, 2901, 548),
+        ("2026-01", 133, 44, 17, 2450, 4102, 812),
+        ("2026-02", 142, 22, 33, 2688, 4530, 905),
+    ]
+]
+
+PROGRAM_FUNNEL = [
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "1",
+        "contract_id": "1",
+        "b2b_contract_name": "FY26 Site License — Data Science Track",
+        "program_pk": 10,
+        "program_title": "Statistics and Data Science MicroMasters",
+        "total_courses": 5,
+        "enrolled_in_contract_courses": 96,
+        "enrolled_via_program": 71,
+        "program_course_completers": 33,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "contract_pk": "2",
+        "contract_id": "2",
+        "b2b_contract_name": "FY26 Site License — Leadership Track",
+        "program_pk": 20,
+        "program_title": "Sustainability Leadership Professional Certificate",
+        "total_courses": 3,
+        "enrolled_in_contract_courses": 54,
+        "enrolled_via_program": None,
+        "program_course_completers": None,
+    },
+]
+
+CONTENT_ENGAGEMENT = [
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "courserun_readable_id": "course-v1:MITx+14.310x+2026_Spring",
+        "courserun_title": "Data Analysis for Social Scientists",
+        "total_enrolled_learners": 96,
+        "engaged_learners": 81,
+        "engagement_rate_pct": 84.4,
+        "total_videos_watched": 4120,
+        "avg_videos_per_engaged_learner": 50.9,
+        "total_problems_attempted": 6890,
+        "avg_problems_per_engaged_learner": 85.1,
+        "total_chatbot_interactions": 1830,
+        "chatbot_users": 58,
+        "chatbot_adoption_pct": 71.6,
+        "certificates_earned": 39,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "courserun_readable_id": "course-v1:MITx+6.86x+2026_Spring",
+        "courserun_title": "Machine Learning with Python",
+        "total_enrolled_learners": 91,
+        "engaged_learners": 67,
+        "engagement_rate_pct": 73.6,
+        "total_videos_watched": 3980,
+        "avg_videos_per_engaged_learner": 59.4,
+        "total_problems_attempted": 7210,
+        "avg_problems_per_engaged_learner": 107.6,
+        "total_chatbot_interactions": 2405,
+        "chatbot_users": 51,
+        "chatbot_adoption_pct": 76.1,
+        "certificates_earned": 22,
+    },
+    {
+        "organization_key": ORG_KEY,
+        "organization_name": ORG_NAME,
+        "courserun_readable_id": "course-v1:MITx+15.031x+2026_Spring",
+        "courserun_title": "Energy Economics and Policy",
+        "total_enrolled_learners": 54,
+        "engaged_learners": None,
+        "engagement_rate_pct": None,
+        "total_videos_watched": None,
+        "avg_videos_per_engaged_learner": None,
+        "total_problems_attempted": None,
+        "avg_problems_per_engaged_learner": None,
+        "total_chatbot_interactions": None,
+        "chatbot_users": None,
+        "chatbot_adoption_pct": None,
+        "certificates_earned": None,
+    },
+]
+
+RESOURCES = {
+    "contract-utilization": CONTRACT_UTILIZATION,
+    "enrollment-funnel": ENROLLMENT_FUNNEL,
+    "engagement-trend": ENGAGEMENT_TREND,
+    "program-funnel": PROGRAM_FUNNEL,
+    "content-engagement": CONTENT_ENGAGEMENT,
+}
+
+# Identity of "the" contract every contract-scoped request is treated as
+# viewing — the stub ignores which contract_id is actually in the path (same
+# policy as the org UUID) and always answers as contract "1".
+_VIEWED_CONTRACT = {
+    "contract_pk": "1",
+    "contract_id": "1",
+    "b2b_contract_name": "FY26 Site License — Data Science Track",
+}
+
+
+def _rows_for(resource, contract_scoped):
+    """Rows for `resource`, scoped to the org or to `_VIEWED_CONTRACT`.
+
+    Org-scoped calls return every fixture row unfiltered (mixed contracts),
+    matching the real org-level views. Contract-scoped calls narrow to just
+    `_VIEWED_CONTRACT`: for the three views that already carry contract
+    identity at every grain, that's a filter; `engagement-trend` and
+    `content-engagement` have no contract-scoped fixture rows of their own
+    (they're org x month / org x run in this stub), so the same rows are
+    reused with the contract identity fields stamped on — matching
+    `ContractMonthlyEngagementTrend`/`ContractContentEngagementDepth`, which
+    are just the org row types plus `ContractIdentity`.
+    """
+    rows = RESOURCES.get(resource)
+    if rows is None:
+        return None
+    if not contract_scoped:
+        return rows
+    if resource in ("engagement-trend", "content-engagement"):
+        return [dict(row, **_VIEWED_CONTRACT) for row in rows]
+    return [
+        row for row in rows if row.get("contract_pk") == _VIEWED_CONTRACT["contract_pk"]
+    ]
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _send_json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        # Health / readiness probe.
+        if path in ("/", "/health", "/healthz"):
+            self._send_json(200, {"status": "ok", "service": "analytics-api-stub"})
+            return
+
+        match = CONTRACT_PATH.match(path)
+        contract_scoped = match is not None
+        if not match:
+            match = ORG_PATH.match(path)
+        if not match:
+            self._send_json(404, {"detail": f"Not found: {path}"})
+            return
+
+        org = match.group("org")
+        resource = match.group("resource")
+        rows = _rows_for(resource, contract_scoped)
+        if rows is None:
+            self._send_json(
+                404,
+                {"detail": f"Unknown analytics resource: {resource}"},
+            )
+            return
+
+        # Honor LIMIT/OFFSET paging the way the real API does.
+        qs = parse_qs(parsed.query)
+        try:
+            offset = int(qs.get("offset", ["0"])[0])
+            limit_raw = qs.get("limit", [None])[0]
+            limit = int(limit_raw) if limit_raw is not None else None
+        except ValueError:
+            self._send_json(422, {"detail": "limit/offset must be integers"})
+            return
+
+        page = rows[offset:]
+        if limit is not None:
+            page = page[:limit]
+
+        self._send_json(
+            200,
+            {
+                "organization_id": org,
+                "as_of": AS_OF,
+                # Total rows for this resource, ignoring limit/offset paging.
+                # The frontend renders `total_count.toLocaleString()`, so it
+                # must always be present (never null/undefined).
+                "total_count": len(rows),
+                "data": page,
+            },
+        )
+
+    def log_message(self, fmt, *args):  # keep pod logs readable
+        userinfo = self.headers.get("X-Userinfo", "-")
+        print(
+            "analytics-api-stub %s - %s"
+            % (self.command + " " + self.path, "auth" if userinfo != "-" else "anon")
+        )
+
+
+def main():
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    print(f"analytics-api stub listening on :{PORT}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### ⚠️ Testing tool only — do not merge

This adds a stub `analytics-api` service to the local-dev Tilt stack so PRs touching the mit-learn B2B analytics dashboard can be exercised end-to-end locally. There is no real `ol-analytics-api` runnable in local dev — it reads
StarRocks materialized views populated by a dbt pipeline that isn't part of this stack — so this stands in for it with a zero-dependency stdlib `http.server` returning fixture data matching the frontend's expected response envelope and row shapes.

Opened as a real PR (rather than a gist/branch link) so reviewers on mitodl/mit-learn#3906 can pull and run it themselves. Not intended to be merged as-is.

### What's in it
- `local-dev/apps/analytics-api/stub_app.py` — the fixture server
- `local-dev/apps/analytics-api/{Tiltfile,deployment.yaml,apisix-routes.yaml}` — wiring into the local-dev Tilt/k3d stack, reusing mit-learn's OIDC secret and CORS plugin config
- `Tiltfile` — registers `analytics-api` in the top-level `APPS` list

### How to use it
1. Check out this branch in your `ol-infrastructure` local-dev checkout, run `tilt up` (or `./local-dev/scripts/start.sh`) as usual.
2. Set `NEXT_PUBLIC_ANALYTICS_API_BASE_URL=https://api.learn.mit.dev/analytics/` in mit-learn-nextjs's `app-env.local.yaml`.
3. See mitodl/mit-learn#3906's test plan for the rest (finding/creating a manager-org test user, feature flag overrides, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)