### PR TITLE
feat(local-dev): make the Keycloak image a per-developer knob

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,3 +140,6 @@ repos:
   rev: v2.15.1
   hooks:
   - id: hadolint-docker
+    # BuildKit reads <Dockerfile>.dockerignore beside a Dockerfile; it is not
+    # Dockerfile syntax.
+    exclude: \.dockerignore$

--- a/Tiltfile
+++ b/Tiltfile
@@ -14,6 +14,7 @@ config.define_string_list("prebuilt_tags", usage="Prebuilt image tag overrides p
 config.define_string("disk_keep_tags", usage="Newest tilt-built image tags kept per repo by the disk janitor (default: 3). Overrides LOCAL_DEV_DISK_KEEP_TAGS env var.")
 config.define_string("disk_buildcache_max_gb", usage="Docker build-cache size cap in GB (default: 10% of total disk; 0 disables). Overrides LOCAL_DEV_BUILDCACHE_MAX_GB env var.")
 config.define_string("log_retention_period", usage="How long Grafana/Loki keeps local-dev logs, as a whole number of days, e.g. 72h or 3d (default: 168h). Overrides LOCAL_DEV_LOG_RETENTION env var.")
+config.define_string("keycloak_image", usage="Keycloak server image for the core stack (default: the published mitodl/keycloak digest). Set and cleared by local-dev/scripts/kc-theme-image.sh to test an unreleased ol-keycloakify theme. Overrides LOCAL_DEV_KEYCLOAK_IMAGE env var.")
 cfg = config.parse()
 
 enabled_apps = cfg.get("enabled_apps", ["mit-learn", "learn-ai", "mitxonline", "odl-video-service"])
@@ -54,6 +55,12 @@ prebuilt_tags = {
 # not pinned in Pulumi.local-dev.core.Dev.yaml, since Pulumi config would win
 # over the environment and silently override this.
 log_retention_period = cfg.get("log_retention_period") or os.environ.get("LOCAL_DEV_LOG_RETENTION", "")
+
+# Keycloak server image. Empty means the Pulumi program's own default (the
+# published mitodl/keycloak digest). Set it to a locally built image to test an
+# unreleased ol-keycloakify theme -- see "Testing a local ol-keycloakify build"
+# in local-dev/README.md. Same not-pinned-in-Pulumi-config caveat as above.
+keycloak_image = cfg.get("keycloak_image") or os.environ.get("LOCAL_DEV_KEYCLOAK_IMAGE", "")
 
 # Workspace root: directory that contains ol-infrastructure and sibling app repos.
 # Override with MITOL_WORKSPACE_ROOT environment variable.
@@ -245,6 +252,7 @@ local_resource(
     env={
         "LOCAL_DEV_ROOT_DOMAIN": root_domain,
         "LOCAL_DEV_LOG_RETENTION": log_retention_period,
+        "LOCAL_DEV_KEYCLOAK_IMAGE": keycloak_image,
         "PULUMI_CONFIG_PASSPHRASE": "",
     },
     dir="./local-dev/infra/core",

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -541,7 +541,7 @@ Confirm the pod is on your tag, then log in again or trigger a password reset to
 kubectl -n local-infra get pod keycloak-0 -o jsonpath='{.spec.containers[0].image}'
 ```
 
-Emails land in [Mailpit](#inspect-emails-mailpit).
+Emails land in [Mailpit](#inspect-emails-mailpit); the olapps realm enables the `UPDATE_EMAIL` required action, so changing an email from the [account console](https://sso.ol.mit.dev/realms/olapps/account/) exercises the email-update confirmation template as well.
 
 Edit, re-run the script, and Keycloak rolls again. The tag is the checkout's short commit plus a hash of its uncommitted changes (tracked edits and untracked files; gitignored files don't count) and of the Dockerfile, so each distinct input gets its own tag and the operator, which only rolls when the image string changes, rolls once per change. The registry keeps the ten most recent tags per repository, so if `keycloak-0` ever fails to pull an old tag after many builds, re-run the script. To return to the published image:
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -166,7 +166,9 @@ ol-infrastructure/
 │
 └── local-dev/
     ├── scripts/                 # setup.sh, start.sh, stop.sh, teardown.sh, seed.sh,
-    │                            # heal-exec.sh, prune-docker.sh (each described in its header)
+    │                            # heal-exec.sh, prune-docker.sh, kc-theme-image.sh
+    │                            # (each described in its header)
+    ├── keycloak/                # Dockerfile for testing an unreleased ol-keycloakify theme
     ├── cluster/                 # k3d cluster definition + registry retention config
     ├── certs/                   # mkcert output (gitignored)
     ├── infra/                   # Pulumi stacks: shared in-cluster infra (see EXTENDING.md)
@@ -349,6 +351,7 @@ The `keycloak` database is deliberately never restored — Pulumi owns the realm
 | `prebuilt_tags` | see example file | `["app=tag"]` list of image tags used when the app repo is not checked out locally. |
 | `disk_keep_tags`, `disk_buildcache_max_gb` | `3`, 10% of disk | Disk retention knobs — see [Disk Management](#disk-management). |
 | `log_retention_period` | `168h` | How long Grafana/Loki keeps logs — see [Log retention](#log-retention). |
+| `keycloak_image` | published `mitodl/keycloak` digest | Keycloak server image for the core stack — see [Testing a local ol-keycloakify build](#testing-a-local-ol-keycloakify-build). |
 | `per_app_databases`, `openedx_mode` | — | Declared but not wired to anything yet; setting them has no effect. |
 
 The rule of thumb for which config surface a knob belongs to: settings that change **which/how Tilt runs things** (apps, image tags) go in `tilt_config.json`; anything that sets an **env var or secret value inside a workload** (API keys, feature flags, endpoints) goes in a gitignored `app-env.local.yaml` override ConfigMap — see [Local Configuration Overrides](#local-configuration-overrides).
@@ -395,6 +398,7 @@ The infrastructure is split across two Pulumi stacks:
 | `apisix_version` | `2.12.0` | APISIX Helm chart version |
 | `cnpg_version` | `0.23.0` | CloudNativePG operator Helm chart version |
 | `keycloak_operator_version` | `26.0.7` | Official Keycloak Operator version |
+| `keycloak_image` | published `mitodl/keycloak` digest | Keycloak server image. Leave unset here and use `tilt_config.json` instead — see [Testing a local ol-keycloakify build](#testing-a-local-ol-keycloakify-build). |
 | `observability_enabled` | `true` | Deploy Grafana + Loki + Alloy (~1.3GB). Set to `false` on a constrained Docker VM. |
 
 **`local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml`** — Keycloak realm and OIDC clients:
@@ -519,6 +523,35 @@ If you prefer to run Ollama on your host machine to use GPU acceleration:
    ```bash
    ollama serve  # Listens on localhost:11434 by default
    ```
+
+### Testing a local ol-keycloakify build
+
+The login, account, and email themes in local Keycloak come from the [ol-keycloakify](https://github.com/mitodl/ol-keycloakify) release baked into the published `mitodl/keycloak` image. To see an unreleased branch of the theme, check it out next to this repo and run:
+
+```bash
+./local-dev/scripts/kc-theme-image.sh            # ../ol-keycloakify
+./local-dev/scripts/kc-theme-image.sh ~/src/ol-keycloakify   # or any checkout
+```
+
+The script builds the theme from the checkout's sources inside Docker (no Node, Yarn, Maven, or JDK needed on the host), bakes the jar into a Keycloak image based on the published one, pushes it to the k3d registry, and writes the image into `keycloak_image` in your gitignored `tilt_config.json`. A running `tilt up` picks that up on its own: `local-infra-core` re-applies and the operator rolls `keycloak-0`, which takes a minute or two and logs you out of every local app. A first build takes about three minutes, mostly downloading the theme's dependencies; later builds reuse them. If the build fails at `yarn install --immutable`, the checkout's `yarn.lock` is out of date: run `yarn install` there and commit it.
+
+Confirm the pod is on your tag, then log in again or trigger a password reset to see the login and email themes:
+
+```bash
+kubectl -n local-infra get pod keycloak-0 -o jsonpath='{.spec.containers[0].image}'
+```
+
+Emails land in [Mailpit](#inspect-emails-mailpit).
+
+Edit, re-run the script, and Keycloak rolls again. The tag is the checkout's short commit plus a hash of its uncommitted changes (tracked edits and untracked files; gitignored files don't count) and of the Dockerfile, so each distinct input gets its own tag and the operator, which only rolls when the image string changes, rolls once per change. The registry keeps the ten most recent tags per repository, so if `keycloak-0` ever fails to pull an old tag after many builds, re-run the script. To return to the published image:
+
+```bash
+./local-dev/scripts/kc-theme-image.sh --reset   # sets keycloak_image back to ""
+```
+
+The realm, clients, and seeded users live in Postgres and are untouched by the image swap. Under the hood, Tilt forwards `keycloak_image` to the core Pulumi stack as `LOCAL_DEV_KEYCLOAK_IMAGE`, so the same value works for a hand-run `pulumi up`.
+
+Why an image at all: Keycloak runs `--optimized`, and an optimized Keycloak refuses to start when a jar in `providers/` differs from the one it was built against, so the theme cannot be copied into the running pod. The Dockerfile (`local-dev/keycloak/Dockerfile`) starts from the same `mitodl/keycloak` digest the core stack defaults to (the script reads it from `local-dev/infra/core/__main__.py`) and reruns `kc.sh build` with the flags from `Dockerfile.hosted` in [ol-keycloak](https://github.com/mitodl/ol-keycloak); when bumping the digest, check those flags still match.
 
 ### Custom S3 Storage (MinIO / RustFS)
 

--- a/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
+++ b/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
@@ -19,6 +19,10 @@ config:
   # LOCAL_DEV_LOG_RETENTION and therefore tilt_config.json. Default is 168h
   # (1 week); set "log_retention_period" in your gitignored tilt_config.json
   # to change it.
+  # keycloak_image: unset on purpose, same reason. local-dev/scripts/
+  # kc-theme-image.sh sets "keycloak_image" in tilt_config.json to run a
+  # locally built Keycloak image instead of the published digest the code
+  # defaults to.
   # Helm chart versions
   ol-local-dev-core:cert_manager_version: "v1.16.2"
   ol-local-dev-core:cnpg_version: "0.23.0"

--- a/local-dev/infra/core/__main__.py
+++ b/local-dev/infra/core/__main__.py
@@ -83,6 +83,21 @@ cnpg_version = config.get("cnpg_version") or "0.23.0"
 apisix_version = config.get("apisix_version") or "2.13.0"
 keycloak_operator_version = config.get("keycloak_operator_version") or "26.0.7"
 
+# Keycloak server image. The default is the published image the hosted
+# environments run, pinned by digest; local-dev/scripts/kc-theme-image.sh reads
+# that digest as the base for a locally built theme image and writes the result
+# into the gitignored tilt_config.json, which the Tiltfile forwards as
+# LOCAL_DEV_KEYCLOAK_IMAGE. Not pinned in Pulumi.local-dev.core.Dev.yaml for
+# the same reason as log_retention_period.
+keycloak_image = (
+    config.get("keycloak_image")
+    or os.environ.get("LOCAL_DEV_KEYCLOAK_IMAGE")
+    or (
+        "mitodl/keycloak"
+        "@sha256:4475afe3c385da6bd240a4a2811fa1231dd3365497ca78c017327c7c4e0ea1e2"
+    )
+)
+
 _infra_dir = Path(__file__).parent.parent
 _repo_root = _infra_dir.parent.parent
 _cert_path = _repo_root / tls_cert_path
@@ -206,6 +221,7 @@ identity = create_identity_core(
     apisix_release=ingress.apisix,
     tls_secret=tls.tls_secret,
     keycloak_operator_version=keycloak_operator_version,
+    keycloak_image=keycloak_image,
     keycloak_hostname=keycloak_hostname,
     keycloak_url=keycloak_url,
     root_domain=root_domain,

--- a/local-dev/infra/core/__main__.py
+++ b/local-dev/infra/core/__main__.py
@@ -94,7 +94,7 @@ keycloak_image = (
     or os.environ.get("LOCAL_DEV_KEYCLOAK_IMAGE")
     or (
         "mitodl/keycloak"
-        "@sha256:4475afe3c385da6bd240a4a2811fa1231dd3365497ca78c017327c7c4e0ea1e2"
+        "@sha256:bac56d272e02121668a3d339b55585820525db248ce83aa58618f5e4f89ec9e0"
     )
 )
 

--- a/local-dev/infra/modules/identity_core.py
+++ b/local-dev/infra/modules/identity_core.py
@@ -34,12 +34,20 @@ def create_identity_core(  # noqa: PLR0913
     apisix_release: k8s.helm.v3.Release,
     tls_secret: k8s.core.v1.Secret,
     keycloak_operator_version: str,
+    keycloak_image: str,
     keycloak_hostname: str,
     keycloak_url: str,  # noqa: ARG001
     root_domain: str,  # noqa: ARG001
     db_cluster: k8s.apiextensions.CustomResource,
 ) -> IdentityCoreResources:
-    """Deploy Keycloak operator, instance, and routes (no realm)."""
+    """Deploy Keycloak operator, instance, and routes (no realm).
+
+    ``keycloak_image`` must be a pre-built (``kc.sh build`` already run) image
+    with the OL theme and SPI jars in ``/opt/keycloak/providers``; the instance
+    starts it with ``--optimized``. Any image built from
+    ``local-dev/keycloak/Dockerfile`` qualifies, as does the published
+    ``mitodl/keycloak`` the core stack defaults to.
+    """
     kc_base = (
         "https://raw.githubusercontent.com/keycloak/"
         f"keycloak-k8s-resources/{keycloak_operator_version}/kubernetes"
@@ -105,10 +113,7 @@ def create_identity_core(  # noqa: PLR0913
         },
         spec={
             "instances": 1,
-            "image": (
-                "mitodl/keycloak"
-                "@sha256:4475afe3c385da6bd240a4a2811fa1231dd3365497ca78c017327c7c4e0ea1e2"
-            ),
+            "image": keycloak_image,
             # The image is pre-built (kc.sh build was run during Docker build).
             # startOptimized=True uses that build; False would re-run kc.sh build
             # on every pod start (slow). The image already has organization baked

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -144,7 +144,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     for alias, default in [
         ("CONFIGURE_TOTP", False),
         ("VERIFY_EMAIL", verify_email),
-        # UPDATE_EMAIL was removed in Keycloak 26 — omit to avoid validation error.
+        ("UPDATE_EMAIL", False),
         ("UPDATE_PASSWORD", False),
     ]:
         keycloak.RequiredAction(

--- a/local-dev/keycloak/Dockerfile
+++ b/local-dev/keycloak/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+# Keycloak image for testing an unreleased ol-keycloakify theme in the local-dev
+# stack. local-dev/scripts/kc-theme-image.sh drives this build; usage is under
+# "Testing a local ol-keycloakify build" in local-dev/README.md. The build
+# context is the ol-keycloakify checkout, not this repo, and the theme jar is
+# built from that checkout's sources here, so the host needs neither Node nor
+# Maven and a stale dist_keycloak/ cannot leak into the image.
+#
+# The base is the published image the core stack runs by default, so the only
+# difference from a stock local-dev deployment is the theme jar. The operator
+# starts Keycloak with --optimized, and an optimized Keycloak refuses to boot
+# when a jar in providers/ no longer matches the one it was built against, so
+# a new theme cannot be mounted or copied into a running pod: it has to be
+# baked in and `kc.sh build` rerun. BASE_IMAGE has no default on purpose: the
+# script reads the digest the core stack pins in
+# local-dev/infra/core/__main__.py and passes it in, so the two cannot drift.
+ARG BASE_IMAGE
+
+# The jar is platform-independent, so build it on the host's own architecture.
+# Only the Keycloak stage below has to be linux/amd64 (the base is amd64-only).
+FROM --platform=$BUILDPLATFORM node:24-bookworm AS theme
+# keycloakify packages the theme with Maven; Debian's package brings a JDK.
+# Any Maven 3 works for that, so the exact Debian package version is not
+# worth pinning (and pins rot as bookworm point releases roll).
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends maven \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /theme
+# Dependencies first so a source-only change reuses the installed node_modules
+# layer. The checkout vendors its own Yarn under .yarn/releases (yarnPath in
+# .yarnrc.yml), so the image's stock yarn just hands off to it.
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/ .yarn/
+RUN --mount=type=cache,target=/root/.yarn/berry/cache \
+    yarn install --immutable --mode=skip-build
+# The project's postinstall (keycloakify sync-extensions) was skipped above
+# because it writes generated account-theme sources into src/, which is not
+# copied yet. Run it now, then build.
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 \
+    yarn run postinstall \
+    && yarn build-keycloak-theme
+
+FROM ${BASE_IMAGE}
+# Remove the released theme first: keycloakify has shipped its jar under more
+# than one filename, and two jars declaring the same theme names is an error.
+RUN rm -f /opt/keycloak/providers/keycloakify-theme*.jar \
+    /opt/keycloak/providers/keycloak-theme-for-kc-*.jar
+# The jar name is fixed by keycloakifyBuildOptions in the checkout's vite.config.ts.
+COPY --from=theme /theme/dist_keycloak/keycloakify-theme_v11-21_and_v26plus.jar \
+    /opt/keycloak/providers/
+
+# Same flags as Dockerfile.hosted in mitodl/ol-keycloak, which built the base.
+# A build-time option that differs from the base would make the pod crash at
+# start because the CR's runtime options assume the hosted build.
+RUN /opt/keycloak/bin/kc.sh build \
+    --db=postgres \
+    --health-enabled=true \
+    --metrics-enabled=true \
+    --event-metrics-user-enabled=true \
+    --spi-login--provider=ol-freemarker \
+    --tracing-enabled=true \
+    --tracing-jdbc-enabled=true \
+    --features=update-email

--- a/local-dev/keycloak/Dockerfile.dockerignore
+++ b/local-dev/keycloak/Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+# Applied to the ol-keycloakify checkout used as build context (BuildKit reads
+# the <Dockerfile>.dockerignore beside the Dockerfile). Everything the build
+# produces itself is excluded so host state cannot leak in and the context
+# stays small; node_modules alone is over a gigabyte.
+.git
+node_modules
+dist
+dist_keycloak
+build
+storybook-static
+.keycloakify
+.yarn/install-state.gz

--- a/local-dev/scripts/kc-theme-image.sh
+++ b/local-dev/scripts/kc-theme-image.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# kc-theme-image.sh — run local Keycloak with an unreleased ol-keycloakify theme
+#
+# Builds the theme from an ol-keycloakify checkout into a Keycloak image
+# (local-dev/keycloak/Dockerfile), pushes it to the k3d registry, and points the
+# core stack at it through `keycloak_image` in tilt_config.json. A running
+# `tilt up` picks the change up on its own: local-infra-core re-applies and the
+# operator rolls keycloak-0, which takes a minute or two and logs every local
+# session out.
+#
+# Usage:
+#   ./local-dev/scripts/kc-theme-image.sh [CHECKOUT]   # default: ../ol-keycloakify
+#   ./local-dev/scripts/kc-theme-image.sh --reset      # back to the published image
+#
+# The default checkout is the ol-keycloakify sibling of this repo, the same
+# workspace layout the root Tiltfile assumes (MITOL_WORKSPACE_ROOT overrides the
+# workspace directory there and here). The image tag is the checkout's short
+# HEAD plus a hash of its uncommitted changes and of the Dockerfile, so each
+# distinct input gets its own tag and the operator rolls once per change.
+#
+# Environment:
+#   DOCKER                  docker CLI to invoke (default: docker)
+#   LOCAL_DEV_REGISTRY_PUSH registry as the host reaches it (default: localhost:5001)
+#   LOCAL_DEV_REGISTRY_PULL registry as the cluster nodes reach it
+#                           (default: k3d-registry.localhost:5000)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DOCKERFILE="${REPO_ROOT}/local-dev/keycloak/Dockerfile"
+TILT_CONFIG="${REPO_ROOT}/tilt_config.json"
+CORE_STACK="${REPO_ROOT}/local-dev/infra/core/__main__.py"
+
+DOCKER="${DOCKER:-docker}"
+# The daemon treats `localhost` as insecure automatically but insists on TLS for
+# `k3d-registry.localhost`, so pushes go to the former; in-cluster pulls use the
+# k3s registry mirror name, which is also how Tilt-built images are referenced.
+PUSH_REGISTRY="${LOCAL_DEV_REGISTRY_PUSH:-localhost:5001}"
+PULL_REGISTRY="${LOCAL_DEV_REGISTRY_PULL:-k3d-registry.localhost:5000}"
+REPO="keycloak"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+usage() { sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+write_keycloak_image() {
+  local value="$1" tmp
+  tmp="$(mktemp)"
+  if [[ -f "${TILT_CONFIG}" ]]; then
+    jq --arg v "${value}" '.keycloak_image = $v' "${TILT_CONFIG}" > "${tmp}"
+  else
+    jq -n --arg v "${value}" '{keycloak_image: $v}' > "${tmp}"
+  fi
+  # cat, not mv: keep the file's mode and identity (mktemp creates 0600).
+  cat "${tmp}" > "${TILT_CONFIG}" && rm -f "${tmp}"
+}
+
+for tool in "${DOCKER}" jq curl git shasum; do
+  command -v "${tool}" >/dev/null || die "${tool} is required"
+done
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --reset)
+    write_keycloak_image ""
+    echo "keycloak_image cleared in ${TILT_CONFIG}. If Tilt is running, local-infra-core re-applies and keycloak-0 rolls back to the published image (a minute or two)."
+    exit 0
+    ;;
+  -*) die "unknown option: $1 (see --help)" ;;
+esac
+
+WORKSPACE_ROOT="${MITOL_WORKSPACE_ROOT:-${REPO_ROOT}/..}"
+CHECKOUT="${1:-${WORKSPACE_ROOT}/ol-keycloakify}"
+[[ -f "${CHECKOUT}/package.json" && -f "${CHECKOUT}/vite.config.ts" ]] \
+  || die "${CHECKOUT} does not look like an ol-keycloakify checkout (pass the path as the first argument)"
+CHECKOUT="$(cd "${CHECKOUT}" && pwd)"
+
+curl -sf "http://${PUSH_REGISTRY}/v2/" >/dev/null \
+  || die "no registry at ${PUSH_REGISTRY}; is the k3d cluster running? (./local-dev/scripts/start.sh)"
+
+# The Dockerfile's base must be the image the core stack runs by default, so
+# read the digest from the one place it is pinned rather than duplicating it.
+BASE_DIGEST="$(grep -o 'sha256:[0-9a-f]\{64\}' "${CORE_STACK}" | head -1)"
+[[ -n "${BASE_DIGEST}" ]] || die "no mitodl/keycloak digest found in ${CORE_STACK}"
+
+# Tag: short HEAD plus a hash of the tracked modifications, untracked files
+# (gitignored ones excluded), and the Dockerfile, so edits made without
+# committing still get a fresh tag and a fresh rollout.
+head_sha="$(git -C "${CHECKOUT}" rev-parse --short HEAD)"
+input_hash="$(
+  {
+    git -C "${CHECKOUT}" diff HEAD --
+    git -C "${CHECKOUT}" ls-files --others --exclude-standard -z \
+      | (cd "${CHECKOUT}" && xargs -0 cat 2>/dev/null)
+    cat "${DOCKERFILE}"
+    echo "${BASE_DIGEST}"
+  } | shasum -a 256 | cut -c1-8
+)"
+TAG="${head_sha}-${input_hash}"
+PUSH_REF="${PUSH_REGISTRY}/${REPO}:${TAG}"
+PULL_REF="${PULL_REGISTRY}/${REPO}:${TAG}"
+
+echo "Building ${PUSH_REF} from ${CHECKOUT} ..."
+# The base image is linux/amd64 only. --provenance=false --sbom=false keeps the
+# push a single image manifest: BuildKit's default attestation turns it into an
+# OCI index, and containerd on the arm64 k3d nodes then looks for an arm64
+# entry, finds none, and fails the pull with "no match for platform in
+# manifest". A plain amd64 manifest is pulled as-is, like the published base.
+"${DOCKER}" build \
+  --platform linux/amd64 \
+  --provenance=false --sbom=false \
+  --build-arg "BASE_IMAGE=mitodl/keycloak@${BASE_DIGEST}" \
+  -f "${DOCKERFILE}" \
+  -t "${PUSH_REF}" \
+  "${CHECKOUT}"
+"${DOCKER}" push "${PUSH_REF}"
+
+media="$(curl -sf "http://${PUSH_REGISTRY}/v2/${REPO}/manifests/${TAG}" \
+  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+  -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+  | jq -r '.mediaType // empty')"
+case "${media}" in
+  *index*|*manifest.list*)
+    die "${PUSH_REF} was pushed as a multi-manifest index (${media}); the cluster nodes cannot pull it. Is a buildx driver overriding --provenance/--sbom?" ;;
+esac
+
+write_keycloak_image "${PULL_REF}"
+cat <<EOF
+keycloak_image = ${PULL_REF} written to ${TILT_CONFIG}
+
+If Tilt is running it re-applies local-infra-core now and the operator rolls
+keycloak-0 (a minute or two). Every local session is logged out by the restart.
+Follow along with:
+  kubectl -n local-infra rollout status statefulset/keycloak
+Return to the published image with:
+  ${BASH_SOURCE[0]} --reset
+EOF

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -18,5 +18,7 @@
 
   "disk_buildcache_max_gb": "",
 
-  "log_retention_period": "168h"
+  "log_retention_period": "168h",
+
+  "keycloak_image": ""
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Lets a developer run local-dev Keycloak on an image built from an [ol-keycloakify](https://github.com/mitodl/ol-keycloakify) checkout, so an unreleased theme branch can be reviewed in the k3d stack before it ships. One command:

```bash
./local-dev/scripts/kc-theme-image.sh          # ../ol-keycloakify, or pass a path
./local-dev/scripts/kc-theme-image.sh --reset  # back to the published image
```

- New `keycloak_image` knob: `tilt_config.json` → `LOCAL_DEV_KEYCLOAK_IMAGE` → core Pulumi stack → Keycloak CR `spec.image`. Unset, it falls back to the published `mitodl/keycloak` digest the stack already pins, so nothing changes by default.
- New `local-dev/keycloak/Dockerfile`, multi-stage: a native-arch node stage builds the theme jar from the checkout (yarn + Maven, no host toolchain needed), and the `linux/amd64` Keycloak stage bakes it in and reruns `kc.sh build` with the same flags as ol-keycloak's `Dockerfile.hosted`. The base digest is read from `local-dev/infra/core/__main__.py` at build time, so there is one copy.
- New `local-dev/scripts/kc-theme-image.sh` (140 lines, a third of them comments): build, push to the k3d registry, verify the pushed manifest, write the knob. The tag hashes the checkout's HEAD, its uncommitted changes, and the Dockerfile, so each change rolls Keycloak once and an unchanged re-run is a cached build.
- README section "Testing a local ol-keycloakify build".
- Enables the `UPDATE_EMAIL` required action in the local olapps realm, mirroring production `olapps.py`. The module skipped it behind a comment saying the alias was removed in Keycloak 26; it exists in 26.5.7 and was only disabled.

<details>
<summary><b>Implementation details</b></summary>
<br>

- The CR runs Keycloak with `--optimized`, which refuses to start when a jar in `providers/` differs from the one recorded at build time, so a theme jar cannot be copied or mounted into the running pod. The image has to be rebuilt.
- Same env-var pattern as `log_retention_period`: the value is deliberately not pinned in `Pulumi.local-dev.core.Dev.yaml`, since Pulumi config would beat the env var.
- The published base image is `linux/amd64` only and a plain single manifest, which is why it runs on the arm64 k3d nodes at all. BuildKit's default OCI index (image + attestation) makes containerd platform-match and reject the pull, so the script builds with `--provenance=false --sbom=false` and checks the registry's stored media type after pushing.
- Pushes go to `localhost:5001` (the daemon insists on TLS for the `k3d-registry.localhost` name); the config gets the in-cluster name `k3d-registry.localhost:5000/...`, the same host Tilt's own images use.
- `Dockerfile.dockerignore` keeps `node_modules` and build output out of the context (10 MB instead of >1 GB). hadolint is told not to parse it as a Dockerfile.
- No Tilt-driven rebuild on save, on purpose: every Keycloak roll logs every local session out, and the Maven + `kc.sh build` cycle is 1–2 minutes, so this stays a deliberate command.
</details>

### How can this be tested?
Ran end to end on this branch with the theme from https://github.com/mitodl/ol-keycloakify/pull/196:

1. `./local-dev/scripts/kc-theme-image.sh` against a dirty ol-keycloakify checkout. Full build about 2.5 min (`kc.sh build` under emulation is 54 s of it); an unchanged re-run is 1.5 s (all stages cached); editing the Dockerfile produced a new tag.
2. Tilt reran `local-infra-core`, the operator rolled `keycloak-0`, and the pod came up on the new tag with the built jar as the only theme jar in `providers/`. The jar in the pulled image contained the checkout's uncommitted edits.
3. Triggered `UPDATE_EMAIL` from the account console as a seeded user. Mailpit received the new `email-update-confirmation` template and the confirm link completed the change.
4. `pulumi preview` on the core stack with the knob unset shows no Keycloak diff; set, only `spec.image` changes.
5. `--reset`, `--help`, and an unknown flag behave as documented. pre-commit (shellcheck, hadolint, ruff, mypy) passes.

The `UPDATE_EMAIL` change was applied to a running realm via Tilt's `local-infra-apps`; the provider adopted the built-in alias in place.

### Additional Context
- The pinned digest is Keycloak 26.5.7 (April build) while `Dockerfile.hosted` is on 26.7.1. Bumping it is now a one-place change in `local-dev/infra/core/__main__.py` plus rechecking the `kc.sh build` flags. Left for a separate PR.
- Two Claude subagent reviews (correctness and developer experience) were run on the branch; their accepted findings are folded in. Deliberately not taken, to keep the script small: a `sha256sum` fallback for hosts without `shasum`, and printing the root-domain account-console URL from the script.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
