### PR TITLE
docs(marimo-data): ol-marimo-app-client is not a Galaxy credential

### DIFF
--- a/src/ol_infrastructure/applications/marimo_data/__main__.py
+++ b/src/ol_infrastructure/applications/marimo_data/__main__.py
@@ -13,8 +13,24 @@ their own ``ApisixRoute`` resources that reference the shared OIDC config
 (``marimo_oidc``) and shared plugin config (``marimo_shared_plugins``) from
 this stack.
 
-Published apps use the ol-marimo-app-client service account (client credentials
-flow) for Trino access, so they are not tied to a specific user session.
+Published apps have no user session, so the interactive Galaxy OAuth2 flow the
+JupyterHub templates use is unavailable to them -- there is nobody to click a
+login link.  They therefore need a non-interactive warehouse credential.
+
+``ol-marimo-app-client`` is NOT that credential.  It is a Keycloak
+service-account client, and the client-credentials flow returns a
+Keycloak-issued JWT.  Starburst Galaxy does not accept externally-issued JWTs;
+customer-JWKS JWT auth is a Starburst Enterprise feature.  Galaxy accepts a
+Galaxy username/password over HTTP Basic, or its own OAuth2 flow.  Pointing a
+published app's Trino client at these credentials produces the same
+``401 Authentication required`` the JupyterHub template hit before #5700.
+
+What is needed is a GALAXY service account, in the shape OpenMetadata already
+uses -- ``login_email``/``password`` synced from Vault, see
+``applications/open_metadata/__main__.py`` and ``OM_TRINO_USERNAME`` /
+``OM_TRINO_PASSWORD``.  That account does not exist yet, and nothing consumes
+the secret below, so nothing is broken today; it breaks the moment someone
+publishes a notebook that queries the warehouse.
 
 The JupyterHub development environment is managed by the separate
 ``applications.jupyterhub_data`` stack.
@@ -82,8 +98,9 @@ application_labels = k8s_global_labels | {
 
 apps_domain = marimo_data_config.require("apps_domain")
 
-# Vault policy for marimo published-app pods to read the service-account
-# Trino client credentials (ol-marimo-app-client).
+# Vault policy for marimo published-app pods to read the ol-marimo-app-client
+# service-account credentials.  These are Keycloak credentials and are not
+# usable against Galaxy -- see the module docstring.
 marimo_vault_policy_hcl = """
 path "secret-operations/data/sso/marimo-app" {
   capabilities = ["read"]
@@ -123,7 +140,9 @@ marimo_vault_k8s_resources = OLVaultK8SResources(
     ),
 )
 
-# VaultStaticSecret: syncs ol-marimo-app-client credentials for published apps
+# VaultStaticSecret: syncs ol-marimo-app-client credentials for published apps.
+# Nothing mounts this secret yet.  It is not a warehouse credential; a Galaxy
+# service account is still required for that.
 marimo_app_trino_secret = OLVaultK8SSecret(
     f"marimo-app-trino-secret-{stack_info.env_suffix}",
     resource_config=OLVaultK8SStaticSecretConfig(


### PR DESCRIPTION
## What

Corrects the `applications/marimo_data` module docstring and two comments that documented `ol-marimo-app-client` as the Trino credential for published (run-mode) marimo apps. Comment-only; no resource changes.

## Why

The claim cannot hold. Client credentials against Keycloak return a Keycloak-issued JWT, and Starburst Galaxy does not accept externally-issued JWTs — customer-JWKS JWT auth is a Starburst Enterprise feature. This is the same root cause as the JupyterHub template `401 Authentication required` fixed in #5700, reached by a different code path; there it was demonstrated empirically, `trino.auth.JWTAuthentication` with a Keycloak access token 401ing where Galaxy's own OAuth2 flow succeeds.

Published apps cannot fall back to that OAuth2 flow either: they have no user session, so there is nobody to click the login link.

## Blast radius: none today

Verified in this repo at `5e3ead4b6`:

- `marimo_app_trino_secret` (`applications/marimo_data/__main__.py:146-168`) creates the k8s secret `marimo-app-oidc-secret`, and nothing mounts it. The only two occurrences of that name anywhere under `src/` are lines 150 and 157, both inside its own definition.
- This repo creates no `MarimoNotebook` resource. Every reference to the kind is either the operator install (`substructure/aws/eks/marimo_operator.py`) or prose; the stack's own comment at `applications/marimo_data/__main__.py:225` says the notebook manifests are managed out-of-band from this stack.

So this breaks the first time someone publishes a notebook that queries the warehouse, not before.

## What is still outstanding

The functional fix is **not** in this PR, because it needs two things this change cannot supply:

1. A **Galaxy service account** minted in the Starburst Galaxy console.
2. Its `login_email`/`password` written to a Vault path, after which this stack syncs it into published-app pods.

That is the shape OpenMetadata already uses — `applications/open_metadata/__main__.py:389-393` templates `OM_TRINO_USERNAME` from `login_email` and `OM_TRINO_PASSWORD` from `password` out of `secret-openmetadata/connectors`. The docstring now points at it.

**Open question for reviewers:** does `ol-marimo-app-client` (`substructure/keycloak/ol_data_platform.py:782-808`) still earn its place once the warehouse half moves to a Galaxy account? Its only documented purpose was Trino access, and published apps already authenticate their users through the APISIX OIDC config in this same stack. If it has no other consumer, the client and the `secret-operations/sso/marimo-app` Vault secret are dead weight — but that is a removal with its own blast radius, so it is a question here rather than a change.

## Testing

`pre-commit run` green on the changed file: ruff format, ruff check, mypy, detect-secrets all passed.

No `pulumi preview` was run. The change touches only a docstring and two `#` comments, so it cannot alter a resource, and no stack credentials were available in this session.

Refs mitodl/ol-data-platform#2624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drmv2eP7vPaTWfwtFQ2dUP
