### PR TITLE
chore: declare pulumi-kubernetes, pyyaml and botocore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,16 @@ dependencies = [
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
   "pyjwt[crypto]>=2.9,<3",
+  # Imported directly throughout this project but, until now, only ever
+  # installed as somebody else's transitive dependency -- pulumi-kubernetes
+  # reached us solely through pulumi-eks, pyyaml through kubernetes and
+  # ol-parliament, botocore through boto3. Nothing pinned them on our behalf, so
+  # a bump that dropped or narrowed one of those edges would have broken 127
+  # import sites with no signal from this file. Declaring them changes nothing
+  # about what gets installed today; it just makes the dependency real.
+  "pulumi-kubernetes>=4,<5",
+  "pyyaml>=6,<7",
+  "botocore~=1.24",
 ]
 
 [project.urls]
@@ -330,12 +340,15 @@ extend_exclude = [
   "src/bilder/.*/test_.*\\.py",
 ]
 
-# PyPI name != import name for these two, and deptry cannot infer the mapping,
-# so it reports both as declared-but-unused (DEP002) while they are in fact
-# used -- pyjwt at lib/github_helper.py, ol-parliament at lib/aws/iam_helper.py.
+# PyPI name != import name for these, and deptry cannot infer the mapping, so
+# it reports each as declared-but-unused (DEP002) *and* raises DEP001 on the
+# module actually imported, while the package is in fact in use -- pyjwt at
+# lib/github_helper.py, ol-parliament at lib/aws/iam_helper.py, pyyaml across
+# ~23 sites.
 [tool.deptry.package_module_name_map]
 pyjwt = ["jwt"]
 ol-parliament = ["parliament"]
+pyyaml = ["yaml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,8 +343,8 @@ extend_exclude = [
 # PyPI name != import name for these, and deptry cannot infer the mapping, so
 # it reports each as declared-but-unused (DEP002) *and* raises DEP001 on the
 # module actually imported, while the package is in fact in use -- pyjwt at
-# lib/github_helper.py, ol-parliament at lib/aws/iam_helper.py, pyyaml across
-# ~23 sites.
+# src/ol_infrastructure/lib/github_helper.py, ol-parliament at
+# src/ol_infrastructure/lib/aws/iam_helper.py, pyyaml across ~23 sites.
 [tool.deptry.package_module_name_map]
 pyjwt = ["jwt"]
 ol-parliament = ["parliament"]

--- a/uv.lock
+++ b/uv.lock
@@ -1501,6 +1501,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
     { name = "boto3" },
+    { name = "botocore" },
     { name = "certifi" },
     { name = "cyclopts" },
     { name = "httpx" },
@@ -1520,6 +1521,7 @@ dependencies = [
     { name = "pulumi-gcp" },
     { name = "pulumi-github" },
     { name = "pulumi-keycloak" },
+    { name = "pulumi-kubernetes" },
     { name = "pulumi-mailgun" },
     { name = "pulumi-mongodbatlas" },
     { name = "pulumi-qdrant-cloud" },
@@ -1534,6 +1536,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyinfra" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-aws4auth" },
 ]
@@ -1559,6 +1562,7 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=5,<6" },
     { name = "boto3", specifier = "~=1.24" },
+    { name = "botocore", specifier = "~=1.24" },
     { name = "certifi", specifier = ">=2024.2.2" },
     { name = "cyclopts", specifier = ">=4.4.0" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
@@ -1578,6 +1582,7 @@ requires-dist = [
     { name = "pulumi-gcp", specifier = ">=9.34,<10" },
     { name = "pulumi-github", specifier = ">=6.0.0,<7" },
     { name = "pulumi-keycloak", specifier = ">=6.0.0,<7" },
+    { name = "pulumi-kubernetes", specifier = ">=4,<5" },
     { name = "pulumi-mailgun", specifier = ">=3.0.0,<4" },
     { name = "pulumi-mongodbatlas", specifier = ">=4,<5" },
     { name = "pulumi-qdrant-cloud", editable = "sdks/qdrant-cloud" },
@@ -1592,6 +1597,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.1,<3" },
     { name = "pyinfra", specifier = "~=3.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9,<3" },
+    { name = "pyyaml", specifier = ">=6,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
     { name = "requests-aws4auth", specifier = ">=1.3.1" },
 ]


### PR DESCRIPTION
All three are imported directly across this project — **127 sites between them** — while never appearing in `pyproject.toml`. They arrived purely as somebody else's transitive dependency:

| Package | Import sites | Reached us via |
|---|---|---|
| `pulumi-kubernetes` | 100 | `pulumi-eks`, and nothing else |
| `pyyaml` (as `yaml`) | 23 | `kubernetes` and `ol-parliament` at runtime (also several dev-group packages) |
| `botocore` | 4 | `boto3` |

Nothing pinned them on our behalf, so a bump that dropped or narrowed any one of those edges would have broken imports across the codebase with no signal from this file. Surfaced by the deptry config in #5789.

## This changes nothing about what gets installed

`uv lock` re-resolves to the identical package set. The lockfile diff is **6 added lines and 0 removed**, recording the new direct edges, with **no package version change anywhere**. Verified after the change that all three still import at the versions already in use:

```
pulumi_kubernetes  |  yaml 6.0.3  |  botocore 1.43.85
```

Constraints follow the conventions already in the file — `>=4,<5` matching the sibling Pulumi providers, and `~=1.24` for `botocore` mirroring the existing `boto3~=1.24` (boto3 pins the exact compatible botocore anyway).

## One extra line the change forced

`pyyaml` installs under the module name `yaml` — the same PyPI-name/import-name mismatch already mapped for `pyjwt` and `ol-parliament`. Without an entry in `package_module_name_map`, declaring it made things *worse*: deptry reported `pyyaml` as declared-but-unused while still raising DEP001 on all 23 `import yaml` sites. Adding the mapping resolves both.

## Result

deptry goes from **130 issues to 3**, and the remaining three are the unused Pulumi SDKs (`pulumi-docker`, `pulumi-aws-native`, `pulumi-terraform`) that are pending a stack-state check before removal. Once those are settled the tool is clean enough to run as a gate.

## Verification

- `uv lock` — 6 lines added, 0 removed, no version changes.
- `uvx deptry .` — 130 → 3.
- `pytest` — 1118 passed.
- `pre-commit` — all hooks pass, including `check-toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqPFiEww9qJiKEcuhiWhav