### PR TITLE
fix(edxapp): read atlas srv_record, not the provider's connection_strings key

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -160,9 +160,16 @@ edxapp_zone_id = edxapp_zone["id"]
 kms_ebs = kms_stack.require_output("kms_ec2_ebs_key")
 kms_s3_key = kms_stack.require_output("kms_s3_data_analytics_key")
 operations_vpc = network_stack.require_output("operations_vpc")
-mongodb_cluster_uri = mongodb_atlas_stack.require_output("atlas_cluster")[
-    "connection_strings"
-][0]
+# Read the mongodb_atlas stack's own `srv_record` export rather than indexing
+# into the provider's raw `connection_strings` list.  That list's keys are
+# serialized straight from the provider, and pulumi-mongodbatlas 4.15.0 renamed
+# them from snake_case to camelCase (`standard_srv` -> `standardSrv`), which
+# broke every edxapp deploy whose atlas stack had re-run since the bump.
+# `srv_record` is exported by our own code, carries the identical value, and
+# does not move when the provider changes its serialization.
+mongodb_cluster_srv_record = mongodb_atlas_stack.require_output("atlas_cluster")[
+    "srv_record"
+]
 
 if edxapp_config.get_bool("move_db") or False:
     rds_subnet = k8s_vpc["rds_subnet"]
@@ -742,12 +749,12 @@ vault.generic.Secret(
 vault.generic.Secret(
     "forum-mongodb-atlas-user-password",
     path=edxapp_vault_mount.path.apply("{}/mongodb-forum".format),
-    data_json=mongodb_cluster_uri.apply(
-        lambda uri: json.dumps(
+    data_json=mongodb_cluster_srv_record.apply(
+        lambda srv_record: json.dumps(
             {
                 "username": "forum",
                 "password": mongo_atlas_credentials["forum"],
-                "uri": uri["standard_srv"],  # This is used by Dagster
+                "uri": srv_record,  # This is used by Dagster
             }
         ),
     ),


### PR DESCRIPTION
## What broke

Every edxapp deploy whose `mongodb_atlas` stack has re-run since `pulumi-mongodbatlas` 4.15.0:

```
KeyError: 'standard_srv'
  src/ol_infrastructure/applications/edxapp/__main__.py:750
```

`atlas_cluster.connection_strings` is the provider's own structure, and its keys pass straight through into our stack output. 4.15.0 changed that serialization from snake_case to camelCase — `standard_srv` became `standardSrv` — so the subscript stopped resolving. The version landed in `744f414b7` ("chore(deps): lock file maintenance", #5764), bumping 4.14.0 → 4.15.0.

**Causal, not coincidental.** The `mongodb_atlas` `mitxonline.CI` stack updated at `2026-09-08T16:02:32Z`. The edxapp `mitxonline-ci` deploy that started at `16:02:22Z` (build 63) is the first failure; build 62, ten minutes earlier, succeeded.

## Why this is a production problem, not a CI one

I read `atlas_cluster` out of all twelve atlas stacks. The split is just "has this stack re-run since the bump":

| spelling | stacks | edxapp deploy |
| --- | --- | --- |
| `standardSrv` (camelCase) | mitxonline.CI, mitx.CI, mitx.QA, xpro.CI, mitx-staging.CI | **already failing** |
| `standard_srv` (snake_case) | mitxonline.QA, **mitxonline.Production**, **mitx.Production**, xpro.QA, **xpro.Production**, mitx-staging.QA, mitx-staging.Production | fails on next atlas deploy |

Seven stacks, including all three Production ones, are holding the old spelling only because their atlas stack has not run yet. This goes off on its own schedule.

That also rules out the obvious one-character fix: changing the subscript to `standardSrv` repairs five stacks and breaks seven.

## The fix

Stop reading the provider's structure. The `mongodb_atlas` stack already exports `srv_record`, which is `atlas_cluster.srv_address` (`infrastructure/mongodb_atlas/__main__.py:278`) — a typed SDK attribute read through our own export name, rather than a raw dict passed through under whatever keys the provider happens to emit. Verified equal to the connection-string entry on all twelve stacks, under both spellings. It also drops the unguarded `[0]` index into a provider-owned list.

`connection_strings` stays exported; nothing consumes it now (`edxapp/__main__.py` was the only reader in the repo), but it remains provider-shaped, so anything reaching into it in future inherits the same fragility.

## Testing

`pulumi preview --stack mitxonline.CI` completes — previously it raised at line 750. The only resources in the diff are those referencing the placeholder image digest I set to get past the pipeline's `EDXAPP_DOCKER_IMAGE_DIGEST` guard locally.

The `forum-mongodb-atlas-user-password` Vault secret is **absent** from that diff, which is the point: the stored `uri` is byte-identical, so the Dagster consumer of that secret sees no change.

`pre-commit run` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVJKTGk9KHUTN2xfU59ujX
