### PR TITLE
feat(mit_learn): set Surrogate-Key from x-amz-meta-site-id on OCW S3 responses

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -956,6 +956,16 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             statement="var.is_ocw_request",
             type="REQUEST",
         ),
+        # Gates the Surrogate-Key header below. Only the OCW content bucket sets
+        # x-amz-meta-site-id, so this is false for NextJS_Frontend responses --
+        # which matters because an unconditional `set` would clobber any
+        # Surrogate-Key the Next.js origin emits (the k8s_apps pipeline purges
+        # mit-learn-nextjs with fastly_purge_scope="html-pages").
+        fastly.ServiceVclConditionArgs(
+            name="S3 response has a site id",
+            statement="beresp.http.x-amz-meta-site-id",
+            type="CACHE",
+        ),
     ],
     dictionaries=[
         fastly.ServiceVclDictionaryArgs(name="path_redirects"),  # exact path redirects
@@ -974,6 +984,20 @@ mitlearn_fastly_service = fastly.ServiceVcl(
         ),
     ],
     headers=[
+        # OCW course objects carry their publishing site as S3 user metadata.
+        # Promoting it to Surrogate-Key at fetch time tags the cached object so a
+        # single course can be purged (POST /service/<id>/purge/<site-id>) without
+        # flushing the rest of the cache. ocw_site does the same thing against the
+        # same bucket, so the two services share one purge key.
+        fastly.ServiceVclHeaderArgs(
+            action="set",
+            cache_condition="S3 response has a site id",
+            destination="http.Surrogate-Key",
+            name="S3 Cache Surrogate Keys",
+            priority=10,
+            source="beresp.http.x-amz-meta-site-id",
+            type="cache",
+        ),
         fastly.ServiceVclHeaderArgs(
             action="set",
             destination="http.Strict-Transport-Security",


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/hq/issues/13251 — "OCW on Learn: clear fastly cache on course publish". Does not close it: this registers the key so a per-course purge is *possible*. The publish-time signal that actually issues the purge against the MIT Learn service is included in https://github.com/mitodl/ocw-studio/pull/3199.

### Description (What does it do?)

- MIT Learn's Fastly service serves OCW course content from `ocw-content-live-<env>` via the `OCW S3 Courses` backend, but set no `Surrogate-Key` on anything
- Copies the site id that S3 returns as `x-amz-meta-site-id` into `Surrogate-Key` at fetch time, tagging each cached OCW object with the course that published it.
- Mirrors the `S3 Cache Surrogate Keys` header `ocw_site` already sets against the same bucket, so both services key off the same value.
- Scoped by a `CACHE` condition on the source header being present, so it applies only to OCW S3 responses and leaves the other two backends untouched.

<details>
<summary><b>Implementation details</b></summary>
<br>

Two additions to the `fastly.ServiceVcl` in `src/ol_infrastructure/applications/mit_learn/__main__.py`, 24 lines total:

```python
fastly.ServiceVclConditionArgs(
    name="S3 response has a site id",
    statement="beresp.http.x-amz-meta-site-id",
    type="CACHE",
),
```

```python
fastly.ServiceVclHeaderArgs(
    action="set",
    cache_condition="S3 response has a site id",
    destination="http.Surrogate-Key",
    name="S3 Cache Surrogate Keys",
    priority=10,
    source="beresp.http.x-amz-meta-site-id",
    type="cache",
),
```

`type="cache"` runs in `vcl_fetch`, before the object is stored — where a surrogate key has to be registered to take effect.

Name and `priority=10` copy [ocw_site's header](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/ocw_site/__main__.py#L1054-L1061) verbatim. The two services front the same bucket — `ocw_site` exports `ocw_site_buckets.buckets.live` and mit_learn consumes it as the OCW backend address — so an object gets the same key whichever service caches it.

**Why the condition.** `ocw_site` needs no guard; that service is single-purpose. MIT Learn's has three backends (`NextJS_Frontend`, `MIT Learn S3 Media Storage`, `OCW S3 Courses`) and only OCW S3 responses carry `x-amz-meta-site-id`. Gating on that header keeps `Surrogate-Key` off Next.js responses, which matters because [`k8s_apps/pipeline.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py#L206) purges `mit-learn-nextjs` with `fastly_purge_scope="html-pages"` — a scoped key this change must not interfere with.

A header object rather than a `vcl_snippet` so it reads identically to the ocw_site precedent; the `cache_condition` wiring follows [xpro's conditioned cache header](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/xpro/__main__.py#L986-L994), the only other one in the repo. No new VCL file, no new imports, no stack config changes.

</details>

### How can this be tested?

Will be tested on QA together with https://github.com/mitodl/ocw-studio/pull/3199.


1. Warm two different courses until both report `x-cache: HIT`:
   `curl -sI https://rc.learn.mit.edu/courses/o/<course-slug>/ | grep -i x-cache`
2. Republish one in ocw-studio so that the build runs and the fastly cache is cleared.
3. Re-request both. The republished course must come back `x-cache: MISS` and the other must stay `HIT`. 

### Additional Context

- Objects already in cache when the new version activates carry no surrogate key and will not answer a key purge. Either let them age out on TTL, or run a one-time `purge_all` after activation so every subsequent fetch is tagged.
- Shielding is on in CI, QA and Production. The key is derived from `x-amz-meta-site-id`, which the shield forwards along with the object, so the edge tier tags its own copy independently — no shield-specific VCL needed. A surrogate-key purge is service-wide across POPs.
