### PR TITLE
fix(canaries): stamp artifact paths without build metadata

### DIFF
--- a/src/ol_concourse/pipelines/canaries/AGENTS.md
+++ b/src/ol_concourse/pipelines/canaries/AGENTS.md
@@ -125,7 +125,7 @@ pipeline collects that directory into a task output and, **on failure only**, up
 to:
 
 ```
-s3://ol-eng-artifacts/canary-results/<pipeline>/<job>/<build>/
+s3://ol-eng-artifacts/canary-results/<pipeline>/<job>/<YYYYMMDDTHHMMSSZ>/
 ```
 
 When triaging, the trace is almost always the fastest route — pull down `trace.zip` and
@@ -138,13 +138,18 @@ Two things about that upload are load-bearing:
   `set -e` would skip collecting them. `pipeline.py` captures the status and re-raises it
   after the copy. If you restructure that script, keep that ordering or the pipeline
   silently publishes nothing for precisely the runs you need it for.
-- **The build is stamped into the directory path, not into the `put`.** A Concourse `put`
-  cannot interpolate build metadata, so the run script writes into
-  `$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME/$BUILD_NAME` and rclone copies the tree wholesale.
-  Uploading to a flat prefix instead would have each failure overwrite the last.
+- **The run is stamped into the directory path, not into the `put`.** Uploading to a flat
+  prefix would have each failure overwrite the last, and neither end of the job can
+  supply a build number: **task containers on our Concourse get `ATC_EXTERNAL_URL` and no
+  `BUILD_*` variables**, verified with an `env` probe against cicd.odl.mit.edu, and a
+  script expanding `$BUILD_PIPELINE_NAME` therefore dies on `set -u` before any test
+  runs. The rclone `put` container does get `BUILD_*`, but a `put` cannot interpolate
+  them into its destination. So the pipeline name and job name are rendered in as
+  literals (`pipeline.py` knows both) and the task appends a UTC timestamp. Match an
+  artifact directory to a build by the build's start time.
 
 rclone uses `copy`, never `sync` — `sync` mirrors deletions, which against a
-build-stamped prefix would erase exactly the history this exists to keep. Credentials
+per-run prefix would erase exactly the history this exists to keep. Credentials
 come from the worker instance role (`env_auth = true`); `ol-eng-artifacts` is already in
 the operations Concourse IAM policy, so no secret is involved and none should be added.
 

--- a/src/ol_concourse/pipelines/canaries/README.md
+++ b/src/ol_concourse/pipelines/canaries/README.md
@@ -66,7 +66,8 @@ Grafana, Slack, or Rootly notification path: like most pipelines here, a passing
 is green in Concourse and a failed journey is red.
 
 When a run fails, its traces, screenshots and video are uploaded to
-`s3://ol-eng-artifacts/canary-results/<pipeline>/<job>/<build>/`. Green runs upload
+`s3://ol-eng-artifacts/canary-results/<pipeline>/<job>/<YYYYMMDDTHHMMSSZ>/`, matched to a
+build by its start time. Green runs upload
 nothing. These artifacts help diagnose a red build; they are not another result or
 notification channel. See [`AGENTS.md`](AGENTS.md) for how to read a trace and for
 what not to change about that step.

--- a/src/ol_concourse/pipelines/canaries/pipeline.py
+++ b/src/ol_concourse/pipelines/canaries/pipeline.py
@@ -209,17 +209,24 @@ def build_canary_pipeline(canary_name: str) -> Pipeline:
 
     project_flags = " ".join(f"--project={browser}" for browser in params.browsers)
     spec_arguments = " ".join(params.spec_paths)
+    canary_job = Identifier(f"run-{params.canary_name}-canary")
+    # Rendered in rather than read from the environment: task containers on our
+    # Concourse get ATC_EXTERNAL_URL and no BUILD_* metadata at all, so a script
+    # expanding $BUILD_PIPELINE_NAME dies on `set -u` before a single test runs.
+    # The put step's own container does have them, but a `put` cannot interpolate
+    # them into a destination, so neither end can supply the build number.
+    artifact_run_prefix = f"canary-{params.canary_name}/{canary_job}"
     run_canary = "\n".join(
         [
             "set -euo pipefail",
             # Resolved before the cd, not climbed back up to afterwards: Concourse
             # lays outputs out as siblings of the task's working directory, while
-            # the specs have to run from inside the checkout. Stamping the build
-            # into the path is what keeps one run's artifacts from overwriting the
-            # last one's -- a `put` cannot interpolate build metadata itself, so
-            # the directory layout carries it instead.
-            f'artifact_dir="$PWD/{ARTIFACT_OUTPUT}/$BUILD_PIPELINE_NAME'
-            '/$BUILD_JOB_NAME/$BUILD_NAME"',
+            # the specs have to run from inside the checkout. The start time is
+            # what keeps one failure's artifacts from overwriting the last one's,
+            # since no build number is reachable from here; match it to a build by
+            # the build's start time in Concourse.
+            f'artifact_dir="$PWD/{ARTIFACT_OUTPUT}/{artifact_run_prefix}'
+            '/$(date -u +%Y%m%dT%H%M%SZ)"',
             f"cd canary-code/{CANARY_REPO_PATH}",
             # @playwright/test is not installed globally in the image, so this is
             # mandatory. It is also cheap -- 6 packages, no browser download,
@@ -268,7 +275,7 @@ def build_canary_pipeline(canary_name: str) -> Pipeline:
         resources=[canary_code, canary_schedule, artifact_store],
         jobs=[
             Job(
-                name=Identifier(f"run-{params.canary_name}-canary"),
+                name=canary_job,
                 # A canary that piles up behind a slow run reports on a target it
                 # is also still loading, and the failures interleave.
                 max_in_flight=1,


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5592

### Description (What does it do?)

The first live `canary-mit-learn` build on cicd.odl.mit.edu died before running a single test:

```
bash: line 2: BUILD_PIPELINE_NAME: unbound variable
```

- Task containers on our Concourse are given `ATC_EXTERNAL_URL` and no `BUILD_*` variables at all, so expanding `$BUILD_PIPELINE_NAME` under `set -u` aborts the run script.
- The pipeline and job names were never dynamic — `pipeline.py` renders both — so they become literals, and the task appends a UTC timestamp so one failure's artifacts cannot overwrite the last one's.
- Failure artifacts now land at `canary-results/<pipeline>/<job>/<YYYYMMDDTHHMMSSZ>/`, matched to a build by the build's start time.
- `AGENTS.md` and `README.md` record the measured environment finding so the next person does not reintroduce a `$BUILD_*` reference.

<details>
<summary><b>Implementation details</b></summary>
<br>

**The measurement.** A throwaway pipeline running `env | sort` in a task on the `infrastructure` team printed `ATC_EXTERNAL_URL` and no `BUILD_ID`, `BUILD_NAME`, `BUILD_JOB_NAME`, `BUILD_PIPELINE_NAME` or `BUILD_TEAM_NAME`. Concourse is 8.3.0.

**Why neither end of the job can supply a build number.** The rclone `put` container *does* get the metadata — its `out` script echoes `BUILD_PIPELINE_NAME` and the value was correct in the failing build's log — but a `put` cannot interpolate anything into its destination, and the resource reads `destination[].subdir` from a file in an input rather than expanding variables. So the build number is reachable from the container that cannot use it and unreachable from the container that can.

**Why a timestamp rather than the git SHA.** A canary's failures are distinguished by *when* they happened, not by what changed — the target moves, the specs usually do not — and the triggering commit is already visible in the build's `canary-code` get step. At a 10-minute cadence with `max_in_flight: 1`, second-resolution collisions cannot occur.

</details>

### How can this be tested?

Verified against the pipeline as deployed on cicd.odl.mit.edu, not just rendered:

- **Green path.** `canary-mit-learn/run-mit-learn-canary` build 2: real Keycloak login plus course search against https://rc.learn.mit.edu, `2 passed (40.7s)`, build green. One test was reported flaky — the first attempt failed `getByRole("article").first()` after the 15s expect timeout and passed on retry. Worth watching during the flake-rate soak; it is not introduced by this diff.
- **Red path.** A throwaway `canary-mit-learn-redtest` pipeline pointed at a scratch branch whose `SEARCH_QUERY` was replaced with `zzzznonsensequerythatcannotmatch`. The Playwright failure propagated to task, job and build (`fly trigger-job -w` exited 1), and the `on_failure` put uploaded 35 objects / 43.2 MiB.
- **Artifact tree.** `s3://ol-eng-artifacts/canary-results/canary-mit-learn-redtest/run-mit-learn-redtest-canary/20260908T194842Z/` contained `artifacts/.../trace.zip`, `test-failed-1.png`, `video.webm`, `error-context.md`, the `html/` report and `results.json`, for both the initial attempt and the retry.
- **The trace really opens.** `trace.zip` was pulled from S3 and loaded in Playwright's own trace viewer (the same application trace.playwright.dev serves) driven headlessly: 12 actions rendered, the failing `Expect "toBeVisible" getByRole('article').first()` and the nonsense query both visible in the action list, no page errors.
- `uv run pre-commit run --files` on the changed files: passed. `uv run mypy src/ol_concourse`: no issues, 114 files. `fly validate-pipeline` on the rendered definition: looks good.

Cleanup: the throwaway pipeline was destroyed, the scratch branch deleted locally and on the remote, and the S3 test tree removed (`canary-results/` is back to 0 objects).

### Additional Context

`canary-meta` and `canary-mit-learn` are now live on the `infrastructure` team, and the Vault credential path is confirmed working — the failing build reached its task container, which only happens after `((canary_mit_learn.email))` and `((canary_mit_learn.password))` resolve.

`canary-mit-learn` is currently set from this branch's definition rather than from `main`, deliberately: the alternative is a canary that fails on the unbound variable every ten minutes until this merges. When it merges, `canary-meta/create-mit-learn-pipeline` re-renders it from `main` and the drift closes itself.