### PR TITLE
chore: drop the unreachable deployment-notification feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "pulumi-eks>=4,<5",
   "pulumi-aws-native>=1.25.0,<2",
   "packaging>=24.2",
-  "pulumiverse-time>=0.1.1",
   "kubernetes>=34.1.0",
   "ol-parliament>=1.7.0",
   "cyclopts>=4.4.0",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -3,12 +3,10 @@
 
 import hashlib
 import json
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import pulumi_kubernetes as kubernetes
-import pulumiverse_time as pulumi_time
 from kubernetes.utils.quantity import parse_quantity
 from pulumi import Alias, ComponentResource, CustomTimeouts, Output, ResourceOptions
 from pydantic import (
@@ -712,8 +710,10 @@ class OLApplicationK8sConfig(BaseModel):
             "will crash-loop on a missing executable."
         ),
     )
-    deployment_notifications: bool = False
-    slack_channel: str | None = None  # Slack channel for deployment notifications
+    # Sets the ol.mit.edu/slack-channel label, which the kubewatch webhook
+    # handler reads to route that workload's notifications to a specific
+    # channel instead of the default one.
+    slack_channel: str | None = None
     vault_k8s_resource_auth_name: str
     registry: Literal["dockerhub", "ecr"] = "ecr"
     image_pull_policy: str = "IfNotPresent"
@@ -1535,10 +1535,6 @@ class OLApplicationK8s(ComponentResource):
             ),
         }
 
-        # Add deployment notification label if enabled
-        if ol_app_k8s_config.deployment_notifications:
-            application_labels["ol.mit.edu/notify-deployments"] = "true"
-
         # Add Slack channel label if specified
         if ol_app_k8s_config.slack_channel:
             application_labels["ol.mit.edu/slack-channel"] = (
@@ -1680,41 +1676,6 @@ class OLApplicationK8s(ComponentResource):
             deployment_options = deployment_options.merge(
                 ResourceOptions(depends_on=[_pre_deploy_job])
             )
-
-            if ol_app_k8s_config.deployment_notifications:
-                _application_pre_deployment_event_name = truncate_k8s_metanames(
-                    f"{ol_app_k8s_config.application_name}-predeploy"
-                )
-                # Create pre-deployment event
-                _now = datetime.now(tz=UTC)
-                _pre_deployment_event = kubernetes.events.v1.Event(
-                    f"{ol_app_k8s_config.application_name}-{stack_info.env_suffix}-pre-deploy-event",
-                    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                        name=_application_pre_deployment_event_name,
-                        namespace=ol_app_k8s_config.application_namespace,
-                        labels=application_labels,
-                        deletion_timestamp=(_now + timedelta(seconds=30)).isoformat(),
-                    ),
-                    event_time=pulumi_time.Static(
-                        f"{_application_pre_deployment_event_name}-time",
-                        triggers={"pre_deploy_job_id": _pre_deploy_job.id},
-                    ),
-                    regarding=kubernetes.core.v1.ObjectReferenceArgs(
-                        api_version="batch/v1",
-                        kind="Job",
-                        name=_application_pre_deployment_event_name,
-                        namespace=ol_app_k8s_config.application_namespace,
-                    ),
-                    action="PreDeployJobStarted",
-                    reason="PreDeployJobStarted",
-                    note=f"Pre-deployment job started for {_application_deployment_name}",
-                    type="Normal",
-                    reporting_controller="ol-infrastructure",
-                    reporting_instance=f"{ol_app_k8s_config.application_name}-controller",
-                    opts=ResourceOptions(delete_before_replace=True).merge(
-                        resource_options
-                    ),
-                )
 
         app_containers.append(
             # Actual application run with uwsgi
@@ -1930,100 +1891,6 @@ class OLApplicationK8s(ComponentResource):
                     ResourceOptions(depends_on=[_application_deployment])
                 ),
             )
-
-            if ol_app_k8s_config.deployment_notifications:
-                # Create post-deployment event
-                _application_post_deployment_event_name = truncate_k8s_metanames(
-                    f"{ol_app_k8s_config.application_name}-postdeploy"
-                )
-
-                # Use the job's status to determine success/failure for the event
-                def create_post_deploy_event_note(job_status):
-                    """Create event note based on job completion status."""
-                    if job_status is None:
-                        return f"Post-deployment job started for {_application_deployment_name}"
-
-                    succeeded = job_status.get("succeeded", 0)
-                    failed = job_status.get("failed", 0)
-
-                    if succeeded > 0:
-                        return f"Post-deployment job completed successfully for {_application_deployment_name}"
-                    elif failed > 0:
-                        return f"Post-deployment job failed for {_application_deployment_name}"
-                    else:
-                        return f"Post-deployment job in progress for {_application_deployment_name}"
-
-                def create_post_deploy_event_type(job_status):
-                    """Determine event type based on job completion status."""
-                    if job_status is None:
-                        return "Normal"
-
-                    failed = job_status.get("failed", 0)
-                    return "Warning" if failed > 0 else "Normal"
-
-                def create_post_deploy_event_action(job_status):
-                    """Determine event action based on job completion status."""
-                    if job_status is None:
-                        return "PostDeployJobStarted"
-
-                    succeeded = job_status.get("succeeded", 0)
-                    failed = job_status.get("failed", 0)
-
-                    if succeeded > 0:
-                        return "PostDeployJobCompleted"
-                    elif failed > 0:
-                        return "PostDeployJobFailed"
-                    else:
-                        return "PostDeployJobInProgress"
-
-                def create_post_deploy_event_reason(job_status):
-                    """Determine event reason based on job completion status."""
-                    if job_status is None:
-                        return "PostDeployJobStarted"
-
-                    succeeded = job_status.get("succeeded", 0)
-                    failed = job_status.get("failed", 0)
-
-                    if succeeded > 0:
-                        return "PostDeployJobSucceeded"
-                    elif failed > 0:
-                        return "PostDeployJobFailed"
-                    else:
-                        return "PostDeployJobRunning"
-
-                _now = datetime.now(tz=UTC)
-                _post_deployment_event = kubernetes.events.v1.Event(
-                    f"{ol_app_k8s_config.application_name}-{stack_info.env_suffix}-post-deploy-event",
-                    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                        name=_application_post_deployment_event_name,
-                        namespace=ol_app_k8s_config.application_namespace,
-                        labels=application_labels,
-                        deletion_timestamp=(_now + timedelta(seconds=30)).isoformat(),
-                    ),
-                    event_time=pulumi_time.Static(
-                        f"{_application_post_deployment_event_name}-time",
-                        triggers={"post_deploy_job_id": _post_deploy_job.id},
-                    ),
-                    regarding=kubernetes.core.v1.ObjectReferenceArgs(
-                        api_version="batch/v1",
-                        kind="Job",
-                        name=f"{_application_deployment_name}-post-deploy",
-                        namespace=ol_app_k8s_config.application_namespace,
-                    ),
-                    action=_post_deploy_job.status.apply(
-                        create_post_deploy_event_action
-                    ),
-                    reason=_post_deploy_job.status.apply(
-                        create_post_deploy_event_reason
-                    ),
-                    note=_post_deploy_job.status.apply(create_post_deploy_event_note),
-                    type=_post_deploy_job.status.apply(create_post_deploy_event_type),
-                    reporting_controller="ol-infrastructure",
-                    reporting_instance=f"{ol_app_k8s_config.application_name}-controller",
-                    opts=resource_options.merge(
-                        ResourceOptions(depends_on=[_post_deploy_job])
-                    ),
-                )
 
         # Pod Disruption Budget to ensure at least one web application pod is available.
         _application_pdb = kubernetes.policy.v1.PodDisruptionBudget(

--- a/uv.lock
+++ b/uv.lock
@@ -11,51 +11,51 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-django-aqueduct = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-edx-sysadmin = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-edx-username-changer = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-apigateway = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-authentication = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-common = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-digitalcredentials = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-geoip = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 mitol-django-google-sheets = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-google-sheets-deferrals = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-google-sheets-refunds = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-hubspot-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-mail = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-oauth-toolkit-extensions = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-observability = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-olposthog = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-openedx = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-payment-gateway = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-scim = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-django-transcoding = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-mitol-drf-lint = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-concourse = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-ai-static-translations = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-auto-select-language = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-uai-content-customization = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-canvas-integration = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-chat = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-concourse = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-olposthog = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-oauth-toolkit-extensions = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-social-auth = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-payment-gateway = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-ai-static-translations = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-google-sheets-refunds = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-chat-xblock = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-checkout-external = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-course-export = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-course-outline-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-course-structure-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-course-sync = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-course-translations = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-events-handler = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-feedback = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-git-auto-export = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-logging = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-lti-utilities = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-otel-monitoring = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ol-openedx-rapid-response-reports = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-sentry = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-openedx-uai-content-customization = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-ol-social-auth = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-observability = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-authentication = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-lti-utilities = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-checkout-external = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-geoip = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-git-auto-export = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-chat = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-hubspot-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 openedx-companion-auth = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-course-sync = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-digitalcredentials = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-common = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-sentry = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 rapid-response-xblock = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-mail = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-google-sheets-deferrals = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-course-translations = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-course-outline-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-transcoding = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+edx-username-changer = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-auto-select-language = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-apigateway = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-course-structure-api = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-drf-lint = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+django-aqueduct = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-otel-monitoring = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+edx-sysadmin = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+ol-openedx-course-export = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-openedx = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+mitol-django-scim = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
 members = [
@@ -1530,7 +1530,6 @@ dependencies = [
     { name = "pulumiverse-grafana" },
     { name = "pulumiverse-heroku" },
     { name = "pulumiverse-sentry" },
-    { name = "pulumiverse-time" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyinfra" },
@@ -1589,7 +1588,6 @@ requires-dist = [
     { name = "pulumiverse-grafana", specifier = ">=2.0.0,<3" },
     { name = "pulumiverse-heroku", specifier = ">=1.0.3,<2" },
     { name = "pulumiverse-sentry", specifier = "==0.0.9" },
-    { name = "pulumiverse-time", specifier = ">=0.1.1" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pydantic-settings", specifier = ">=2.0.1,<3" },
     { name = "pyinfra", specifier = "~=3.0" },
@@ -2262,17 +2260,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/6e/72/9f15791e623a757aa
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/cb/0ebafe1922b94924a0998b319824f2b6db7a61e0f63400ffd254ad35fce5/pulumiverse_sentry-0.0.9-py3-none-any.whl", hash = "sha256:259ac657e0b77ce790ebd349b2c622115a8dfa3a55007718c05d766f00a16718", size = 64874, upload-time = "2024-11-15T11:56:54.69Z" },
 ]
-
-[[package]]
-name = "pulumiverse-time"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parver" },
-    { name = "pulumi" },
-    { name = "semver" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/6b/89e78d25f6a8ec58fdb02a2daef019bb7a277bc0c1af6ee504c4d4ca2dc8/pulumiverse_time-0.1.1.tar.gz", hash = "sha256:4567837b6f2c1112871ff8a2cf4433308af8ab7a2814ca3aabd424825b2ad6ec", size = 15567, upload-time = "2024-12-29T17:07:24.188Z" }
 
 [[package]]
 name = "pycparser"


### PR DESCRIPTION
Removes a feature that has never run, and the abandoned Pulumi provider that only it used.

## The feature was unreachable

`OLApplicationK8sConfig.deployment_notifications` is `bool = False` and **no caller has ever set it** — not in the current tree, and `git log -S"deployment_notifications=True" --all` returns nothing. The three blocks it gated have never executed in any environment.

They also would not have worked if anyone had switched it on. Both `kubernetes.events.v1.Event` resources pass the whole `pulumi_time.Static` **resource** as `event_time`, where Kubernetes expects a MicroTime string. `Static` exposes `.rfc3339` for exactly this and neither call site used it.

## What goes, and what deliberately stays

**Removed:** the `deployment_notifications` field, the pre-deploy Event block, the post-deploy Event block and its four `create_post_deploy_event_*` helpers, and the `ol.mit.edu/notify-deployments` label — that label is written here and read nowhere in the repo.

**Kept:** `slack_channel`. It sets `ol.mit.edu/slack-channel`, which the kubewatch webhook handler genuinely reads at `webhook_handler.py:129` to route a workload's notifications to a specific channel. Its inline comment described the feature being deleted, so it now names the actual consumer instead.

The `datetime`/`UTC`/`timedelta` import also goes — those names were used only inside the deleted blocks.

## Dropping pulumiverse-time

With those blocks gone it has no callers. **Removing it cannot strand resources in any stack's state:** the code that would have created `time:index:Static` was unreachable, so none were ever created. That is a stronger guarantee than the other unused Pulumi SDKs found in the same audit (`pulumi-docker`, `pulumi-aws-native`, `pulumi-terraform`), which is why those are *not* included here — they need a state check first.

The provider is also flagged abandoned upstream, last released 2024-12-29.

## Verification

- `pytest` — 1103 passed.
- `pre-commit` — all hooks pass, including `ruff check` and `mypy` on the edited module.
- `uv lock` — the lockfile diff removes exactly one package (`pulumiverse-time` 0.1.1) and changes no other version.
- Net on `k8s.py`: 137 lines removed, 4 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqPFiEww9qJiKEcuhiWhav