### PR TITLE
docs: Iceberg REST catalog evaluation, Gravitino spike results, and Keycloak identity spec

### DIFF
--- a/docs/plans/gravitino-keycloak-integration-spec.md
+++ b/docs/plans/gravitino-keycloak-integration-spec.md
@@ -1,0 +1,440 @@
+# Keycloak spec: identity for the Gravitino Iceberg REST catalog
+
+Status: spec, ready for review
+Date: 2026-09-08
+Project: `wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`
+Task: `tk-spec-keycloak-service-account-and-audience-mappe-d7443a`
+Supersedes the Lakekeeper framing of that task. Catalog choice: see
+`docs/plans/iceberg-rest-catalog-evaluation.md` (recommendation: Apache Gravitino 1.3.0).
+
+## Scope
+
+Everything Keycloak has to emit, and everything Gravitino has to be told, for the end user's
+Keycloak token forwarded by StarRocks under `iceberg.catalog.security=JWT` to authenticate and
+carry role membership into the catalog.
+
+Out of scope: the role-to-namespace grant model itself (that is
+`tk-spec-cedar-authorization-policy-set-for-lakekeep-cf7568`, void as written and needing a
+Gravitino rewrite), EKS placement, and the StarRocks-side catalog SQL.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | One dedicated audience value, `ol-gravitino-catalog`, emitted by an `AudienceProtocolMapper` on every client whose tokens reach the catalog. |
+| D2 | New confidential service-account client, OIDC `client_id` `ol-gravitino-catalog`, for the catalog bootstrap credential; secret to Vault at `secret-operations/sso/gravitino-catalog`. Its client id doubles as the D1 audience value. |
+| D3 | Per-client `access_token_lifespan` override on the two StarRocks clients. **Value needs sign-off**; recommended `3600`. Realm default stays 5m. |
+| D4 | `principalFields = starrocks_username,preferred_username`. |
+| D5 | Reuse the existing `role_keys` claim as Gravitino's group source. Do **not** create Keycloak groups. |
+| D6 | `authority` set to the exact realm issuer per environment. It is the issuer check, and blank means no check. |
+| D7 | `allowSkewSecs = 30`. |
+| D8 | Assert the running authenticator at deploy time. Gravitino fails open. |
+
+D5 is a change from the evaluation document, which assumed Keycloak groups and a
+`^/(.*)$` group mapper to strip the leading slash from group paths. The realm already emits the
+six governance roles as a flat `role_keys` array, so no groups and no slash-stripping are needed.
+
+## Measured facts this rests on
+
+Everything below was read from source or from live state, not from documentation.
+
+**M1. The live Production realm issues 5-minute tokens.** From
+`pulumi stack export --stack Production` of `ol-substructure-keycloak`, resource
+`urn:pulumi:Production::ol-substructure-keycloak::keycloak:index/realm:Realm::ol-data-platform`,
+read 2026-09-08:
+
+```
+accessTokenLifespan                 = 5m0s
+accessTokenLifespanForImplicitFlow  = 15m0s
+ssoSessionIdleTimeout               = 2h0m0s
+ssoSessionMaxLifespan               = 24h0m0s
+clientSessionIdleTimeout            = 0s
+clientSessionMaxLifespan            = 0s
+```
+
+`src/ol_infrastructure/substructure/keycloak/ol_data_platform.py:99-100` sets only the two
+session timeouts, so `accessTokenLifespan` is the Keycloak default and 5m is what is actually
+live.
+
+**M2. The ID token dies with the access token.** Keycloak 26.0.8,
+`services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java:1277`:
+
+```java
+idToken.exp(accessToken.getExp());
+```
+
+The MySQL `authentication_openid_connect_client` plugin sends the **ID** token, so M1 applies to
+the token StarRocks stores and forwards.
+
+**M3. A client-level lifespan override wins, capped by the client session.** Same file,
+`getTokenExpiration`, lines 1063-1068:
+
+```java
+String clientLifespan = client.getAttribute(OIDCConfigAttributes.ACCESS_TOKEN_LIFESPAN);
+if (clientLifespan != null && !clientLifespan.trim().isEmpty()) {
+    tokenLifespan = Integer.parseInt(clientLifespan);
+} else {
+    tokenLifespan = realm.getAccessTokenLifespan();
+}
+```
+
+and lines 1081-1085 clamp the result to `calculateClientSessionMaxLifespanTimestamp`, which with
+`clientSessionMaxLifespan = 0` falls back to the realm's `ssoSessionMaxLifespan` of 24h. A
+lifespan of `-1` (lines 1072-1076) means "expire with the SSO session", i.e. 24h here.
+
+**M4. The audience mapper appends, and reaches the ID token.**
+`services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceProtocolMapper.java:36`
+declares `implements OIDCAccessTokenMapper, OIDCIDTokenMapper, TokenIntrospectionTokenMapper`,
+and line 112 is `token.addAudience(audienceValue)`. Adding an audience does not replace
+`idToken.audience(client.getClientId())` set at `TokenManager.java:1270`.
+
+**M5. Gravitino validates `aud` by at-least-one match.** Gravitino v1.3.0,
+`server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java:133-147`:
+
+```java
+// Audience validation per RFC 7519 (at-least-one match)
+Set<String> acceptedAudiences = null;
+if (StringUtils.isNotBlank(serviceAudience)) {
+  acceptedAudiences = Collections.singleton(serviceAudience);
+}
+...
+new DefaultJWTClaimsVerifier<>(acceptedAudiences, exactMatchClaims, null, null);
+```
+
+A multi-valued `aud` passes as long as it contains `serviceAudience`. Note the shape: Gravitino
+accepts exactly **one** audience value, so every token reaching it must share that value.
+
+**M6. StarRocks also checks `aud` by containment,** so adding a second audience does not break
+the existing login path. `fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectVerifier.java`
+on `branch-4.1` does `Arrays.stream(requiredAudience).anyMatch(claims.getAudience()::contains)`
+against a `List<String>`.
+
+**M7. `authority` is the issuer check.** `JwksTokenValidator.java:73`:
+`this.expectedIssuer = config.get(OAuthConfig.AUTHORITY);`. `OAuthConfig.java:111-116` documents
+`authority` only as a Web UI setting, but it is what the validator compares `iss` against, and
+lines 141-144 skip the issuer check entirely when it is blank. This is a trap: the setting whose
+documentation says "Web UI" is the one that decides whether a foreign issuer's token is accepted.
+
+**M8. `principalFields` is an ordered fallback list, default `["sub"]`.**
+`OAuthConfig.java:132-139`; `JwksTokenValidator.java:199-212` returns the first non-null claim.
+
+**M9. `groupsFields` is new in 1.3.0 and silently ignores a non-List claim.**
+`OAuthConfig.java:141-148` (default `["groups"]`, `VERSION_1_3_0`);
+`JwksTokenValidator.java:216-232` returns the claim only `if (groupsObj instanceof List)`. A
+single-valued Keycloak mapper emits a string and would be dropped with no error, so the source
+mapper must be `multivalued=True`.
+
+**M10. Gravitino fails open.** `core/src/main/java/org/apache/gravitino/Configs.java:233-246`,
+`gravitino.authenticators` is `.createWithDefault(Lists.newArrayList("simple"))`, and `simple` is
+an unvalidated HTTP Basic header.
+
+**M11. `allowSkewSecs` defaults to 0** (`OAuthConfig.java:40-44`).
+
+**M12. The Iceberg REST service shares the one authenticator.**
+`iceberg/iceberg-rest-server/src/main/java/org/apache/gravitino/iceberg/server/GravitinoIcebergRESTServer.java:52`
+calls `ServerAuthenticator.getInstance().initialize(serverConfig)`, and
+`iceberg/.../RESTService.java:94-95` installs `IcebergAuthenticationFilter`, which extends the
+shared `AuthenticationFilter`. One `gravitino.authenticator.oauth.*` block governs both the
+management API and the catalog data path.
+
+**M13. Neither StarRocks client has an audience mapper today.** The only
+`AudienceProtocolMapper` in the realm is Superset's
+(`ol_data_platform.py:358-367`).
+
+**M14. `role_keys` is emitted for `ol-starrocks-client` only.** The
+`UserClientRoleProtocolMapper` at `ol_data_platform.py:616-630` is a direct client mapper on
+`ol-starrocks-client`. `ol-starrocks-cli` (`:675-700`) carries only the `starrocks_username`
+attribute mapper (`:709-720`). Humans on the interactive PKCE path arrive through
+`ol-starrocks-cli`, so **any role-driven catalog policy matches nothing for exactly those
+tokens** until this is fixed.
+
+**M15. A service account can carry `role_keys` too.** `ol_data_platform.py:202-220` grants
+`ol_platform_admin` to the Superset service account via `ClientServiceAccountRole` precisely so
+that its `client_credentials` token carries the claim. The same mechanism gives a machine
+identity group membership in Gravitino without a per-machine grant in the catalog.
+
+**M16. StarRocks' own principal mapping is already inconsistent, and this spec inherits it.**
+`applications/starrocks/__main__.py:763-764` writes
+`oauth2_principal_field = preferred_username` and `jwt_principal_field = preferred_username` into
+fe.conf, while both security integrations set `"principal_field" = "starrocks_username"`
+(`substructure/starrocks/__main__.py:649` and `:745`). fe.conf governs manually-created
+`IDENTIFIED WITH authentication_jwt` users; the integration governs auto-provisioned ones. This is
+the divergence already tracked by `tk-verify-first-then-fix-keycloak-group-sync-writes-c1bbf7`.
+
+## D1: audience
+
+`serviceAudience` is a single string (M5), so one value has to appear in every token that reaches
+the catalog. Reusing a StarRocks client id cannot work: the interactive path issues through
+`ol-starrocks-cli` and the JDBC path through `ol-starrocks-client`, and their default `aud` values
+differ.
+
+Create the audience as the machine client's own id (D2) and point every mapper at it with
+`included_client_audience`, so the string has exactly one source of truth and cannot drift.
+
+Clients needing the mapper:
+
+| Client | Why |
+|---|---|
+| `ol-starrocks-client` | JDBC browser flow; FE exchanges the code and stores this ID token. |
+| `ol-starrocks-cli` | Interactive PKCE (`starrocks-auth`); the token humans actually arrive with. |
+| `ol-gravitino-catalog` | Catalog bootstrap `client_credentials` access token. |
+
+Both `add_to_id_token=True` and `add_to_access_token=True` on all three. The ID token flag is the
+load-bearing one for the two human paths (M2 sends the ID token); the access token flag is the
+load-bearing one for the machine path, where `client_credentials` yields no ID token.
+
+Safe against the existing StarRocks check by M6.
+
+## D2: bootstrap machine client
+
+`iceberg.catalog.security=JWT` cannot create the catalog on its own:
+`RESTSessionCatalog.initialize()` runs with no user session, so `GET /v1/config` goes out
+unauthenticated. The cure, already recorded in `substructure/starrocks/__main__.py:717-733`, is to
+pair it with `iceberg.catalog.oauth2.credential`. That credential is a Keycloak
+`client_credentials` pair and needs a client.
+
+Model on `ol-marimo-app-client` (`ol_data_platform.py:782-808`): CONFIDENTIAL,
+`service_accounts_enabled=True`, standard/implicit/direct-grants all off, secret written to Vault
+by `vault.generic.Secret`, read back by the StarRocks substructure through
+`vault_get_secret_output` as it already does for `secret-operations/sso/starrocks`
+(`substructure/starrocks/__main__.py:609-623`).
+
+The catalog bootstrap is the only machine identity this spec provisions. Gravitino has **no**
+Kubernetes service-account authenticator (`gravitino.authenticators` accepts `simple`, `basic`,
+`oauth`, `kerberos` only), so any pod that talks to the catalog directly needs its own Keycloak
+service-account client. Whether Dagster and Airbyte do is not settled: see
+`tk-decide-airbyte-lakekeeper-sequencing-does-airbyt-fe6119`. Provision those clients when that
+question closes, using the same template plus a `ClientServiceAccountRole` for the role they need
+(M15).
+
+## D3: token lifetime — DECISION REQUIRED
+
+This is the sharpest constraint in the design and the one item that needs a call rather than a
+recommendation applied silently.
+
+The chain: the live realm issues 5-minute tokens (M1); the ID token expires with them (M2);
+StarRocks forces `TOKEN_REFRESH_ENABLED=false` in JWT mode, so the stored token is never
+refreshed; and `OpenIdConnectVerifier` checks `exp` at **login only**, so the StarRocks session
+outlives its own token. The result is a session that keeps answering local queries while every
+catalog call fails, roughly 5 minutes after connecting.
+
+Three options, all reachable through `keycloak.openid.Client(access_token_lifespan=...)`, which
+maps to the client attribute in M3:
+
+| Option | Effect | Cost |
+|---|---|---|
+| Leave at realm default | Catalog access breaks ~5 min into every session | Not viable |
+| `"3600"` (recommended) | Catalog access works for 1h, then 401s until reconnect | A forwarded bearer token is valid for 1h if leaked |
+| `"-1"` | Token expires with the SSO session, so 24h here (M3) | 24h leaked-token window |
+
+Recommend `"3600"` on `ol-starrocks-client` and `ol-starrocks-cli` only, leaving the realm at 5m
+for Superset, Marimo and everything else. It removes the failure mode from ordinary interactive
+work while keeping the exposure window bounded. Long-running JDBC pools will still cross the
+boundary, and the symptom to document is a mid-session catalog 401 cured by reconnecting.
+
+Note that `ssoSessionIdleTimeout` of 2h does not protect a token already issued: an external
+resource server validating a JWT against JWKS has no view of the Keycloak session, so a token
+lives to its `exp` regardless. That is the whole of the exposure argument against `-1`.
+
+## D4: principal field
+
+```properties
+gravitino.authenticator.oauth.principalFields = starrocks_username,preferred_username
+```
+
+`starrocks_username` first so a Touchstone human is the same name in a StarRocks `GRANT` and in a
+Gravitino grant. `preferred_username` second so a machine token, which has no `saml_uid` attribute
+and therefore no `starrocks_username` claim, resolves to `service-account-<client-id>` rather than
+a UUID.
+
+Two things to watch, both consequences of M8's silent fallback:
+
+- A human whose `saml_uid` attribute is unset falls through to `preferred_username`, which in this
+  realm is the email address (`registration_email_as_username=True`, `ol_data_platform.py:43`).
+  The same person would then hold grants under two different names. Add a check that no Gravitino
+  principal contains `@`.
+- If `preferred_username` turns out to be absent from a `client_credentials` token in this realm's
+  scope configuration, the principal falls through to nothing and the request is rejected with
+  "No valid principal found in token" (`JwksTokenValidator.java:156-160`). Verify against a real
+  machine token before relying on it; appending `sub` to the list is the fallback, at the cost of
+  a UUID principal in grants and audit.
+
+This does not resolve M16. StarRocks' own two paths still disagree with each other, and that stays
+with `tk-verify-first-then-fix-keycloak-group-sync-writes-c1bbf7`. What this spec does is pick the
+side that matches the auto-provisioned identity, which is the one real users get.
+
+## D5: groups from `role_keys`
+
+```properties
+gravitino.authenticator.oauth.groupsFields = role_keys
+gravitino.authenticator.oauth.groupMapper  = regex
+gravitino.authenticator.oauth.groupMapper.regex.pattern = ^(.*)$
+```
+
+The realm already emits the six governance roles as a flat multivalued `role_keys` array (M14).
+Gravitino's group source is a configurable claim name (M9), so it can read that array directly.
+Gravitino "groups" then are `ol_platform_admin`, `ol_data_engineer`, `ol_data_analyst`,
+`ol_researcher`, `ol_instructor`, `ol_business_analyst`, matching the ACL model in
+`tk-design-per-user-acl-model-for-iceberg-rest-catal-ae239e` exactly. No Keycloak groups are
+created, and the default identity regex is correct because role names carry no leading slash.
+
+**Required fix: `ol-starrocks-cli` has no `role_keys` mapper (M14).** Add one, mirroring
+`ol_data_platform.py:616-630` with `client_id` pointing at the CLI client and
+`client_id_for_role_mappings="ol-starrocks-client"` so both paths project the same client's roles.
+Without it, every human on the interactive path arrives with no groups and matches no policy.
+This is worth doing regardless of catalog choice.
+
+Do not add the shared `ol_roles` scope to either StarRocks client. The comment at
+`ol_data_platform.py:632-638` explains why: that scope carries a second `role_keys` mapper for
+`ol-superset-client` roles, and two mappers on one claim make Keycloak emit only one of them.
+
+## D6/D7: issuer and skew
+
+```properties
+gravitino.authenticators                          = oauth
+gravitino.authenticator.oauth.tokenValidatorClass = org.apache.gravitino.server.authentication.JwksTokenValidator
+gravitino.authenticator.oauth.jwksUri             = https://sso.ol.mit.edu/realms/ol-data-platform/protocol/openid-connect/certs
+gravitino.authenticator.oauth.authority           = https://sso.ol.mit.edu/realms/ol-data-platform
+gravitino.authenticator.oauth.serviceAudience     = ol-gravitino-catalog
+gravitino.authenticator.oauth.allowSkewSecs       = 30
+```
+
+Per environment the host is `sso.ol.mit.edu` (Production), `sso-qa.ol.mit.edu` (QA),
+`sso-ci.ol.mit.edu` (CI), matching `derived_relying_party_id` at `ol_data_platform.py:25-28`.
+
+`authority` is not optional. It looks like a Web UI setting and is in fact the issuer check (M7).
+`allowSkewSecs` defaults to 0 (M11), which makes validation intolerant of ordinary clock drift
+between the Keycloak pod and the Gravitino pod.
+
+## D8: assert the posture at deploy time
+
+`gravitino.authenticators` defaults to `simple`, an unvalidated HTTP Basic header (M10). A
+misrendered config, a dropped key, or a chart upgrade that resets it produces a running, healthy,
+completely unauthenticated catalog. The Lakekeeper evaluation found the same class of trap on the
+other side, so this is not a reason to prefer either product, but it is a reason not to trust the
+deployment to complain.
+
+Minimum check, run post-deploy and on a schedule:
+
+1. An unauthenticated `GET` against the Iceberg REST `/v1/config` endpoint returns 401.
+2. A request bearing a token from a different realm returns 401 (proves D6 is in force).
+3. Alert on either failing.
+
+## Pulumi changes
+
+All in `src/ol_infrastructure/substructure/keycloak/ol_data_platform.py`, inside the existing
+`# STARROCKS [START]` / `[END]` block or a new `# GRAVITINO` block beside it.
+
+```python
+# GRAVITINO [START]
+# Bootstrap credential for CREATE EXTERNAL CATALOG. security=JWT alone cannot
+# create the catalog: RESTSessionCatalog.initialize() runs with no user session,
+# so GET /v1/config goes out unauthenticated. This credential is used at catalog
+# init only; every per-user operation carries the end user's own token.
+ol_data_platform_gravitino_machine_client = keycloak.openid.Client(
+    "ol-data-platform-gravitino-machine-client",
+    name="ol-data-platform-gravitino-machine-client",
+    realm_id=ol_data_platform_realm.id,
+    client_id="ol-gravitino-catalog",
+    client_secret=keycloak_realm_config.get(
+        "ol-data-platform-gravitino-machine-client-secret"
+    ),
+    enabled=True,
+    access_type="CONFIDENTIAL",
+    standard_flow_enabled=False,
+    implicit_flow_enabled=False,
+    service_accounts_enabled=True,
+    direct_access_grants_enabled=False,
+    opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+)
+
+vault.generic.Secret(
+    "ol-data-platform-gravitino-machine-client-vault-credentials",
+    path="secret-operations/sso/gravitino-catalog",
+    data_json=Output.all(
+        client_id=ol_data_platform_gravitino_machine_client.client_id,
+        client_secret=ol_data_platform_gravitino_machine_client.client_secret,
+        realm_id=ol_data_platform_gravitino_machine_client.realm_id,
+        realm_name="ol-data-platform",
+        url=ol_data_platform_gravitino_machine_client.realm_id.apply(
+            lambda _: f"{keycloak_url}/realms/ol-data-platform"
+        ),
+    ).apply(json.dumps),
+)
+
+# Gravitino accepts exactly one serviceAudience, so every client whose tokens
+# reach the catalog has to carry the same aud value. Both token flags matter:
+# the two human paths forward the ID token, the bootstrap path has only an
+# access token. Keycloak appends rather than replaces, and both StarRocks and
+# Gravitino check aud by containment, so this does not disturb existing logins.
+for _res_name, _client in (
+    ("starrocks", ol_data_platform_starrocks_client),
+    ("starrocks-cli", ol_data_platform_starrocks_cli_client),
+    ("gravitino-machine", ol_data_platform_gravitino_machine_client),
+):
+    keycloak.openid.AudienceProtocolMapper(
+        f"ol-data-platform-{_res_name}-gravitino-audience-mapper",
+        realm_id=ol_data_platform_realm.id,
+        client_id=_client.id,
+        name="gravitino-audience",
+        included_client_audience=(ol_data_platform_gravitino_machine_client.client_id),
+        add_to_id_token=True,
+        add_to_access_token=True,
+        opts=resource_options,
+    )
+
+# The interactive PKCE path issues through ol-starrocks-cli, which had no
+# role_keys mapper, so role-driven catalog policy matched nothing for exactly
+# the tokens humans arrive with. Project the same ol-starrocks-client roles as
+# the confidential client's mapper does.
+keycloak.openid.UserClientRoleProtocolMapper(
+    "ol-data-platform-starrocks-cli-role-keys-mapper",
+    claim_name="role_keys",
+    realm_id=ol_data_platform_realm.id,
+    add_to_access_token=True,
+    add_to_id_token=True,
+    add_to_userinfo=True,
+    claim_value_type="String",
+    client_id=ol_data_platform_starrocks_cli_client.id,
+    client_id_for_role_mappings="ol-starrocks-client",
+    multivalued=True,
+    name="starrocks-role-keys",
+    opts=resource_options,
+)
+# GRAVITINO [END]
+```
+
+Plus, on both existing StarRocks client resources (D3, pending sign-off):
+
+```python
+access_token_lifespan = ("3600",)
+```
+
+`keycloak_url` is already a parameter of `create_ol_data_platform_realm`
+(`ol_data_platform.py:12`), so the issuer string in the Vault payload needs no new input.
+
+## Verification before this is called done
+
+1. Decode a real ID token from `ol-starrocks-cli` and confirm `aud` contains both
+   `ol-starrocks-cli` and `ol-gravitino-catalog`, and that `role_keys` is a JSON array (M9 drops
+   a string silently).
+2. Decode a real `client_credentials` access token from `ol-gravitino-catalog` and confirm
+   `preferred_username` is present (D4's second risk) and `aud` contains the audience.
+3. Confirm `exp - iat` on both is the configured lifespan, not 300.
+4. Confirm an existing StarRocks login still succeeds after the audience mapper lands. M6 says it
+   will; the audience change touches the one claim `oauth2_required_audience` reads.
+5. Confirm the D8 checks fail closed against a token from another realm.
+
+Items 1 through 3 need a Vault token this session did not have. They are cheap once someone with
+one runs them and they should not be skipped: the whole chain is claims arriving in the right
+shape.
+
+## What this spec does not settle
+
+- The grant model itself. `tk-spec-cedar-authorization-policy-set-for-lakekeep-cf7568` is void as
+  written and needs re-filing against Gravitino roles and groups.
+- Whether Dagster and Airbyte reach the catalog directly, and therefore whether they need their
+  own service-account clients.
+- M16, StarRocks' internal principal-field divergence.
+- The FE metadata cache, which bypasses the catalog on repeated reads under any catalog. StarRocks
+  `GRANT`s remain the query-time filter. Do not claim the catalog authorizes every access.

--- a/docs/plans/gravitino-keycloak-integration-spec.md
+++ b/docs/plans/gravitino-keycloak-integration-spec.md
@@ -318,8 +318,17 @@ deployment to complain.
 Minimum check, run post-deploy and on a schedule:
 
 1. An unauthenticated `GET` against the Iceberg REST `/v1/config` endpoint returns 401.
-2. A request bearing a token from a different realm returns 401 (proves D6 is in force).
+2. The rendered `gravitino.authenticator.oauth.authority` in the running config is non-empty and
+   equals the expected issuer for the environment.
 3. Alert on either failing.
+
+Check 2 is a configuration assertion rather than a behavioural one, deliberately. A token from
+another realm is signed by that realm's own key, which is absent from this realm's JWKS, so it is
+rejected at signature verification and returns 401 even with `authority` blank. A foreign-realm
+token therefore proves nothing about D6. Proving the issuer check behaviourally needs a token this
+realm's JWKS *will* verify carrying a foreign `iss`, which Keycloak will not mint. The equivalent
+test in a throwaway environment is to point `jwksUri` at one realm and `authority` at another and
+confirm the first realm's token is rejected.
 
 ## Pulumi changes
 
@@ -405,10 +414,15 @@ keycloak.openid.UserClientRoleProtocolMapper(
 # GRAVITINO [END]
 ```
 
-Plus, on both existing StarRocks client resources (D3, pending sign-off):
+Plus one keyword argument on each of the two existing StarRocks client resources,
+`ol_data_platform_starrocks_client` and `ol_data_platform_starrocks_cli_client` (D3, pending
+sign-off on the value):
 
 ```python
-access_token_lifespan = ("3600",)
+keycloak.openid.Client(
+    ...,
+    access_token_lifespan="3600",
+)
 ```
 
 `keycloak_url` is already a parameter of `create_ol_data_platform_realm`

--- a/docs/plans/gravitino-keycloak-integration-spec.md
+++ b/docs/plans/gravitino-keycloak-integration-spec.md
@@ -56,8 +56,9 @@ clientSessionMaxLifespan            = 0s
 session timeouts, so `accessTokenLifespan` is the Keycloak default and 5m is what is actually
 live.
 
-**M2. The ID token dies with the access token.** Keycloak 26.0.8,
-`services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java:1277`:
+**M2. The ID token dies with the access token.** Keycloak 26.7.3 (the version this repo pins at
+`src/bridge/lib/versions.py:10`),
+`services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java:1324`:
 
 ```java
 idToken.exp(accessToken.getExp());
@@ -67,7 +68,7 @@ The MySQL `authentication_openid_connect_client` plugin sends the **ID** token, 
 the token StarRocks stores and forwards.
 
 **M3. A client-level lifespan override wins, capped by the client session.** Same file,
-`getTokenExpiration`, lines 1063-1068:
+`getTokenExpiration`, lines 1077-1082:
 
 ```java
 String clientLifespan = client.getAttribute(OIDCConfigAttributes.ACCESS_TOKEN_LIFESPAN);
@@ -78,15 +79,15 @@ if (clientLifespan != null && !clientLifespan.trim().isEmpty()) {
 }
 ```
 
-and lines 1081-1085 clamp the result to `calculateClientSessionMaxLifespanTimestamp`, which with
+and lines 1098-1102 clamp the result to `calculateClientSessionMaxLifespanTimestamp`, which with
 `clientSessionMaxLifespan = 0` falls back to the realm's `ssoSessionMaxLifespan` of 24h. A
-lifespan of `-1` (lines 1072-1076) means "expire with the SSO session", i.e. 24h here.
+lifespan of `-1` (lines 1086-1090) means "expire with the SSO session", i.e. 24h here.
 
 **M4. The audience mapper appends, and reaches the ID token.**
 `services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceProtocolMapper.java:36`
 declares `implements OIDCAccessTokenMapper, OIDCIDTokenMapper, TokenIntrospectionTokenMapper`,
 and line 112 is `token.addAudience(audienceValue)`. Adding an audience does not replace
-`idToken.audience(client.getClientId())` set at `TokenManager.java:1270`.
+`idToken.audience(client.getClientId())` set at `TokenManager.java:1318`.
 
 **M5. Gravitino validates `aud` by at-least-one match.** Gravitino v1.3.0,
 `server-common/src/main/java/org/apache/gravitino/server/authentication/JwksTokenValidator.java:133-147`:

--- a/docs/plans/gravitino-spike-results.md
+++ b/docs/plans/gravitino-spike-results.md
@@ -300,9 +300,11 @@ The second set is O(number of governance roles), stable, and changes only when t
 changes. The first is per-user but is a single idempotent "add user" with no privilege decisions in
 it, unlike Lakekeeper's per-user grants or Polaris's per-user grants *plus* pre-created principals.
 
-**Still unknown:** whether `s3-token` genuinely downscopes (item 4), and how the FE metadata cache interacts with this
-(the cached-read bypass established for Lakekeeper is a StarRocks-side behaviour and applies here
-too, so StarRocks GRANTs remain the query-time filter regardless).
+**Still unknown:** how the FE metadata cache interacts with this. The cached-read bypass
+established for Lakekeeper is a StarRocks-side behaviour and applies here too, so StarRocks GRANTs
+remain the query-time filter regardless. (`s3-token` downscoping was the other open item and is no
+longer unknown: item 4 above re-ran against real AWS STS with the vending role deliberately granted
+the whole bucket, so the narrowing observed can only have come from Gravitino's session policy.)
 
 ## Non-negotiables from the prior spikes, re-checked
 

--- a/docs/plans/gravitino-spike-results.md
+++ b/docs/plans/gravitino-spike-results.md
@@ -40,7 +40,7 @@ Gravitino ran with the Iceberg REST service as an **auxiliary service** and the
 | 1 | Per-user identity reaches the catalog through `security=JWT` | **PASS** |
 | 2 | The `groups` claim arrives and is parsed | **PASS** |
 | 3 | A role granted to a GROUP allows and denies correctly | **PASS** |
-| 4 | Credential vending, per-table scope, revalidation | **PARTIAL** — vending proven, STS downscoping not |
+| 4 | Credential vending, per-table scope, revalidation | **PASS** (against real AWS STS) |
 | 5 | End-user principal in an audit trail | **PASS** |
 
 ### Item 1 — identity delegation through StarRocks: PASS
@@ -157,7 +157,71 @@ Note the asymmetry: **denials log `UNKNOWN` as the operation and `null` as the o
 only the raw HTTP method and URI. Successes are fully structured, denials are not. Usable, but a
 denial-rate alert would have to parse URIs.
 
-### Item 4 — credential vending: PARTIAL
+### Item 4 — credential vending: PASS against real AWS STS
+
+Re-run against a throwaway S3 bucket and a real IAM role, after MinIO proved unable to stand in for
+STS. **The vending role was deliberately granted the WHOLE bucket**, so any narrowing observed can
+only have come from Gravitino's session policy.
+
+With `credential-providers=s3-token`, `alice` (authorized only through her Keycloak group) loading
+the table received:
+
+```json
+{ "prefix": "s3://gravitino-spike-<redacted>/wh/ns/t",
+  "config": {
+    "s3.access-key-id": "ASIA<redacted>",
+    "s3.session-token": "<redacted>",
+    "s3.session-token-expires-at-ms": "1788899639000",
+    "client.refresh-credentials-endpoint": "v1/awscat/namespaces/ns/tables/t/credentials" } }
+```
+
+A real temporary STS credential (`ASIA…` plus session token and expiry), not the static key.
+
+**The STS session is named for the end user.** `sts get-caller-identity` with the vended credential:
+
+```
+Arn: arn:aws:sts::<account>:assumed-role/gravitino-spike-vending/gravitino_alice
+```
+
+So CloudTrail attributes the S3 access to `alice`, not to a shared service identity. That is the
+property Polaris offers as an optional flag; here it is the default.
+
+**It is genuinely downscoped.** The role can read the whole bucket. The vended credential cannot:
+
+```
+POSITIVE  ls s3://<bucket>/wh/ns/t/          -> 00000-ab7c9980-….metadata.json   (allowed)
+NEGATIVE  cp s3://<bucket>/other/secret.txt  -> 403 Forbidden
+NEGATIVE  ls s3://<bucket>/                  -> AccessDenied ... is not authorized to perform:
+                                                s3:ListBucket ... because NO SESSION POLICY
+                                                allows the s3:ListBucket action
+CONTROL   the caller key CAN read other/secret.txt, so the object is readable in principle
+```
+
+AWS names the session policy as the reason, which is direct evidence the narrowing is Gravitino's
+doing rather than the role's.
+
+**Re-validation re-checks identity.** Hitting the advertised per-table refresh endpoint:
+
+```
+alice      [200]  prefix s3://…/wh/ns/t, ASIA… key
+bob        [403]  ForbiddenException, "not authorized to perform operation
+                  'getTableCredentials' on metadata 'lakehouse.awscat.ns.t'"
+no bearer  [401]  NotAuthorizedException
+```
+
+Two caveats worth carrying forward:
+
+- **Successive refreshes return the same credential** (identical key id), so it is cached until
+  expiry rather than a fresh AssumeRole per call. The credential is already scoped and
+  time-limited, so this is a performance choice, not a hole. But a revoked grant does not
+  invalidate an already-vended credential before its expiry.
+- **Gravitino's own catalog IO does not use the assumed role.** Table metadata is written with the
+  static `s3-access-key-id`/`s3-secret-access-key`; `credential-providers=s3-token` governs only
+  what is vended to clients. `createTable` failed with `s3:PutObject ... no identity-based policy
+  allows` until the service principal was given direct S3 access on the warehouse **in addition to**
+  `sts:AssumeRole`. In EKS that means the IRSA role needs both. Put it in the deployment spec.
+
+### Superseded first attempt — `s3-secret-key` (kept, because it is a trap)
 
 **The vending mechanism works, and authorization gates it.** `alice` loading an S3-backed table
 with `X-Iceberg-Access-Delegation: vended-credentials` got a `storage-credentials` block carrying a

--- a/docs/plans/gravitino-spike-results.md
+++ b/docs/plans/gravitino-spike-results.md
@@ -1,0 +1,263 @@
+# SPIKE RESULT: Gravitino's group-claim role model
+
+Task: `tk-spike-prove-gravitino-s-group-claim-role-model-o-59dc91`
+Date: 2026-09-08
+Verdict: **the claim under test PASSES.** One defect found. One item unverified.
+
+## The claim under test
+
+Gravitino maps a JWT claim to group membership, and a role granted to a **group** reaches a user
+through it. If true, Keycloak roles drive catalog authorization with no per-user grant sync, which
+is the property the project was otherwise going to license Cedar for
+(`tk-decision-openfga-oss-second-role-vocabulary-vs-c-1497cb`).
+
+Before this spike that was documentation only. It is now measured.
+
+## Harness
+
+Matches the two Lakekeeper spikes. All local containers.
+
+| Component | Version |
+|---|---|
+| StarRocks | `4.1.3-8a8e186` (allin1-ubuntu, matches deployed) |
+| Gravitino | `1.3.0` (`groupsFields` / `groupMapper` are new in this release) |
+| Keycloak | `26.0.8` |
+| MySQL client | `9.4.0` (for `authentication_openid_connect_client`) |
+| Object store | MinIO |
+
+Two end users, `alice` in Keycloak group `/ol_data_analyst`, `bob` in `/ol_data_engineer`, plus a
+`gravitino-admin` service admin and an `ol-gravitino-machine` confidential client for the catalog
+bootstrap credential.
+
+Gravitino ran with the Iceberg REST service as an **auxiliary service** and the
+**dynamic config provider**, which its docs require for access control:
+"Standalone Iceberg REST server deployments do not support access control features."
+
+## Results
+
+| # | Item | Result |
+|---|---|---|
+| 1 | Per-user identity reaches the catalog through `security=JWT` | **PASS** |
+| 2 | The `groups` claim arrives and is parsed | **PASS** |
+| 3 | A role granted to a GROUP allows and denies correctly | **PASS** |
+| 4 | Credential vending, per-table scope, revalidation | **PARTIAL** — vending proven, STS downscoping not |
+| 5 | End-user principal in an audit trail | **PASS** |
+
+### Item 1 — identity delegation through StarRocks: PASS
+
+`alice` logged in to StarRocks over TLS with her own Keycloak id_token
+(`authentication_jwt`, `authentication_openid_connect_client`), then queried the external catalog.
+Gravitino's audit log for that session:
+
+```
+alice  LIST_SCHEMA  lakehouse.iceberg            SUCCESS  GRAVITINO_ICEBERG_REST_SERVER
+       User-Agent=StarRocks-Iceberg-Connector/4.1.3-8a8e186
+       X-Iceberg-Access-Delegation=vended-credentials
+alice  LOAD_SCHEMA  lakehouse.iceberg.analytics  SUCCESS  GRAVITINO_ICEBERG_REST_SERVER
+alice  LOAD_TABLE   lakehouse.iceberg.analytics.enrollments  SUCCESS  GRAVITINO_ICEBERG_REST_SERVER
+```
+
+The principal is `alice`, not the bootstrap machine account. StarRocks forwarded the end user's own
+token, exactly as it does to Lakekeeper.
+
+Two things confirmed in passing:
+
+- **The bootstrap-credential requirement holds for Gravitino too.** `CREATE EXTERNAL CATALOG`
+  succeeded with `security=JWT` paired with `iceberg.catalog.oauth2.credential` pointed at
+  Keycloak's token endpoint. The machine principal needs no Gravitino grants, because `/v1/config`
+  requires authentication but not authorization.
+- **StarRocks sends `X-Iceberg-Access-Delegation: vended-credentials` on its own**, unprompted.
+
+The catalog SQL that worked:
+
+```sql
+CREATE EXTERNAL CATALOG gravitino_cat PROPERTIES (
+  'type'='iceberg',
+  'iceberg.catalog.type'='rest',
+  'iceberg.catalog.uri'='http://gravitino:9001/iceberg',
+  'iceberg.catalog.warehouse'='iceberg',              -- the Gravitino CATALOG name
+  'iceberg.catalog.security'='JWT',
+  'iceberg.catalog.oauth2.server-uri'='http://keycloak:8080/realms/ol/protocol/openid-connect/token',
+  'iceberg.catalog.oauth2.credential'='ol-gravitino-machine:machine-secret',
+  'iceberg.catalog.oauth2.scope'='openid');
+```
+
+### Item 2 — the groups claim: PASS
+
+Keycloak's group-membership mapper emits full paths, and the claim is present in **both** tokens:
+
+```
+alice  id_token      groups=["/ol_data_analyst"]   aud=["ol-starrocks-client","gravitino"]
+alice  access_token  groups=["/ol_data_analyst"]   aud="gravitino"
+```
+
+The id_token is what StarRocks forwards, so `id.token.claim=true` on the mapper is load-bearing.
+This is the same trap the project already recorded for `role_keys`.
+
+`gravitino.authenticator.oauth.groupMapper.regex.pattern = ^/(.*)$` strips the leading slash, and
+the task's prediction that this would be needed was correct.
+
+**Control: membership comes from the token, not from Gravitino state.** Gravitino's stored group
+object has no member list at all:
+
+```json
+{"name":"ol_data_analyst","audit":{...},"roles":["analyst_read"]}
+```
+
+Mutating **Keycloak only**, with no Gravitino change whatsoever:
+
+```
+STATE 0  alice groups=["/ol_data_analyst"]                      loadTable=200
+         bob   groups=["/ol_data_engineer"]                     loadTable=403
+  -- remove alice from the group, add bob to it, in Keycloak --
+STATE 1  alice groups=null                                      loadTable=403
+         bob   groups=["/ol_data_analyst","/ol_data_engineer"]  loadTable=200
+  -- restore --
+         alice groups=["/ol_data_analyst"]                      loadTable=200
+         bob   groups=["/ol_data_engineer"]                     loadTable=403
+```
+
+Authorization follows the token. Throughout, `users/alice` and `users/bob` both reported
+`roles: []`.
+
+### Item 3 — group-granted role allows and denies: PASS
+
+Role `analyst_read` = `USE_CATALOG` on the catalog + `USE_SCHEMA` on the schema + `SELECT_TABLE` on
+the table. Granted **to the group `ol_data_analyst` only**. No user ever received a direct grant.
+
+```
+BASELINE (no grants)      alice listNamespaces=403  loadTable=403
+                          bob   listNamespaces=403  loadTable=403
+AFTER granting to GROUP   alice listNamespaces=200  loadTable=200
+                          bob   listNamespaces=403  loadTable=403
+
+bob's denial: ForbiddenException
+  "User 'bob' is not authorized to load table 'lakehouse.iceberg.analytics.enrollments'"
+
+users/alice roles: []      users/bob roles: []      groups/ol_data_analyst roles: ["analyst_read"]
+```
+
+Deny-by-default confirmed by the baseline. This is the claim the whole spike existed to test, and
+it holds.
+
+### Item 5 — audit trail: PASS, but off by default
+
+`gravitino.audit.enabled` defaults to false; the server logs "Audit log is not enabled" at startup
+and `gravitino_audit.log` stays empty. Once enabled, entries carry the end-user principal, the
+operation, the fully-qualified object, outcome, source and client IP:
+
+```
+alice  LOAD_TABLE  lakehouse.iceberg.analytics.enrollments  SUCCESS  GRAVITINO_ICEBERG_REST_SERVER
+bob    UNKNOWN     null                                     FAILURE  GRAVITINO_ICEBERG_REST_SERVER
+       {http.method=GET, http.uri=/iceberg/v1/iceberg/namespaces/analytics/tables/enrollments,
+        http.status=403}
+```
+
+Note the asymmetry: **denials log `UNKNOWN` as the operation and `null` as the object**, leaving
+only the raw HTTP method and URI. Successes are fully structured, denials are not. Usable, but a
+denial-rate alert would have to parse URIs.
+
+### Item 4 — credential vending: PARTIAL
+
+**The vending mechanism works, and authorization gates it.** `alice` loading an S3-backed table
+with `X-Iceberg-Access-Delegation: vended-credentials` got a `storage-credentials` block carrying a
+**per-table prefix**:
+
+```json
+"storage-credentials": [
+  { "prefix": "s3://warehouse/wh/sales/orders",
+    "config": { "s3.access-key-id": "minioadmin", "s3.secret-access-key": "minioadmin" } }
+]
+```
+
+`bob`, who is not an analyst, got `403 ForbiddenException` and no credentials at all. So the
+authorization decision gates credential issue, not just metadata.
+
+**But read that credential carefully. It is the catalog's own static root key, verbatim.** Under
+`credential-providers=s3-secret-key` the `prefix` is descriptive metadata only; the credential
+handed to the user grants whatever the catalog's configured key grants, which here is the entire
+MinIO instance. Anyone authorized for one table receives a credential good for the whole bucket.
+**This is a trap: picking the convenient provider silently destroys the blast-radius property that
+is the main reason to want vending at all.**
+
+Real downscoping requires `credential-providers=s3-token` (STS AssumeRole). That path **could not
+be verified here**: MinIO does not accept an AWS-style role ARN, and the load failed with
+
+```
+500  "Failed to generate credential using org.apache.gravitino.s3.credential.S3TokenGenerator"
+```
+
+That is an environment limitation, not a Gravitino defect. Whether `s3-token` produces genuinely
+scoped, per-table, per-request-revalidated credentials the way Lakekeeper's signer was measured to
+remains **unmeasured**, and needs real AWS STS to settle. Do not assume parity.
+
+(The host disk was at 100% when this item was first attempted, and MinIO refused all writes with
+`Status Code: 507`. Clearing 96G of `uv` cache unblocked it.)
+
+## DEFECT: a cache-expiry miss is resolved as DENY
+
+The first authorization check after a jcasbin cache entry expires returns **403 for a user who is
+authorized**. The immediately following identical request returns 200.
+
+Measured across four configurations, changing only `gravitino.authorization.jcasbin.cacheExpirationSecs`:
+
+| TTL | idle gap | first call | next call | trials |
+|---|---|---|---|---|
+| 5s | 12s | **403** | 200 | 10/10 |
+| 30s | 40s | **403** | 200 | 2/3 |
+| 30s | 10s (< TTL) | 200 | 200 | 0/6 |
+| 3600s (default) | 12s (< TTL) | 200 | 200 | 0/6 |
+
+The behaviour appears and disappears with the TTL alone, so the cause is cache expiry, not the
+particular value. It fails **closed**, so it is not a security hole. But at the default 3600s TTL
+it means an authorized user who comes back after an idle hour gets one spurious "not authorized"
+error before their query works. Through StarRocks that surfaces as a failed query, not a retryable
+blip the user can't see.
+
+I did not observe this at the literal 3600s setting, which would need an hour of idling. The
+extrapolation from the 5s and 30s results is inference, not measurement.
+
+Worth an upstream issue against Gravitino before anyone commits to it.
+
+## What this does and does not settle
+
+**Settles:** the role vocabulary question. Gravitino drives catalog authorization from Keycloak
+group membership carried in the token. Per-user role assignment does not need syncing, which is the
+recurring, drift-prone half of the OpenFGA option and the entire reason Cedar was attractive.
+
+**Does not eliminate provisioning.** Two things still have to exist inside Gravitino:
+
+1. **Users must be added to the metalake.** `alice` and `bob` were added explicitly. This is
+   per-user, and it does not go away.
+2. **Groups must exist in Gravitino, with role grants attached**, and the group name must match the
+   post-`groupMapper` claim value.
+
+The second set is O(number of governance roles), stable, and changes only when the role model
+changes. The first is per-user but is a single idempotent "add user" with no privilege decisions in
+it, unlike Lakekeeper's per-user grants or Polaris's per-user grants *plus* pre-created principals.
+
+**Still unknown:** whether `s3-token` genuinely downscopes (item 4), and how the FE metadata cache interacts with this
+(the cached-read bypass established for Lakekeeper is a StarRocks-side behaviour and applies here
+too, so StarRocks GRANTs remain the query-time filter regardless).
+
+## Non-negotiables from the prior spikes, re-checked
+
+- **Fail-open check.** `gravitino.authenticators` defaults to `simple`, which reads an unvalidated
+  HTTP Basic header. That is a genuine fail-open default. With `oauth` configured, unauthenticated
+  requests to both `:8090` and the IRC on `:9001` returned **401**, so this deployment fails closed.
+  Assert this explicitly in any real deployment, the way the Lakekeeper spike learned to assert
+  `/management/v1/info`.
+- **Grant at the narrowest level.** Privileges inherit downward, and `USE_CATALOG` + `USE_SCHEMA`
+  are both required in addition to `SELECT_TABLE`.
+- **Bootstrap credential at catalog init.** Required, as for Lakekeeper. StarRocks#75792/#75811
+  apply to any REST catalog.
+- **StarRocks GRANTs are still the query-time filter.** During item 1, `alice` was authorized by
+  Gravitino but StarRocks refused the SELECT until its own grant existed
+  (`ERROR 5203 ... you need the SELECT privilege on TABLE enrollments`). Defence in depth works as
+  described; neither layer substitutes for the other.
+
+## Reproducing
+
+Harness lives in the session scratchpad (`gspike/`): `compose.yaml`, `gravitino.conf`,
+`kc/realm-ol.json`, `sr/fe.conf`, and numbered `step*.sh` scripts, one per item. It is not
+committed; it is a throwaway lab, and the versions above are what matter for reproducing it.

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -220,6 +220,137 @@ cadences. Lakekeeper is pre-1.0 at v0.13.3 and is a single-vendor project with a
 None of this is disqualifying on its own, but the governance difference is real: an ASF project
 cannot move a feature we depend on behind a licence.
 
+## What the rest of the project says (swept 2026-09-08, after the Gravitino spike)
+
+A pass over every task and memory in
+`wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`, looking for evidence that tilts the
+choice. It does tilt, in both directions, and the net is a reframing rather than a winner.
+
+### First, a correction to this document's own premise
+
+An earlier section of this file said the project's "evaluate catalog options" step "was never
+done". **That was wrong.** `tk-evaluate-iceberg-rest-catalog-options-for-jwt-de-17d9c3` closed
+2026-06-25 having compared Nessie, Polaris, Lakekeeper and Unity Catalog OSS. The real gap was
+narrower: it never considered Gravitino, and Gravitino is the one that changes the answer.
+
+But that evaluation is not a reliable input any more, and this matters for how much weight the
+incumbent deserves. It recommended "Lakekeeper v0.12.4 with Cedar" on the grounds that Lakekeeper
+"maps `realm_access.roles` claim to per-table Cedar policies **without pre-registering
+principals**" and was "the only catalog that has both first-class StarRocks validation AND direct
+JWT-claim-driven RBAC". Since then:
+
+- Cedar turned out to be **Vakamo enterprise-only**, absent from the OSS build.
+- The roles claim **does not bind** in the OSS build; `/management/v1/role` stays empty.
+- Gravitino **also** has direct claim-driven RBAC, now measured, not documented.
+- The version pin (0.12.4) is two minors stale.
+
+So Lakekeeper's incumbency rests on an evaluation whose central differentiator did not survive
+contact with the software. That is not a reason to drop it, but it is a reason not to treat
+"we already chose Lakekeeper" as evidence.
+
+### Tilts toward Gravitino
+
+**1. The ACL model this project already designed is purely role-to-namespace.** This is the
+strongest single signal in the graph. `tk-design-per-user-acl-model-for-iceberg-rest-catal-ae239e`
+(closed) maps the six governance roles onto namespace-level grants:
+
+```
+ol_data_analyst:     SELECT on silver_analytics, gold_analytics, gold_operations
+ol_researcher:       SELECT on silver_analytics, gold_analytics
+ol_instructor:       SELECT on gold_analytics, gold_operations
+...
+```
+
+There is not a single per-user grant anywhere in it. That is precisely what Gravitino's group-claim
+model expresses natively: six groups, six roles, done, with membership arriving in the token. Under
+Lakekeeper OSS it is the awkward case, because the roles claim does not bind and each role has to
+be projected onto every user as explicit grants. **The design that already exists fits Gravitino
+and fights Lakekeeper.**
+
+**2. The second-vocabulary cost is already on record as a known pain, next to a live bug of the
+same shape.** `pf-openfga-operational-profile-measured-and-how-it--488b31` puts it plainly: grants
+"must be projected from Keycloak into Lakekeeper by more automation — a second thing shaped exactly
+like `keycloak_group_sync.py`, inheriting the same staleness and reload problems already open on
+that one". Those problems are not hypothetical:
+`tk-verify-first-then-fix-keycloak-group-sync-writes-c1bbf7` (p1, open) records that the existing
+sync "will deny all OIDC login the moment the path is used", and
+`tk-put-the-keycloak-starrocks-group-sync-on-a-sched-f660b3` records that a CronJob alone cannot fix
+it because the FE never reloads. Committing to build a second sync of that shape, while the first
+is broken, is a real strike.
+
+**3. Smaller operational footprint.** The house pattern is one RDS instance per application
+(`OLPostgresDBConfig`, `db.t4g.small`), and OpenFGA's vendor guidance says its datastore "should be
+used exclusively for OpenFGA". Lakekeeper+OpenFGA is two services and two databases per
+environment: **four RDS instances** across QA and Production. Gravitino is one service and one
+database: **two**.
+
+**4. End-user attribution in CloudTrail**, from the STS session naming measured in the spike. Not
+required by any task, but the project's stated motivation is precisely to stop "sharing the pod's
+IRSA service identity".
+
+### Tilts toward Lakekeeper
+
+**1. Kubernetes service-account authentication, which Gravitino does not have.** The closed
+dual-catalog design (`tk-resolve-lakekeeper-access-for-native-auth-no-jwt-daf21e`) explicitly
+depends on it: "enable `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION=true` — pods authenticate via
+their K8s SA token as `k8s~namespace~sa-name` principals, **no separate Keycloak service accounts
+needed**". Lakekeeper's config confirms it (`enable_kubernetes_authentication`,
+`kubernetes_authentication_audience`). **Gravitino 1.3.0 has no Kubernetes authenticator** —
+`gravitino.authenticators` accepts only `simple`, `basic`, `oauth`, `kerberos` (verified against
+the 1.3.0 docs).
+
+Under Gravitino, the Dagster and Airbyte pods need Keycloak service-account clients and secrets in
+Vault instead. This touches two already-planned implementation tasks. Two counterweights: the repo
+provisions such clients routinely (`ol-marimo-app-client`, `ol-starrocks-client`, superset), so it
+is more of an existing pattern rather than a new capability; and it keeps machine identities in
+**one** vocabulary (Keycloak) instead of Lakekeeper's three (`oidc~sub`, `k8s~ns~sa`, and
+Lakekeeper-managed roles).
+
+**2. OpenFGA generalizes beyond the catalog; Gravitino's authorization does not.** This is the
+strongest pro-Lakekeeper argument in the graph, and it is an argument about the estate rather than
+about catalogs. `pf-openfga-candidate-use-cases-beyond-lakekeeper-an-654747` names two strong fits:
+`ol-analytics-api`'s `require_org_manager`, which today answers "is this user a manager of this
+org?" with a synchronous HTTP round-trip to MITx Online, and the unresolved MIT-admin membership
+problem where "role DEFINITION is Pulumi-managed while role MEMBERSHIP has NO OWNING SYSTEM".
+That memory's own verdict on Cedar — "an EMBEDDED authorizer ... NOT a standalone service other
+applications can query" — applies verbatim to Gravitino's built-in authorization.
+
+The counterweight is recorded in the same place: every extra consumer promotes OpenFGA from a
+Lakekeeper dependency to a **tier-0 cross-service dependency** that fails closed with a ~10s hang
+per request and a lagging `/health`.
+
+**3. Adopting Gravitino means running a second metadata system alongside OpenMetadata.** Not
+previously flagged anywhere in this project, and it deserves an explicit decision rather than a
+later discovery. Gravitino is a metadata lake and catalog-federation service, not narrowly an
+Iceberg catalog; OpenMetadata already runs in the same data cluster
+(`applications/open_metadata`), and the two overlap on cataloguing, lineage and tagging. Lakekeeper
+has no such overlap. Whoever takes the decision should say where the boundary sits, or scope
+Gravitino deliberately to its Iceberg REST service and nothing else.
+
+### Neutral
+
+The Glue migration path (`iceberg-catalog-migrator --target-catalog-type REST`), dbt-starrocks
+(unaffected, it reads through the StarRocks external catalog), the FE metadata-cache bypass
+(StarRocks-side, applies to both), and Helm-via-Pulumi deployment (established for both).
+
+### The reframing
+
+The project's own artifacts favour **Gravitino on the thing this project is actually for** —
+per-role catalog authorization driven by Keycloak, matching an ACL model that is already designed
+and contains no per-user grants — and favour **Lakekeeper on adjacent concerns**: machine
+authentication for in-cluster pods, and OpenFGA as reusable estate infrastructure.
+
+So the decision hinges on a question that is not about catalogs at all:
+
+> **Does OL want a general-purpose, standalone authorization service?**
+
+If yes, OpenFGA is worth its cost and Lakekeeper is the way in, with the second role vocabulary as
+the price of admission. If no, Gravitino serves the designed model with less machinery, and the
+k8s-auth gap is the price of admission instead.
+
+That question should be answered by someone with a view of `ol-analytics-api` and the feedback
+system, not by this project alone.
+
 ## Recommendation
 
 **Do not switch on documentation alone, and do not settle the OpenFGA-vs-Cedar fork yet.**

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -1,0 +1,252 @@
+# Iceberg REST catalog evaluation: Lakekeeper vs Apache Polaris vs Apache Gravitino
+
+Status: evaluation complete, recommendation pending one spike
+Date: 2026-09-08
+Project: `wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`
+Task: `tk-evaluate-iceberg-rest-catalog-options-lakekeeper-2e4ed9`
+
+## Why this exists
+
+The project's stated scope includes "evaluating Iceberg REST catalog options". That step was
+skipped. Two spikes and every dependent spec assumed Lakekeeper. Before the Keycloak and EKS
+specs encode Lakekeeper-specific configuration, and before the open p0 fork
+(`tk-decision-openfga-oss-second-role-vocabulary-vs-c-1497cb`) is settled, the alternatives get
+the same scrutiny.
+
+Versions examined: Lakekeeper v0.13.1 (deployed pin; v0.13.3 released 2026-08-17), Apache Polaris
+1.7.0 (released 2026-08-02, `main` at 1.8.0-SNAPSHOT), Apache Gravitino 1.3.0 (released
+2026-06-29, `main` at 2.0.0-SNAPSHOT).
+
+## Criteria
+
+These come from what the two spikes proved actually matters, not from a generic feature grid.
+
+| # | Criterion |
+|---|---|
+| A | Accepts an externally issued OIDC token as bearer. StarRocks forwards the Keycloak id_token verbatim under `iceberg.catalog.security=JWT`; the catalog must validate it against Keycloak's JWKS rather than minting its own tokens. |
+| B | Catalog init: `GET /v1/config` is called with no user session. |
+| C | Authorization vocabulary: can policy key on Keycloak roles/groups, or does it need a second vocabulary kept in sync? |
+| D | Credential vending / per-table storage downscoping. |
+| E | Audit trail carrying the end-user principal. |
+| F | Open source vs enterprise gating. |
+| G | Operational footprint in EKS. |
+
+## Summary
+
+| | Lakekeeper 0.13 | Polaris 1.7 | Gravitino 1.3 |
+|---|---|---|---|
+| A. External OIDC bearer | Yes, **measured** end to end | Yes, documented | Yes, documented |
+| B. `/v1/config` | Requires auth; cured by bootstrap credential | Same StarRocks-side issue | Same StarRocks-side issue |
+| C. Principal provisioning | **Self-registers on first touch** | **Must pre-exist; auth fails otherwise** | Must be added to metalake |
+| C. Role vocabulary | Second vocabulary, own sync | Second vocabulary, own sync, roles only *select* existing grants | **Group claim drives role membership** |
+| D. Credential vending | Yes, **measured** (per-table, identity + location revalidated) | Yes, optional principal in STS session name | Yes (S3, GCS, OSS, ADLS) |
+| E. End-user audit | Yes, **measured** | Not verified | Not verified |
+| F. Licensing | Apache-2.0 core, **Cedar authorizer is enterprise** | Apache-2.0, ASF top-level | Apache-2.0, ASF top-level |
+| G. Footprint | Service + Postgres, plus OpenFGA + its own Postgres | Service + Postgres (+ OPA if used, beta) | Service + backend DB (+ Ranger if pushdown wanted) |
+
+Bold entries are the ones that decide this.
+
+## Findings
+
+### Criterion A: external OIDC token
+
+All three can validate a Keycloak-issued JWT against JWKS.
+
+- **Lakekeeper.** `LAKEKEEPER__OPENID_PROVIDER_URI` / `OPENID_AUDIENCE` /
+  `OPENID_SUBJECT_CLAIM` / `OPENID_ROLES_CLAIM` (`crates/lakekeeper/src/config.rs:395-436`).
+  This is the only one of the three measured against our exact StarRocks build: the
+  2026-08-07 spikes showed two distinct end-user subjects reaching Lakekeeper's audit log
+  through StarRocks, and the follow-up spike showed per-user allow and deny actually enforced.
+- **Polaris.** `polaris.authentication.type=external` delegates to Quarkus OIDC
+  (`quarkus.oidc.auth-server-url`, `quarkus.oidc.client-id`), with
+  `polaris.oidc.principal-mapper.{id,name}-claim-path` selecting the claims. There is a
+  Keycloak integration guide in tree. Note the documented caveat that the default
+  `PrincipalMapper` only handles JWT, not opaque tokens; that is fine for us.
+- **Gravitino.** `gravitino.authenticators=oauth` with
+  `gravitino.authenticator.oauth.jwksUri` and
+  `tokenValidatorClass=org.apache.gravitino.server.authentication.JwksTokenValidator`.
+  `gravitino.authenticator.oauth.principalFields` names the claim that becomes the username
+  and defaults to `sub`.
+
+Not a discriminator.
+
+### Criterion B: `GET /v1/config` at catalog creation
+
+This is a StarRocks-side problem, not a catalog-side one. `IcebergRESTCatalog`'s constructor
+calls `RESTSessionCatalog.initialize()` with no user session, so the config call goes out
+unauthenticated, and the fix (pair `security=JWT` with a bootstrap
+`iceberg.catalog.oauth2.credential`) applies to any REST catalog that requires auth there.
+StarRocks#75792 / #75811 apply equally to all three.
+
+Not a discriminator.
+
+### Criterion C: authorization vocabulary
+
+This is the criterion that decides the evaluation, and it reverses part of the framing in the
+open p0 decision task.
+
+**Lakekeeper self-registers users on first contact.** `crates/lakekeeper/src/server/config.rs:185-235`
+registers the authenticated principal on the `/config` call ("Register on first touch"),
+stamping `UserLastUpdatedWith::ConfigCallCreation`. No per-user pre-provisioning. This is why
+alice and bob appeared in the spike's audit log without setup.
+
+What Lakekeeper does *not* give you is roles from the token. The spike measured
+`/management/v1/role` staying empty with `OPENID_ROLES_CLAIM` set, so grants are explicit,
+per-user or to Lakekeeper-managed Role entities. v0.13.1 does now carry token roles into
+`RequestMetadata` (`service/authn.rs:465-467`, `request_metadata.rs:96-271`), but the only
+consumer in tree is the admission layer (`service/admission.rs`), not OpenFGA tuples. SCIM is
+explicitly not implemented: the concepts doc says "We are looking into SCIM support" and points
+at issue #497. So the second-vocabulary-plus-own-sync cost in the decision task stands.
+
+**Polaris is worse than Lakekeeper here, not better.** `DefaultAuthenticator` is the only
+`Authenticator` implementation in the tree, and it carries this in its class javadoc
+(`runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java:59-61`):
+
+> **This authenticator is used in both internal and external authentication scenarios. For now,
+> it does not support federated principals that are not managed by Polaris.**
+
+`resolvePrincipalEntity` loads the principal from the Polaris metastore by id or name and throws
+`AuthenticationFailedException("Unable to authenticate")` when it is absent. And
+`resolvePrincipalRoles` intersects the roles requested in the token against the grants the
+principal *already holds in Polaris*: the OIDC role claim selects among existing grants, it does
+not confer any. `PolarisAdminService` further refuses to create a federated principal, assign a
+role to one, or rotate its credentials.
+
+So Polaris under external OIDC needs every end user created as a Polaris PRINCIPAL entity *and*
+every role granted to them inside Polaris. That is strictly more synchronisation than Lakekeeper,
+which needs only the grants. The docs present the principal-roles-mapper as if Keycloak roles
+drive Polaris authorization; the code shows they only filter it.
+
+**Gravitino has the property the project wanted to buy Cedar for.** Two settings:
+
+```properties
+gravitino.authenticator.oauth.principalFields = preferred_username
+gravitino.authenticator.oauth.groupsFields    = groups
+```
+
+`groupsFields` names the claim supplying group membership, and Gravitino's own documentation
+states this "is how a role granted to a group reaches a user". Roles are granted to groups once;
+membership arrives in the token. There is also a configurable `groupMapper` (regex by default)
+for rewriting claim values into Gravitino group names, which matters because Keycloak emits group
+paths as `/name`.
+
+Users must still be added to a metalake before they can act in it, so per-user provisioning does
+not disappear. What disappears is the per-user *role assignment* sync, which is the recurring,
+drift-prone half. That is the same benefit Cedar was going to be licensed for, in an Apache-2.0
+project.
+
+### Criterion D: credential vending
+
+All three vend subscoped storage credentials. Lakekeeper's is measured: per-table path with the
+signer revalidating identity and location per request.
+
+Polaris adds one thing worth noting: a feature flag that puts the principal name into the STS
+session name (`polaris-<principal>` rather than `polaris`), which would make CloudTrail attribute
+S3 access to the end user. Its own documentation notes the cost, that per-principal sessions
+defeat credential caching.
+
+### Criterion E: end-user audit
+
+Measured only for Lakekeeper. Unverified for the other two. Do not assume it.
+
+### Criterion F: licensing
+
+Lakekeeper's Cedar authorizer is a Vakamo enterprise offering. `lakekeeper-bin/src/main.rs` at
+v0.13.1 wires only OpenFGA and bails on any other external authorizer, despite the nightly docs
+presenting Cedar as a standard option. This project has already lost time to that once.
+
+Polaris and Gravitino are both ASF top-level projects under Apache-2.0 with their authorization
+in the open-source build. Polaris additionally ships an OPA authorizer, currently marked Beta and
+subject to breaking changes.
+
+Lakekeeper is the only one of the three where the preferred authorization model sits behind a
+commercial licence whose price we still do not know.
+
+### Criterion G: operational footprint
+
+- **Lakekeeper**, Option A of the open decision: Lakekeeper + Postgres, plus a separate OpenFGA
+  service and its own Postgres. Two services, two databases.
+- **Polaris**: one service plus its metastore. Add OPA only if the internal RBAC is not enough.
+- **Gravitino**: one service plus its backend store. The Iceberg REST service is a component of
+  it. Apache Ranger only if authorization pushdown to other engines is wanted, which is not our
+  case.
+
+Helm charts exist for all three.
+
+## Maturity
+
+Polaris (1.7.0) and Gravitino (1.3.0) are both graduated ASF projects on monthly-ish release
+cadences. Lakekeeper is pre-1.0 at v0.13.3 and is a single-vendor project with a commercial tier.
+None of this is disqualifying on its own, but the governance difference is real: an ASF project
+cannot move a feature we depend on behind a licence.
+
+## Recommendation
+
+**Do not switch on documentation alone, and do not settle the OpenFGA-vs-Cedar fork yet.**
+
+Lakekeeper is the only candidate with measured end-to-end evidence against our exact StarRocks
+build, covering identity delivery, enforcement, and storage delegation. That evidence is worth
+real money and should not be discarded for a feature matrix.
+
+But Gravitino's group-claim-driven role model dissolves the fork that is currently blocking the
+project's top-priority decision. The whole reason Cedar was attractive was one role model driving
+both StarRocks RBAC and catalog policy, and the whole reason it is a problem is that it costs
+money and we could not exercise it. Gravitino appears to offer that property in an Apache-2.0
+build. "Appears" is doing work in that sentence: it is documentation, not measurement, which is
+exactly the epistemic position that the Cedar option is in and that the project has already been
+burned by.
+
+Concretely:
+
+1. **Run a Gravitino spike on the same harness as the two Lakekeeper spikes** (StarRocks 4.1.3,
+   Keycloak 26.x, local containers, two distinct end users). Prove or disprove, in order:
+   per-user identity reaches the catalog through `security=JWT`; the `groups` claim actually
+   drives role membership; a role granted to a group allows and denies correctly; credential
+   vending works. Same bar the Lakekeeper enforcement spike had to clear. This is a bounded piece
+   of work and it is the only thing that can responsibly settle the fork.
+2. **Rank Polaris third and do not pursue it** unless the Gravitino spike fails and the Cedar
+   price turns out to be unacceptable. It is dominated: more user-provisioning burden than
+   Lakekeeper, and no group-claim path to role assignment. Its OIDC role mapping does not do what
+   the docs imply.
+3. **Hold the Keycloak and EKS specs** at the parts that are catalog-independent. The audience
+   mapper, the machine service-account client, and the token-lifetime constraint apply to any of
+   the three; the specific environment-variable names do not.
+4. **Keep pricing discovery moving in parallel.** If Gravitino proves out, the Cedar quote stops
+   mattering. If it does not, the fork is back and the quote is on its critical path.
+
+## What is true regardless of the choice
+
+Unchanged from the earlier spike findings, and worth restating because it survives every option
+here:
+
+- The FE metadata cache bypasses the catalog. Catalog-side authorization is not consulted on
+  cached metadata reads, under any of these three. StarRocks GRANTs remain the query-time filter;
+  the catalog is enforcement on actual catalog traffic. Do not promise that every access is
+  authorized by the catalog or that the catalog audits every read.
+- Per-table storage downscoping is a real blast-radius improvement over Glue's single ambient
+  IRSA identity, and it is available in all three.
+- TLS on the StarRocks FE is mandatory for every human client on the JWT path, independent of
+  catalog choice.
+
+## Sources
+
+All file references are to the released versions named at the top, read from source rather than
+documentation unless stated.
+
+- Lakekeeper: `crates/lakekeeper/src/config.rs:395-436` (OIDC config),
+  `crates/lakekeeper/src/server/config.rs:185-235` (first-touch user registration),
+  `crates/lakekeeper/src/service/authn.rs:355-402` (authenticator construction, subject claim
+  defaults `["oid","sub"]` with an explicit recommendation to set it in production),
+  `docs/docs/concepts.md:127` (SCIM not implemented, issue #497).
+- Polaris: `runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java:59-61,
+  120-160` (federated principals unsupported, principal must resolve, roles select among existing
+  grants), `runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java:1084,
+  1559` (cannot create federated principal, cannot assign a role to one),
+  `site/content/in-dev/unreleased/managing-security/external-idp/_index.md`,
+  `site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_authorization_opa.md`
+  (OPA authorizer, Beta).
+- Gravitino: `docs/security/access-control.md:505-530` (principalFields, groupsFields, users must
+  be added to a metalake), `docs/security/how-to-authenticate.md:96-215` (JWKS validation, group
+  mapping), `docs/security/credential-vending.md`, `docs/iceberg-rest-engine/starrocks.md`.
+- StarRocks: `fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectVerifier.java`
+  on `branch-4.1`.

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -393,6 +393,90 @@ policy/tag subsystem could in principle close it in one system, which is an argu
 Gravitino rather than against; Lakekeeper cannot, and OpenMetadata's own policy engine governs
 OpenMetadata, not data access.
 
+### Authorization head-to-head: Lakekeeper + OpenFGA vs Gravitino built-in
+
+The two configurations actually on the table. Cedar is excluded (enterprise), Ranger is excluded
+(wrong stack, and catalog-independent anyway). Both columns are backed by a spike against
+StarRocks 4.1.3 and Keycloak 26.0.8; **bold** marks a measured result rather than a documented one.
+
+| Dimension | Lakekeeper + OpenFGA | Gravitino built-in |
+|---|---|---|
+| Paradigm | ReBAC — relationship tuples in an external engine | RBAC + ownership, embedded (jcasbin) |
+| Role membership source | **Explicit grants only.** The token's roles claim does not become a grantable principal | **The token.** Group claim drives role membership |
+| Grantable principals | Users, Lakekeeper-managed Roles, **k8s service accounts** | Users, Groups |
+| Role nesting | Yes, arbitrary | No — roles are flat sets of object+privilege |
+| Ownership model | Project/warehouse admin roles | First-class on 13 object types, incl. **group ownership** |
+| Object hierarchy | Project → Warehouse → Namespace → Table | Metalake → Catalog → Schema → Table |
+| Column-level grants | No | No |
+| Explicit DENY | **No** — positive assignments only | **Yes**, with hard precedence over ALLOW |
+| Inheritance | **Downward; warehouse-level grants are very broad** | Downward; DENY cannot be undone by a lower ALLOW |
+| Deny presentation | **404, hides existence** | **403, names operation and object** |
+| List filtering | **Filtered to what you can see** | Not measured |
+| Storage delegation | **Per-table remote signing; signer re-validates identity AND location per request** | **Per-table STS session policy; session named for the end user** |
+| Credential revocation | Signer re-checks every request | **Cached until expiry** — a revoked grant does not invalidate an issued credential |
+| Failure mode | **503 after a ~10s hang; `/health` lags** | In-process; no network hop |
+| Misconfiguration hazard | **Unsupported authorizer silently becomes allow-all, zero log lines** | **`authenticators` defaults to `simple` (unvalidated Basic) — fails open** |
+| Correctness defect found | None | **Cache-expiry miss resolves as DENY** — spurious 403 for an authorized user |
+| Audit | **Per-user `oidc~<sub>` on each operation** | **End-user principal, operation, FQ object, outcome**; denials less structured |
+| Reusable outside the catalog | **Yes** — OpenFGA is a standalone service | No — embedded, catalog-only |
+| Footprint per env | 2 services, 2 databases | 1 service, 1 database |
+
+#### The three differences that actually decide it
+
+**1. Where role membership comes from.** This is the whole ballgame, because the ACL model this
+project already designed is role-to-namespace with no per-user grants. Gravitino reads membership
+from the token, so that model is six groups and six roles and nothing else moves. Lakekeeper OSS
+cannot read it from the token, so the same model has to be projected onto every user by
+synchronisation code — the second vocabulary. Everything else on this table is secondary to that.
+
+**2. Gravitino can express DENY; Lakekeeper cannot.** Gravitino's DENY beats ALLOW regardless of
+which role it came from or where in the hierarchy it sits, and its docs are explicit that "denials
+cannot be circumvented by grants at lower levels". Lakekeeper's grant surface is positive
+assignment only — OpenFGA's `but not` exclusion exists when *authoring* an authorization model, but
+Lakekeeper owns that model, so an operator cannot write a deny rule. The practical consequence:
+"analysts can read gold, except this one table" is one grant in Gravitino and a restructuring
+exercise in Lakekeeper. Given that the measured Lakekeeper failure mode was *accidentally granting
+too much* via a warehouse-level assignment, this is not academic.
+
+**3. Lakekeeper's storage delegation is tighter, and revocation is the reason.** Both downscope per
+table. But Lakekeeper's remote signer re-validates identity *and* the requested location on every
+signing request — a signer URL is not a bearer of authority. Gravitino issues an STS credential and
+caches it until expiry, so revoking a grant does not invalidate a credential already vended. If the
+requirement is "revoke access and have it take effect now", Lakekeeper is materially better.
+Gravitino's counter is that its STS session is named for the end user, so CloudTrail attributes S3
+access to a human.
+
+#### Two hazards that are not symmetric
+
+Both fail open when misconfigured, but differently and with different odds of being caught.
+Lakekeeper's is worse in character: setting an unsupported authorizer leaves a **running, healthy,
+completely unauthorized catalog with no log line at all**, and only `/management/v1/info` reveals
+it. Gravitino's is a default rather than a silent downgrade — leaving `gravitino.authenticators`
+unset gives you `simple`, which trusts an unvalidated HTTP Basic header. Either way the deployment
+must **assert** its own security posture at startup and alert on it; neither can be trusted to
+complain.
+
+Gravitino carries a live correctness defect that Lakekeeper does not: the first authorization check
+after a cache entry expires denies an authorized user. It fails closed, so it is a usability and
+correctness problem rather than a security one, but through StarRocks it surfaces as a failed query
+and it should be filed upstream before adoption.
+
+#### What is equal, and should not be used to argue either way
+
+Neither supports column-level grants, so neither can enforce PII at column granularity without an
+external layer. Both are bypassed by the StarRocks FE metadata cache on repeated reads, so
+catalog-side authorization is not consulted on every user action under either, and StarRocks GRANTs
+remain the query-time filter regardless. Both require the bootstrap catalog-init principal to be
+provisioned explicitly. Both were proven to deliver per-user identity end to end through
+`security=JWT`.
+
+#### Not measured
+
+For Lakekeeper: STS-based vending (the spike used remote signing against RustFS, which has no STS),
+Cedar, and OpenFGA's `reconcile` maintenance path. For Gravitino: whether list operations are
+*filtered* to visible objects or simply refused — Lakekeeper's filtering is proven and Gravitino's
+is unknown, which matters for the discovery experience. For both: behaviour under real concurrency.
+
 ### The reframing
 
 The project's own artifacts favour **Gravitino on the thing this project is actually for** —

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -173,6 +173,46 @@ commercial licence whose price we still do not know.
 
 Helm charts exist for all three.
 
+## Unity Catalog: checked and disqualified
+
+Added 2026-09-08 after it was raised. Unity Catalog OSS (unitycatalog/unitycatalog, v0.6.0
+released 2026-08-20, LF AI & Data) **fails criterion A, and fails it harder than Polaris.**
+
+It does implement the Iceberg REST API, including writes, so criterion B is fine:
+`IcebergRestCatalogService` serves `/v1/config`, namespaces, and table create/update/delete. It
+also has a `StorageCredentialVendor`. The problem is authentication.
+
+`AuthDecorator.serve()` is installed as a global security decorator covering the Iceberg REST
+service (`UnityCatalogServer.addSecurityDecorators`), and it contains:
+
+```java
+if (!issuer.equals(INTERNAL)) {
+  throw new AuthorizationException(ErrorCode.PERMISSION_DENIED, "Invalid access token.");
+}
+```
+
+with `Issuers.INTERNAL = "internal"`. Every request on the data path must carry a **UC-minted**
+token. An external IdP token is accepted only at `POST /auth/tokens`, which exchanges it for a UC
+token.
+
+StarRocks under `iceberg.catalog.security=JWT` forwards the end user's Keycloak id_token verbatim
+and performs no token exchange. So the delegation chain this whole project rests on cannot work
+against Unity Catalog without upstream changes to StarRocks, to UC, or both. Polaris at least ships
+an `external` mode that validates a foreign OIDC token directly and merely requires the principal to
+pre-exist; UC has no equivalent for data-path requests.
+
+Two lesser points, both already familiar:
+
+- `AuthDecorator` resolves the principal with `userRepository.getUserByEmail(subject)` and rejects
+  an unknown or disabled user, so per-user pre-provisioning in UC's local database is required, as
+  in Polaris.
+- Security decorators are installed only `if (serverProperties.isAuthorizationEnabled())`, carrying
+  the comment `// TODO: eventually might want to make this secure-by-default.` So it fails open when
+  unconfigured, the same class of trap as Gravitino's `simple` authenticator default.
+
+Not worth a spike. It would re-enter consideration only if UC gained a direct external-issuer mode
+on the data path.
+
 ## Maturity
 
 Polaris (1.7.0) and Gravitino (1.3.0) are both graduated ASF projects on monthly-ish release

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -411,7 +411,8 @@ StarRocks 4.1.3 and Keycloak 26.0.8; **bold** marks a measured result rather tha
 | Explicit DENY | **No** — positive assignments only | **Yes**, with hard precedence over ALLOW |
 | Inheritance | **Downward; warehouse-level grants are very broad** | Downward; DENY cannot be undone by a lower ALLOW |
 | Deny presentation | **404, hides existence** | **403, names operation and object** |
-| List filtering | **Filtered to what you can see** | Not measured |
+| List filtering | **Filtered to what you can see** | **Filtered inside a container you can reach; 403 if you cannot** |
+| Existence hiding on deny | **Yes — 404** | **No — 403 names the object** |
 | Storage delegation | **Per-table remote signing; signer re-validates identity AND location per request** | **Per-table STS session policy; session named for the end user** |
 | Credential revocation | Signer re-checks every request | **Cached until expiry** — a revoked grant does not invalidate an issued credential |
 | Failure mode | **503 after a ~10s hang; `/health` lags** | In-process; no network hop |
@@ -470,12 +471,47 @@ remain the query-time filter regardless. Both require the bootstrap catalog-init
 provisioned explicitly. Both were proven to deliver per-user identity end to end through
 `security=JWT`.
 
+#### List behaviour, measured 2026-09-08
+
+Gravitino does both, and which one you get depends on where you are in the hierarchy. Setup: one
+catalog `lf`, two sibling namespaces `gold` and `raw`, two tables in `gold`. alice was granted
+`USE_CATALOG` on `lf`, `USE_SCHEMA` on `lf.gold` and `SELECT_TABLE` on `lf.gold.t_gold` only —
+nothing on `raw`, nothing on `t_gold_secret`. bob got nothing at all.
+
+```
+admin  listNamespaces      -> [gold, raw]                    ground truth
+admin  listTables(gold)    -> [t_gold, t_gold_secret]        ground truth
+
+alice  listNamespaces      -> [gold]                  200    FILTERED, raw absent
+alice  listTables(gold)    -> [t_gold]                200    FILTERED, t_gold_secret absent
+alice  listTables(raw)     -> 403 ForbiddenException         REFUSED
+bob    listNamespaces      -> 403 ForbiddenException         REFUSED
+```
+
+**The rule: a privilege on the container is required to list it at all; once you can list it, the
+contents are filtered to what you may see.** Direct access matches — alice loads `gold.t_gold`
+(200) but not `gold.t_gold_secret` or `raw.t_raw` (403 each).
+
+The filtering half is equivalent to Lakekeeper. The refusal half is not, and the difference is
+**existence disclosure**. Lakekeeper deliberately answers an unauthorized namespace with `404
+NoSuchNamespaceException` ("Namespace not found or access denied") so a caller cannot distinguish
+absent from forbidden. Gravitino answers `403` and names the object: alice learns `lakehouse.lf.raw`
+exists, and bob learns the catalog does. Gravitino's errors also echo the internal authorization
+expression back to the caller — e.g. `ANY_USE_CATALOG && (SCHEMA::OWNER || ANY_USE_SCHEMA)` — which
+is a policy-internals leak in an end-user-visible error.
+
+None of this is severe, and Gravitino's messages are far better for debugging. But if hiding the
+existence of restricted datasets is a requirement, Lakekeeper does it by design and Gravitino does
+not.
+
+Not measured here: how this surfaces through StarRocks' `SHOW DATABASES`, which applies its own
+GRANT filter on top and is subject to the FE metadata cache. The catalog-level behaviour above is
+what the catalog itself does.
+
 #### Not measured
 
 For Lakekeeper: STS-based vending (the spike used remote signing against RustFS, which has no STS),
-Cedar, and OpenFGA's `reconcile` maintenance path. For Gravitino: whether list operations are
-*filtered* to visible objects or simply refused — Lakekeeper's filtering is proven and Gravitino's
-is unknown, which matters for the discovery experience. For both: behaviour under real concurrency.
+Cedar, and OpenFGA's `reconcile` maintenance path. For both: behaviour under real concurrency.
 
 ### The reframing
 

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -536,8 +536,18 @@ system, not by this project alone.
 Superseding the earlier "run a Gravitino spike first" version of this section. The spike ran, and
 everything it was asked to prove, it proved.
 
-**On the evidence in hand, Gravitino has the balance — contingent on one question that this project
-cannot answer by itself.**
+**Gravitino. Not contingent any more — the contingency was resolved on 2026-09-08.**
+
+The earlier version of this section made the recommendation conditional on whether OL wants a
+general-purpose standalone authorization service, because that was the only argument capable of
+outweighing Gravitino. It has been answered: **OpenFGA is not a strong contender for OL**, and the
+`ol-analytics-api` → MITx Online dependency that the August analysis called "the ideal migration
+target" is a **workaround for an architectural problem already being resolved**, not a foundation to
+build shared infrastructure on. Building OpenFGA around a call that is being designed out would
+cement the workaround as a new tier-0 dependency.
+
+So the "OpenFGA generalizes and Gravitino's embedded authorization does not" argument is void. It
+was the load-bearing one for Lakekeeper.
 
 ### Why
 
@@ -582,31 +592,42 @@ Against those, Gravitino carries one live correctness defect Lakekeeper does not
 spurious deny. It fails closed, so it is a correctness and usability problem rather than a security
 one, but it should be filed upstream and ideally fixed before production.
 
-### The contingency
+### What the resolved contingency leaves behind
 
-**If OL decides it wants a general-purpose, standalone authorization service, the answer flips to
-Lakekeeper.** OpenFGA generalizes to two named consumers outside the catalog; Gravitino's embedded
-authorization generalizes to none. That is an estate-level decision involving `ol-analytics-api`
-and the feedback system, and it should be taken deliberately rather than inherited as a side effect
-of a catalog choice. Note that it is an argument for adopting *OpenFGA*, and Lakekeeper follows from
-it — not the other way round.
+With OpenFGA declined, Lakekeeper's case reduces to the three narrow items above: revocation
+latency, Kubernetes service-account authentication, and existence hiding on deny. Those are worth
+holding onto as requirements to satisfy in whatever is adopted, but individually and together they
+do not outweigh a role model that fits the designed ACL versus one that needs a synchroniser to
+approximate it.
+
+One thing does **not** get solved by this and should not be quietly filed away: the MIT-admin
+membership problem (role definition is Pulumi-managed, role membership has no owning system, plus
+the olapps/ol-data cross-realm bind). OpenFGA was one proposed answer to it. With OpenFGA off the
+table that problem needs a different answer, and it is unrelated to the catalog.
 
 ### Recommended next steps
 
-1. **Put the OpenFGA question to whoever owns the estate view.** It is the only thing standing
-   between here and a decision.
-2. **If the answer is "no" or "not now": adopt Gravitino**, scoped deliberately to its Iceberg REST
-   service and its authorization, with OpenMetadata left as the governance and discovery plane.
-3. File the cache-expiry defect upstream regardless.
-4. **Rank Polaris third and Unity Catalog out.** Polaris is dominated; Unity Catalog cannot accept a
+1. **Adopt Gravitino**, scoped deliberately to its Iceberg REST service and its authorization, with
+   OpenMetadata left as the governance and discovery plane.
+2. **Carry Lakekeeper's three advantages forward as requirements**, not as regrets. Decide
+   explicitly what revocation latency is acceptable given that a vended STS credential lives until
+   expiry; plan Keycloak service-account clients for the Dagster and Airbyte pods; and decide
+   whether existence disclosure on denied namespaces is acceptable.
+3. **File the cache-expiry spurious-deny defect upstream** before production.
+4. **Re-scope the dependent tasks.** The Cedar policy-set spec is void as written, and the
+   Lakekeeper EKS, Keycloak and implementation tasks need rewriting against Gravitino. The
+   catalog-independent parts of the Keycloak spec (audience mapper on both tokens, machine
+   service-account client, token-lifetime constraint) survive unchanged.
+5. **Rank Polaris third and Unity Catalog out.** Polaris is dominated; Unity Catalog cannot accept a
    forwarded external token at all.
-5. The Cedar quote is off the critical path either way. Both live options are Apache-2.0.
+6. Cedar pricing is moot. Both live options were Apache-2.0 and the enterprise arm is not needed.
 
 ### Confidence, and how to discount it
 
-Moderate-to-high on the technical comparison, which rests on measurements rather than documentation
-on both sides. Lower on the weighting, because the OpenFGA contingency is a judgement about OL's
-direction that I do not have standing to make.
+High on the technical comparison, which rests on measurements rather than documentation on both
+sides. The weighting is now also settled, because the one judgement I did not have standing to make
+— whether OL wants a standalone authorization service — has been made, and it went against the
+option that needed it.
 
 One bias worth naming: the Gravitino evidence was gathered in a single session by the same person
 writing this recommendation, while the Lakekeeper evidence accumulated over two earlier spikes. The

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -319,19 +319,79 @@ The counterweight is recorded in the same place: every extra consumer promotes O
 Lakekeeper dependency to a **tier-0 cross-service dependency** that fails closed with a ~10s hang
 per request and a lagging `/health`.
 
-**3. Adopting Gravitino means running a second metadata system alongside OpenMetadata.** Not
-previously flagged anywhere in this project, and it deserves an explicit decision rather than a
-later discovery. Gravitino is a metadata lake and catalog-federation service, not narrowly an
-Iceberg catalog; OpenMetadata already runs in the same data cluster
-(`applications/open_metadata`), and the two overlap on cataloguing, lineage and tagging. Lakekeeper
-has no such overlap. Whoever takes the decision should say where the boundary sits, or scope
-Gravitino deliberately to its Iceberg REST service and nothing else.
+**3. Gravitino ships a metadata-platform surface that overlaps OpenMetadata; Lakekeeper does not.**
+This is real but narrower than it first looks — see the section below, which walks the actual
+overlap against the live OpenMetadata instance. It is a scope-discipline risk, not a technical
+blocker, and part of what I first counted here turned out to be symmetric between the two
+candidates.
 
 ### Neutral
 
 The Glue migration path (`iceberg-catalog-migrator --target-catalog-type REST`), dbt-starrocks
 (unaffected, it reads through the StarRocks external catalog), the FE metadata-cache bypass
 (StarRocks-side, applies to both), and Helm-via-Pulumi deployment (established for both).
+
+### Gravitino vs OpenMetadata: the actual overlap
+
+Measured against the live production OpenMetadata on 2026-09-08, because the first version of this
+section asserted an overlap without checking one.
+
+**What OpenMetadata actually holds today:**
+
+| | count |
+|---|---|
+| database services | 2 (Glue, Starburst Galaxy) |
+| tables | 3,465 (2,795 Trino, 670 Glue) |
+| PII classification tags | 1,951 (1,384 `pii.nonsensitive`, 567 `pii.sensitive`) |
+| data-quality test cases | 3,781, `testPlatforms: ["dbt"]` |
+| glossary terms | 0 |
+| owners / tiers / domains / certifications | 0 |
+
+So its live value is discovery over ~3.5k tables, **PII classification at scale**, and **dbt test
+results**. The governance features it also ships (glossary, ownership, tiering, domains) are
+deployed but unused.
+
+**Where the two genuinely overlap.** Gravitino is a metadata platform, not narrowly an Iceberg
+catalog: alongside its catalogs (Hive, Glue, Iceberg, Paimon, Hudi, Delta/Lance, seven JDBC
+flavours, Kafka, filesets, models) it ships `manage-tags-in-gravitino.md`,
+`manage-policies-in-gravitino.md`, `manage-statistics-in-gravitino.md` and a `lineage/` subsystem
+with server and Spark lineage. Four things are modelled by both: **a table inventory, tags,
+lineage, and access policy.**
+
+**Where they do not overlap at all.** OpenMetadata has PII auto-classification, data profiling,
+data-quality test ingestion, a business glossary and the discovery UI humans actually use.
+Gravitino has none of those. Note also that one of its apparent overlaps is a false positive:
+Gravitino's `glossary.md` is a documentation glossary of terms ("API", "AWS"), **not** a business
+glossary feature.
+
+**The distinction that matters is role, not features.** OpenMetadata is a *passive* plane: it reads
+metadata *about* systems and nothing queries data through it. Gravitino is an *active* plane:
+engines resolve tables through it and it vends the credentials they use. A table would be known to
+both, from opposite directions. That is duplication of a record, not of a function.
+
+**One thing I initially miscounted as a Gravitino risk is symmetric.** OpenMetadata ingests today
+from Glue and Trino. If any REST catalog becomes the catalog of record, the Glue source stops
+seeing those tables — and that is equally true of Lakekeeper. The already-planned mitigation covers
+both:
+`tk-replace-the-five-trino-openmetadata-cronomjobs-m-0bbe3f` moves those jobs to **StarRocks and
+Glue sources**, and a StarRocks source sees whatever StarRocks sees, external catalogs included. So
+ingestion survives either choice. This is a project-wide dependency, not a differentiator. (Whether
+OpenMetadata has a native connector for either catalog was not checked; the StarRocks path makes it
+moot.)
+
+**What is left as a genuine, Gravitino-specific risk** is narrow and is about discipline rather
+than capability: Gravitino would ship tags, policies, statistics and lineage that we intend not to
+use, and the drift risk is that someone starts using them and creates a split brain with
+OpenMetadata. The mitigation is a one-line scoping decision — adopt Gravitino's Iceberg REST
+service and its authorization, and declare OpenMetadata the governance and discovery plane.
+
+**And one real gap that exists under either catalog, worth naming while it is cheap.** PII
+classification lives in OpenMetadata (1,951 tables tagged) while access policy would live in the
+catalog, and nothing links them. Those tags are decorative today — nothing enforces on them. The
+moment anyone wants "deny access to `pii.sensitive`", they hit an unbridged gap. Gravitino's
+policy/tag subsystem could in principle close it in one system, which is an argument *for*
+Gravitino rather than against; Lakekeeper cannot, and OpenMetadata's own policy engine governs
+OpenMetadata, not data access.
 
 ### The reframing
 

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -533,37 +533,86 @@ system, not by this project alone.
 
 ## Recommendation
 
-**Do not switch on documentation alone, and do not settle the OpenFGA-vs-Cedar fork yet.**
+Superseding the earlier "run a Gravitino spike first" version of this section. The spike ran, and
+everything it was asked to prove, it proved.
 
-Lakekeeper is the only candidate with measured end-to-end evidence against our exact StarRocks
-build, covering identity delivery, enforcement, and storage delegation. That evidence is worth
-real money and should not be discarded for a feature matrix.
+**On the evidence in hand, Gravitino has the balance — contingent on one question that this project
+cannot answer by itself.**
 
-But Gravitino's group-claim-driven role model dissolves the fork that is currently blocking the
-project's top-priority decision. The whole reason Cedar was attractive was one role model driving
-both StarRocks RBAC and catalog policy, and the whole reason it is a problem is that it costs
-money and we could not exercise it. Gravitino appears to offer that property in an Apache-2.0
-build. "Appears" is doing work in that sentence: it is documentation, not measurement, which is
-exactly the epistemic position that the Cedar option is in and that the project has already been
-burned by.
+### Why
 
-Concretely:
+**The criterion this project exists to satisfy is the one Gravitino wins outright.** The ACL model
+already designed here is role-to-namespace with no per-user grants anywhere in it. Gravitino reads
+role membership from the token, so that model is six groups and six roles and nothing else moves.
+Lakekeeper OSS structurally cannot read it from the token, so the same model has to be projected
+onto every user by synchronisation code — and the one piece of synchronisation code of that exact
+shape already in this estate is currently broken and unable to be fixed by a CronJob. This is not a
+feature-matrix point; it is the project's own design meeting the two products.
 
-1. **Run a Gravitino spike on the same harness as the two Lakekeeper spikes** (StarRocks 4.1.3,
-   Keycloak 26.x, local containers, two distinct end users). Prove or disprove, in order:
-   per-user identity reaches the catalog through `security=JWT`; the `groups` claim actually
-   drives role membership; a role granted to a group allows and denies correctly; credential
-   vending works. Same bar the Lakekeeper enforcement spike had to clear. This is a bounded piece
-   of work and it is the only thing that can responsibly settle the fork.
-2. **Rank Polaris third and do not pursue it** unless the Gravitino spike fails and the Cedar
-   price turns out to be unacceptable. It is dominated: more user-provisioning burden than
-   Lakekeeper, and no group-claim path to role assignment. Its OIDC role mapping does not do what
-   the docs imply.
-3. **Hold the Keycloak and EKS specs** at the parts that are catalog-independent. The audience
-   mapper, the machine service-account client, and the token-lifetime constraint apply to any of
-   the three; the specific environment-variable names do not.
-4. **Keep pricing discovery moving in parallel.** If Gravitino proves out, the Cedar quote stops
-   mattering. If it does not, the fork is back and the quote is on its critical path.
+**Gravitino now has measured parity on every advantage Lakekeeper was ever credited with.**
+Identity delegation through StarRocks, per-user allow and deny, per-table storage downscoping via
+real STS, an audit trail naming the end user, and list filtering — all measured, on the same
+harness, against the same StarRocks build. Nothing in the original case for Lakekeeper survives as
+a differentiator.
+
+**And it adds three things Lakekeeper does not have:** explicit DENY with hard precedence, STS
+sessions named for the end user so CloudTrail attributes S3 access to a human, and half the
+infrastructure (one service and one database per environment instead of two and two).
+
+**Lakekeeper's incumbency is not evidence.** It was chosen in June for "claim-driven RBAC without
+pre-registering principals", which is false for the OSS build, and by an evaluation that never
+considered Gravitino.
+
+### What genuinely still favours Lakekeeper
+
+Three things, in descending order of weight, and none of them is nothing:
+
+1. **Revocation latency.** Lakekeeper's remote signer re-validates identity and location on every
+   signing request. Gravitino issues an STS credential cached until expiry, so revoking a grant
+   does not invalidate a credential already vended. If "revoke and have it take effect now" is a
+   hard requirement, this is the one row where Lakekeeper is materially better and no amount of
+   configuration closes it.
+2. **Kubernetes service-account authentication**, which Gravitino has not got. Dagster and Airbyte
+   pods would need Keycloak service-account clients instead. A real cost, but an existing pattern
+   in this repo rather than new capability.
+3. **Existence hiding.** Lakekeeper's 404-on-deny conceals restricted datasets; Gravitino's 403
+   names them.
+
+Against those, Gravitino carries one live correctness defect Lakekeeper does not: the cache-expiry
+spurious deny. It fails closed, so it is a correctness and usability problem rather than a security
+one, but it should be filed upstream and ideally fixed before production.
+
+### The contingency
+
+**If OL decides it wants a general-purpose, standalone authorization service, the answer flips to
+Lakekeeper.** OpenFGA generalizes to two named consumers outside the catalog; Gravitino's embedded
+authorization generalizes to none. That is an estate-level decision involving `ol-analytics-api`
+and the feedback system, and it should be taken deliberately rather than inherited as a side effect
+of a catalog choice. Note that it is an argument for adopting *OpenFGA*, and Lakekeeper follows from
+it — not the other way round.
+
+### Recommended next steps
+
+1. **Put the OpenFGA question to whoever owns the estate view.** It is the only thing standing
+   between here and a decision.
+2. **If the answer is "no" or "not now": adopt Gravitino**, scoped deliberately to its Iceberg REST
+   service and its authorization, with OpenMetadata left as the governance and discovery plane.
+3. File the cache-expiry defect upstream regardless.
+4. **Rank Polaris third and Unity Catalog out.** Polaris is dominated; Unity Catalog cannot accept a
+   forwarded external token at all.
+5. The Cedar quote is off the critical path either way. Both live options are Apache-2.0.
+
+### Confidence, and how to discount it
+
+Moderate-to-high on the technical comparison, which rests on measurements rather than documentation
+on both sides. Lower on the weighting, because the OpenFGA contingency is a judgement about OL's
+direction that I do not have standing to make.
+
+One bias worth naming: the Gravitino evidence was gathered in a single session by the same person
+writing this recommendation, while the Lakekeeper evidence accumulated over two earlier spikes. The
+appropriate discount is for *recency and effort-justification*, not for correctness — both products
+were proven to work, and the thing that separates them is a structural fit between Gravitino's
+membership model and an ACL design that predates both spikes.
 
 ## What is true regardless of the choice
 

--- a/docs/plans/iceberg-rest-catalog-evaluation.md
+++ b/docs/plans/iceberg-rest-catalog-evaluation.md
@@ -1,15 +1,19 @@
 # Iceberg REST catalog evaluation: Lakekeeper vs Apache Polaris vs Apache Gravitino
 
-Status: evaluation complete, recommendation pending one spike
+Status: evaluation complete, Gravitino recommended (the contingency was resolved 2026-09-08)
 Date: 2026-09-08
 Project: `wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`
 Task: `tk-evaluate-iceberg-rest-catalog-options-lakekeeper-2e4ed9`
 
 ## Why this exists
 
-The project's stated scope includes "evaluating Iceberg REST catalog options". That step was
-skipped. Two spikes and every dependent spec assumed Lakekeeper. Before the Keycloak and EKS
-specs encode Lakekeeper-specific configuration, and before the open p0 fork
+The project's stated scope includes "evaluating Iceberg REST catalog options", and that step was
+done: `tk-evaluate-iceberg-rest-catalog-options-for-jwt-de-17d9c3` closed 2026-06-25 having
+compared Nessie, Polaris, Lakekeeper and Unity Catalog OSS. The gap is narrower than "never
+evaluated". It never considered Gravitino, and its central reason for choosing Lakekeeper did not
+survive contact with the software (see "how much weight the incumbent deserves" below). Two spikes
+and every dependent spec have assumed Lakekeeper since. Before the Keycloak and EKS specs encode
+Lakekeeper-specific configuration, and before the open p0 fork
 (`tk-decision-openfga-oss-second-role-vocabulary-vs-c-1497cb`) is settled, the alternatives get
 the same scrutiny.
 
@@ -40,7 +44,7 @@ These come from what the two spikes proved actually matters, not from a generic 
 | C. Principal provisioning | **Self-registers on first touch** | **Must pre-exist; auth fails otherwise** | Must be added to metalake |
 | C. Role vocabulary | Second vocabulary, own sync | Second vocabulary, own sync, roles only *select* existing grants | **Group claim drives role membership** |
 | D. Credential vending | Yes, **measured** (per-table, identity + location revalidated) | Yes, optional principal in STS session name | Yes (S3, GCS, OSS, ADLS) |
-| E. End-user audit | Yes, **measured** | Not verified | Not verified |
+| E. End-user audit | Yes, **measured** | Not verified | Yes, **measured** |
 | F. Licensing | Apache-2.0 core, **Cedar authorizer is enterprise** | Apache-2.0, ASF top-level | Apache-2.0, ASF top-level |
 | G. Footprint | Service + Postgres, plus OpenFGA + its own Postgres | Service + Postgres (+ OPA if used, beta) | Service + backend DB (+ Ranger if pushdown wanted) |
 
@@ -147,7 +151,12 @@ defeat credential caching.
 
 ### Criterion E: end-user audit
 
-Measured only for Lakekeeper. Unverified for the other two. Do not assume it.
+Measured for Lakekeeper and, in the 2026-09-08 spike, for Gravitino: once `gravitino.audit.enabled`
+is turned on (it defaults to false and the server logs "Audit log is not enabled" at startup),
+entries carry the end-user principal, the operation, the fully-qualified object and the outcome.
+Unverified for Polaris. Do not assume it there.
+
+Not a discriminator between the two live options.
 
 ### Criterion F: licensing
 
@@ -226,14 +235,10 @@ A pass over every task and memory in
 `wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`, looking for evidence that tilts the
 choice. It does tilt, in both directions, and the net is a reframing rather than a winner.
 
-### First, a correction to this document's own premise
+### How much weight the incumbent deserves
 
-An earlier section of this file said the project's "evaluate catalog options" step "was never
-done". **That was wrong.** `tk-evaluate-iceberg-rest-catalog-options-for-jwt-de-17d9c3` closed
-2026-06-25 having compared Nessie, Polaris, Lakekeeper and Unity Catalog OSS. The real gap was
-narrower: it never considered Gravitino, and Gravitino is the one that changes the answer.
-
-But that evaluation is not a reliable input any more, and this matters for how much weight the
+The June evaluation (`tk-evaluate-iceberg-rest-catalog-options-for-jwt-de-17d9c3`, closed
+2026-06-25) is not a reliable input any more, and this matters for how much weight the
 incumbent deserves. It recommended "Lakekeeper v0.12.4 with Cedar" on the grounds that Lakekeeper
 "maps `realm_access.roles` claim to per-table Cedar policies **without pre-registering
 principals**" and was "the only catalog that has both first-class StarRocks validation AND direct


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Tracked in the witan work graph under `wp-starrocks-iceberg-rest-catalog-jwt-identity-dele-13ccbe`.

### Description (What does it do?)

Documentation only. Three files, no code.

- `docs/plans/iceberg-rest-catalog-evaluation.md` — Lakekeeper 0.13 vs Polaris 1.7 vs Gravitino 1.3, plus Unity Catalog OSS. Recommends **Gravitino**.
- `docs/plans/gravitino-spike-results.md` — the measurements behind that, on the same harness as the earlier Lakekeeper spike.
- `docs/plans/gravitino-keycloak-integration-spec.md` — what the realm must emit and what Gravitino must be told for a forwarded end-user token to authenticate and carry role membership.

Lakekeeper was picked in June for "claim-driven RBAC without pre-registering principals". Neither half survived contact with the OSS build: Cedar is enterprise-only, and the roles claim does not bind. Gravitino reads role membership from the token, which is what the already-designed six-role ACL model needs.

**One decision is deliberately open.** D3 of the Keycloak spec needs a call on token lifetime, because the live Production realm issues 5-minute tokens and StarRocks cannot refresh them in JWT mode. 1h (recommended) or expire-with-session at 24h.

<details>
<summary><b>Implementation details</b></summary>
<br>

**What decided it:** Gravitino reads group membership from a configurable JWT claim, so the designed ACL model is six groups and six roles; Lakekeeper OSS cannot, so the same model needs a per-user synchroniser shaped like the one that is currently broken. Gravitino also has explicit DENY, which Lakekeeper cannot express, and half the footprint (one service and one database per environment, against two and two with OpenFGA).

**What still favours Lakekeeper,** carried as requirements rather than regrets: revocation latency, Kubernetes service-account authentication, and existence hiding on deny.

**Two findings changed the spec rather than restating the task:**

- The live realm has `accessTokenLifespan = 5m0s`. Keycloak sets `idToken.exp(accessToken.getExp())`, StarRocks forces `TOKEN_REFRESH_ENABLED=false` in JWT mode, and `OpenIdConnectVerifier` checks `exp` at login only, so a session keeps answering local queries while catalog calls fail five minutes in. The fix is the client attribute `access.token.lifespan`, scoped to the two StarRocks clients so Superset and Marimo stay at 5m.
- No Keycloak groups are needed. The evaluation assumed groups plus a `^/(.*)$` mapper; `groupsFields` names any claim and the realm already emits the six roles as a flat `role_keys` array. The spec supersedes the evaluation here.

**Four traps in Gravitino's auth config,** all read from v1.3.0 source:

- `gravitino.authenticators` defaults to `simple`, an unvalidated Basic header. Fails open.
- `authority` is documented as a Web UI setting but is the `iss` check; blank means no check.
- `extractGroups` takes the claim only `if (groupsObj instanceof List)`. A single-valued mapper emits a string and is dropped with no log line.
- `allowSkewSecs` defaults to 0.

**One live bug found on the way,** filed separately: the `role_keys` mapper exists only on `ol-starrocks-client`, not on `ol-starrocks-cli`, which is what humans arrive through on the interactive path. Any role-driven policy silently matches nothing for those tokens. Catalog-independent.

</details>

### How can this be tested?

Nothing executable, so no test to run. What a reviewer can check instead:

- Every file:line citation is to a released tag, read from source: Keycloak 26.7.3 (what `src/bridge/lib/versions.py:10` pins), Gravitino v1.3.0, Lakekeeper v0.13.1, Polaris 1.7.0, Unity Catalog v0.6.0.
- The token-lifetime measurement reproduces with `pulumi stack export --stack Production` in `src/ol_infrastructure/substructure/keycloak/`, field `accessTokenLifespan` on the `ol-data-platform` realm resource.
- The `ol-starrocks-cli` gap is visible comparing `ol_data_platform.py:616-630` against `:675-720`.

Three checks are explicitly **not** done and are listed as such in the spec: decoding a real id_token for its `aud` contents, confirming `role_keys` serialises as a JSON array rather than a string, and confirming `exp - iat` matches the configured lifespan. They need a Vault token the authoring session did not have, and should not be skipped before the spec is implemented.

### Additional Context

The Gravitino evidence was gathered in one session by the same person writing the recommendation, while the Lakekeeper evidence accumulated over two earlier spikes. The evaluation names that bias and argues for discounting recency rather than correctness. Worth a sceptical read on that point specifically.

Two follow-ups these documents create: `tk-spec-cedar-authorization-policy-set-for-lakekeep-cf7568` is void as written, and `tk-spec-lakekeeper-eks-placement-and-infrastructure-a0eb29` needs a Gravitino rewrite that adds one real constraint (access control requires the Iceberg REST service to run as an auxiliary service inside the Gravitino server; standalone supports none). The MIT-admin membership problem is not solved by any of this and still needs an answer now that OpenFGA is declined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2NHcVdRxb4c16VSTtKYB1
