### PR TITLE
raise the read timeout for credential metadata generation

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1910,6 +1910,35 @@ learn_external_service_apisix_route_no_prefix = OLApisixRoute(
             backend_service_name=mitlearn_k8s_app.application_lb_service_name,
             backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
         ),
+        # Credential metadata generation calls a frontier model once per Open
+        # Badges field (gpt-5 and Claude measure 25-46s each, generated
+        # concurrently), so it does not fit the 60s read timeout every route
+        # takes by default. Since the nginx sidecar was dropped and APISIX
+        # proxies to Granian directly this route's timeout is the only ceiling
+        # in front of the request -- see docs/plans/remove-nginx-sidecar.md.
+        #
+        # A route of its own rather than a raised timeout on "passauth": that
+        # one matches every path, so lifting its ceiling would let any slow
+        # request in the application hold a connection three times as long.
+        # Django bounds the model call itself at CREDENTIAL_METADATA_LLM_TIMEOUT
+        # (120s), below this, so a slow model is recorded as a failed
+        # generation rather than surfacing here as a gateway timeout.
+        OLApisixRouteConfig(
+            route_name="credential-metadata",
+            priority=10,
+            timeout_read="180s",
+            shared_plugin_config_name=learn_external_service_shared_plugins.resource_name,
+            plugins=[
+                proxy_rewrite_plugin_config,
+                mitlearn_k8s_app_oidc_resources_no_prefix.get_full_oidc_plugin_config(
+                    unauth_action="pass"
+                ),
+            ],
+            hosts=[mitlearn_api_domain],
+            paths=["/api/v0/credential_metadata/"],
+            backend_service_name=mitlearn_k8s_app.application_lb_service_name,
+            backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
+        ),
         OLApisixRouteConfig(
             route_name="logout-redirect",
             priority=10,
@@ -1992,6 +2021,35 @@ learn_external_service_apisix_route = OLApisixRoute(
             ],
             hosts=[mitlearn_api_domain],
             paths=["/learn/*"],
+            backend_service_name=mitlearn_k8s_app.application_lb_service_name,
+            backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
+        ),
+        # Credential metadata generation calls a frontier model once per Open
+        # Badges field (gpt-5 and Claude measure 25-46s each, generated
+        # concurrently), so it does not fit the 60s read timeout every route
+        # takes by default. Since the nginx sidecar was dropped and APISIX
+        # proxies to Granian directly this route's timeout is the only ceiling
+        # in front of the request -- see docs/plans/remove-nginx-sidecar.md.
+        #
+        # A route of its own rather than a raised timeout on "passauth": that
+        # one matches every path, so lifting its ceiling would let any slow
+        # request in the application hold a connection three times as long.
+        # Django bounds the model call itself at CREDENTIAL_METADATA_LLM_TIMEOUT
+        # (120s), below this, so a slow model is recorded as a failed
+        # generation rather than surfacing here as a gateway timeout.
+        OLApisixRouteConfig(
+            route_name="credential-metadata",
+            priority=10,
+            timeout_read="180s",
+            shared_plugin_config_name=learn_external_service_shared_plugins.resource_name,
+            plugins=[
+                proxy_rewrite_plugin_config,
+                mitlearn_k8s_app_oidc_resources.get_full_oidc_plugin_config(
+                    unauth_action="pass"
+                ),
+            ],
+            hosts=[mitlearn_api_domain],
+            paths=["/learn/api/v0/credential_metadata/"],
             backend_service_name=mitlearn_k8s_app.application_lb_service_name,
             backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
         ),


### PR DESCRIPTION


### What are the relevant tickets?
https://github.com/mitodl/hq/issues/13028
learn pr https://github.com/mitodl/mit-learn/pull/3893

### Description (What does it do?)
learn pr https://github.com/mitodl/mit-learn/pull/3893 adds a route for generating Open Badges credential metadata 
 
We plan to use chatgpt/claude for this in prod that can be slow

This pr adds a `credential-metadata` route at priority 10 with timeout_read=180s to both the prefixed and unprefixed route groups. 
