### PR TITLE
fix(omnigraph): make the council probe exercise the full-text path

### DIFF
--- a/docs/witan-council-probe-runbook.md
+++ b/docs/witan-council-probe-runbook.md
@@ -25,9 +25,19 @@ death — see `applications/witan/deployment.py`).
 So this is a separate, out-of-band, **authenticated** caller:
 `applications/omnigraph/council_probe.py` runs a CronJob
 (`check_council_health.py`) on its own schedule, in its own pod, carrying its
-own Cedar identity. It runs one trivial read against `council` and exits
-non-zero if that read did not come back — nothing more. See the script's own
-module docstring for the wire-level detail.
+own Cedar identity. It runs two trivial reads against `council` — an ordinary
+`match` and a full-text `search()` — and exits non-zero if either did not come
+back. Nothing more. See the script's own module docstring for the wire-level
+detail.
+
+The second read is not redundant. Ordinary and full-text reads fail
+independently: omnigraph's full-text rebuild-required guard refuses
+`search()`/`bm25()` while explicitly leaving ordinary reads working, so a
+probe that only did the first would report healthy through a total BM25
+outage — which is precisely what happened to CI on 2026-09-08, for a week,
+at a passing run every 15 minutes. It deliberately does not assert on the
+number of hits: an empty result is a legitimate answer, and the failure mode
+here is a refusal, not a wrong result.
 
 **It needs no new alert rule.** A failing run *is* the signal:
 `WitanScheduledJobNeverSucceeded` and `eks_general.py`'s `WorkloadJobFailed*`

--- a/src/ol_infrastructure/applications/omnigraph/council_probe.py
+++ b/src/ol_infrastructure/applications/omnigraph/council_probe.py
@@ -35,6 +35,9 @@ from pathlib import Path
 import pulumi_kubernetes as kubernetes
 from pulumi import Output, Resource, ResourceOptions
 
+from ol_infrastructure.applications.omnigraph.scripts.check_council_health import (
+    PROBE_ACTIVE_DEADLINE_SECONDS,
+)
 from ol_infrastructure.lib.aws.eks_helper import cached_image_uri
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -45,20 +48,22 @@ SCRIPT_MOUNT_PATH = "/opt/witan-council-probe"
 SCRIPT_FILENAME = "check_council_health.py"
 
 # Every 15 minutes. The window this closes is bounded by cadence, not by the
-# request itself (one query, ~15s ceiling below) — 15m keeps the worst-case
-# "council is down and nobody has restarted a pod or made a call" detection
+# requests themselves (see PROBE_ACTIVE_DEADLINE_SECONDS) — 15m keeps the
+# worst-case "council is down and nobody has restarted a pod or made a call"
+# detection
 # window well inside the existing staleness rule's 6h fast-bucket threshold
 # (eks_general.py), so a genuinely stuck CronJob controller is caught by that
 # rule long before a single missed run would be.
 DEFAULT_PROBE_SCHEDULE = "*/15 * * * *"
 
-# One HTTP call with its own 15s client-side timeout (script module docstring).
-# A run that has not finished in a minute is wedged on something the client
-# timeout should already have caught.
-PROBE_ACTIVE_DEADLINE_SECONDS = 60
+# The deadline is DERIVED from the script's own query list and client
+# timeout, and is imported rather than restated here so the two cannot drift
+# — see PROBE_ACTIVE_DEADLINE_SECONDS in check_council_health.py for the
+# arithmetic and why it is not a literal.
 
-# The script is a single idempotent read; a retry is always safe, and two of
-# them ride out one dropped connection without waiting for the next tick.
+# Every query the script runs is an idempotent read, so a retry is always
+# safe, and two of them ride out one dropped connection without waiting for
+# the next tick.
 PROBE_BACKOFF_LIMIT = 1
 
 
@@ -149,9 +154,9 @@ def create_council_probe(  # noqa: PLR0913
                         run_as_user=1000,
                         run_as_group=1000,
                     ),
-                    # One HTTP call. The limits are here to make it
-                    # evictable-last rather than because it is anywhere near
-                    # them.
+                    # A couple of small HTTP calls. The limits are here to
+                    # make it evictable-last rather than because it is
+                    # anywhere near them.
                     resources=kubernetes.core.v1.ResourceRequirementsArgs(
                         requests={"cpu": "25m", "memory": "32Mi"},
                         limits={"cpu": "250m", "memory": "128Mi"},

--- a/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
@@ -1,4 +1,9 @@
-"""Authenticated synthetic probe: prove `council` answers a real query.
+"""Authenticated synthetic probe: prove `council` answers real queries.
+
+It sends TWO queries, and the second one exists because the first cannot see
+what broke CI on 2026-09-08: an ordinary read and a full-text (`search()`)
+read fail independently, so a probe that only does the former reports healthy
+while every BM25 caller is being refused. See `SEARCH_PROBE_QUERY` below.
 
 Carved out of tk-observability-for-shared-witan-service-ad3dba item 1
 (tk-an-authenticated-synthetic-probe-for-council-to--e89d8f). Two alert rules
@@ -70,6 +75,38 @@ query council_probe() {
 }
 """
 
+# A second bounded read that goes through the FULL-TEXT path specifically.
+#
+# The plain query above cannot see a dead BM25 index, and on 2026-09-08 that
+# was not hypothetical: CI was skipped in the 2026-09-01 Lance 11 analyzer
+# rebuild, every `search()`/`bm25()` query there was refused with HTTP 409
+# `full_text_index_rebuild_required`, and this probe went on passing every 15
+# minutes because `match { $m: Memory }` is an ordinary read. The
+# rebuild-required guard is deliberately narrow — "ordinary reads remain
+# available; do not return a partial indexed result" — and that narrowness is
+# exactly what made the existing probe blind to it. `check_omnigraph_format.py`
+# stays green through an analyzer bump too, and correctly so: the on-disk
+# format does not move. Nothing else watches this.
+#
+# ★ IT DELIBERATELY DOES NOT ASSERT ON THE HIT COUNT. A search matching zero
+# rows is a legitimate answer — an empty or freshly-cut-over graph would fail
+# such an assertion forever, for no defect. What this probe asserts is that the
+# full-text path ANSWERS AT ALL, which is precisely the thing that breaks: the
+# failure mode is a refusal (HTTP 409), not a wrong result, so `run_probe`'s
+# existing non-2xx handling turns it into a non-zero exit with no new
+# machinery. Keep the literal inline rather than parameterising it, for the
+# same reason the query above takes no parameters.
+SEARCH_PROBE_QUERY = """
+query council_search_probe() {
+    match {
+        $m: Memory
+        search($m.content, "witan")
+    }
+    return { $m.slug }
+    limit 1
+}
+"""
+
 HTTP_TIMEOUT_SECONDS = 15
 
 
@@ -77,8 +114,10 @@ class ProbeError(Exception):
     """A condition that must exit the run non-zero."""
 
 
-def run_probe(server_addr: str, graph_id: str, token: str) -> dict[str, Any]:
-    """POST the probe query and return the decoded JSON body on success.
+def run_probe(
+    server_addr: str, graph_id: str, token: str, query: str = PROBE_QUERY
+) -> dict[str, Any]:
+    """POST a probe query and return the decoded JSON body on success.
 
     Raises :class:`ProbeError` for anything that means `council` did not
     answer: an unreachable server, a non-2xx response, or a 2xx body that
@@ -87,7 +126,7 @@ def run_probe(server_addr: str, graph_id: str, token: str) -> dict[str, Any]:
     proxy in front of the real server would otherwise read as success.
     """
     url = f"{server_addr.rstrip('/')}/graphs/{graph_id}/query"
-    payload = json.dumps({"query": PROBE_QUERY, "params": {}}).encode()
+    payload = json.dumps({"query": query, "params": {}}).encode()
     request = urllib.request.Request(  # noqa: S310 - server_addr is our own config
         url,
         method="POST",
@@ -156,6 +195,12 @@ def main() -> int:
         # enforcing twice, just a fact the type checker cannot see through
         # the comprehension above.
         result = run_probe(cast(str, server_addr), graph_id, cast(str, token))
+        search_result = run_probe(
+            cast(str, server_addr),
+            graph_id,
+            cast(str, token),
+            query=SEARCH_PROBE_QUERY,
+        )
     except ProbeError as exc:
         # Not `.exception()`: `exc` is already a fully-formatted, known
         # failure message (a classified HTTP/JSON condition), not an
@@ -164,9 +209,10 @@ def main() -> int:
         return 1
 
     LOG.info(
-        "council-health probe OK: graph=%s row_count=%s",
+        "council-health probe OK: graph=%s row_count=%s search_row_count=%s",
         graph_id,
         result.get("row_count", len(result.get("rows", []))),
+        search_result.get("row_count", len(search_result.get("rows", []))),
     )
     return 0
 

--- a/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/check_council_health.py
@@ -107,7 +107,40 @@ query council_search_probe() {
 }
 """
 
+#: Every query one run makes, in order — the ordinary read first, then the
+#: full-text read.
+#:
+#: This tuple, not a hand-kept number, is what says how many HTTP calls a run
+#: costs: ``council_probe.py`` derives the CronJob's
+#: ``activeDeadlineSeconds`` from ``len(PROBE_QUERIES) * HTTP_TIMEOUT_SECONDS``
+#: plus a startup budget. Adding a third probe here therefore widens that
+#: deadline automatically instead of quietly eating into the headroom the pod
+#: needs to be scheduled and start an interpreter — which is exactly what
+#: adding the second one did, when the deadline was a literal 60.
+PROBE_QUERIES: tuple[tuple[str, str], ...] = (
+    ("ordinary", PROBE_QUERY),
+    ("search", SEARCH_PROBE_QUERY),
+)
+
 HTTP_TIMEOUT_SECONDS = 15
+
+#: Budget for everything in a run that is not an HTTP call: pod scheduling,
+#: image pull, interpreter start. Generous on purpose — the deadline below is
+#: a backstop for a wedged run, not a policy on slow nodes.
+PROBE_STARTUP_BUDGET_SECONDS = 30
+
+#: What `council_probe.py` sets as the CronJob's `activeDeadlineSeconds`.
+#:
+#: DERIVED, and that is the point. It lives here, beside the two inputs it is
+#: a function of, because here is where drift starts: when this script grew
+#: its second query, a literal 60 in the deployment would have silently
+#: halved the startup headroom instead of widening the deadline. Adding a
+#: third probe to PROBE_QUERIES now moves this on its own.
+#:
+#: Currently 2 * 15 + 30 = 60, the value it has always had.
+PROBE_ACTIVE_DEADLINE_SECONDS = (
+    len(PROBE_QUERIES) * HTTP_TIMEOUT_SECONDS + PROBE_STARTUP_BUDGET_SECONDS
+)
 
 
 class ProbeError(Exception):
@@ -170,6 +203,11 @@ def run_probe(
     return parsed
 
 
+def _row_count(result: dict[str, Any]) -> int:
+    """Rows a query returned, preferring the server's own count."""
+    return int(result.get("row_count", len(result.get("rows", []))))
+
+
 def main() -> int:
     """Run the probe once and exit non-zero on any failure to answer."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -194,13 +232,14 @@ def main() -> int:
         # cast rather than assert since this is not a runtime invariant worth
         # enforcing twice, just a fact the type checker cannot see through
         # the comprehension above.
-        result = run_probe(cast(str, server_addr), graph_id, cast(str, token))
-        search_result = run_probe(
-            cast(str, server_addr),
-            graph_id,
-            cast(str, token),
-            query=SEARCH_PROBE_QUERY,
-        )
+        counts = {
+            label: _row_count(
+                run_probe(
+                    cast(str, server_addr), graph_id, cast(str, token), query=query
+                )
+            )
+            for label, query in PROBE_QUERIES
+        }
     except ProbeError as exc:
         # Not `.exception()`: `exc` is already a fully-formatted, known
         # failure message (a classified HTTP/JSON condition), not an
@@ -209,10 +248,9 @@ def main() -> int:
         return 1
 
     LOG.info(
-        "council-health probe OK: graph=%s row_count=%s search_row_count=%s",
+        "council-health probe OK: graph=%s %s",
         graph_id,
-        result.get("row_count", len(result.get("rows", []))),
-        search_result.get("row_count", len(search_result.get("rows", []))),
+        " ".join(f"{label}_row_count={count}" for label, count in counts.items()),
     )
     return 0
 

--- a/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
@@ -15,6 +15,10 @@ from typing import Any, ClassVar
 import pytest
 
 from ol_infrastructure.applications.omnigraph.scripts.check_council_health import (
+    HTTP_TIMEOUT_SECONDS,
+    PROBE_ACTIVE_DEADLINE_SECONDS,
+    PROBE_QUERIES,
+    PROBE_STARTUP_BUDGET_SECONDS,
     SEARCH_PROBE_QUERY,
     ProbeError,
     main,
@@ -240,3 +244,30 @@ def test_main_fails_on_a_probe_failure(stub_server, monkeypatch):
     monkeypatch.setenv("OMNIGRAPH_BEARER_TOKEN", "t")  # pragma: allowlist secret
 
     assert main() == 1
+
+
+def test_active_deadline_is_derived_from_the_probe_query_list():
+    """The deadline must track the number of queries, not sit at a literal.
+
+    This is the regression Copilot caught on #5801: adding the search probe
+    doubled worst-case client time (15s -> 30s) against a hardcoded
+    `activeDeadlineSeconds = 60`, silently halving the headroom left for pod
+    scheduling and interpreter start. Deriving it means a third probe widens
+    the deadline instead of eating that headroom.
+    """
+    assert (
+        len(PROBE_QUERIES) * HTTP_TIMEOUT_SECONDS + PROBE_STARTUP_BUDGET_SECONDS
+    ) == PROBE_ACTIVE_DEADLINE_SECONDS
+    # The startup budget has to survive the worst case, or the backstop fires
+    # on a slow node instead of on a wedged run.
+    assert PROBE_STARTUP_BUDGET_SECONDS > 0
+    assert len(PROBE_QUERIES) * HTTP_TIMEOUT_SECONDS < PROBE_ACTIVE_DEADLINE_SECONDS
+
+
+def test_probe_queries_covers_both_read_paths():
+    """Ordinary and full-text reads fail independently; both must be probed."""
+    labels = [label for label, _ in PROBE_QUERIES]
+    assert labels == ["ordinary", "search"]
+    ordinary, search = (query for _, query in PROBE_QUERIES)
+    assert "search(" not in ordinary
+    assert "search(" in search

--- a/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_check_council_health.py
@@ -15,6 +15,7 @@ from typing import Any, ClassVar
 import pytest
 
 from ol_infrastructure.applications.omnigraph.scripts.check_council_health import (
+    SEARCH_PROBE_QUERY,
     ProbeError,
     main,
     run_probe,
@@ -170,8 +171,66 @@ def test_main_succeeds_end_to_end(stub_server, monkeypatch):
     monkeypatch.delenv("OMNIGRAPH_GRAPH_ID", raising=False)
 
     assert main() == 0
-    [seen] = _StubHandler.requests
-    assert seen["path"] == "/graphs/council/query"
+    # TWO calls, not one: the ordinary read and the full-text read are
+    # separate failure modes and the probe has to exercise both.
+    ordinary, search = _StubHandler.requests
+    assert ordinary["path"] == "/graphs/council/query"
+    assert search["path"] == "/graphs/council/query"
+    assert "search(" not in ordinary["body"]["query"]
+    assert search["body"]["query"] == SEARCH_PROBE_QUERY
+
+
+def test_main_fails_when_the_full_text_index_needs_a_rebuild(stub_server, monkeypatch):
+    """The regression this probe was extended for.
+
+    On 2026-09-08 CI served every ordinary read happily while refusing every
+    `search()` with HTTP 409 `full_text_index_rebuild_required`, because it had
+    been skipped in the Lance 11 analyzer rebuild. The old probe passed
+    throughout. A stub that answers the first call and refuses the second is
+    that exact shape, and it must now exit non-zero.
+    """
+    _, base = stub_server
+    calls = {"n": 0}
+    ok = (200, {"rows": [{"m.slug": "x"}], "row_count": 1})
+    refused = (
+        409,
+        {
+            "error": "full-text index 'content_idx' requires rebuild: "
+            "analyzer certificate is missing",
+            "code": "full_text_index_rebuild_required",
+        },
+    )
+
+    class _Routes(dict[str, Any]):
+        def get(self, key: str, default: Any = None) -> Any:
+            if key != "/graphs/council/query":
+                return default
+            calls["n"] += 1
+            return ok if calls["n"] == 1 else refused
+
+    _StubHandler.routes = _Routes()
+    monkeypatch.setenv("OMNIGRAPH_SERVER_ADDR", base)
+    monkeypatch.setenv("OMNIGRAPH_BEARER_TOKEN", "t")  # pragma: allowlist secret
+    monkeypatch.delenv("OMNIGRAPH_GRAPH_ID", raising=False)
+
+    assert main() == 1
+    assert calls["n"] == 2  # it really did reach the search call
+
+
+def test_search_probe_tolerates_zero_hits(stub_server, monkeypatch):
+    """An empty result is a legitimate answer, not a failure.
+
+    Asserting on hit count would fail forever on an empty or freshly-cut-over
+    graph. What the probe asserts is that the full-text path ANSWERS — the
+    failure mode is a refusal, not a wrong result.
+    """
+    _, base = stub_server
+    _StubHandler.routes = {"/graphs/council/query": (200, {"rows": [], "row_count": 0})}
+    monkeypatch.setenv("OMNIGRAPH_SERVER_ADDR", base)
+    monkeypatch.setenv("OMNIGRAPH_BEARER_TOKEN", "t")  # pragma: allowlist secret
+    monkeypatch.delenv("OMNIGRAPH_GRAPH_ID", raising=False)
+
+    assert main() == 0
 
 
 def test_main_fails_on_a_probe_failure(stub_server, monkeypatch):


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in the witan graph as `tk-ci-was-missed-in-the-2026-09-01-full-text-index--d065f0`. The incident is described inline below so this PR stands alone.

### Description (What does it do?)

The council probe sent one query, `match { $m: Memory }`, which cannot detect a dead full-text index.

On 2026-09-08 `witan.ci` refused every `search()`/`bm25()` query with HTTP 409 `full_text_index_rebuild_required` — it had been skipped in the 2026-09-01 Lance 11 analyzer rebuild that covered QA and production, then took the same image anyway. The probe passed every 15 minutes throughout; one run completed 71 seconds before the breakage was found by hand.

- Adds `SEARCH_PROBE_QUERY`, a second bounded read that goes through the full-text path.
- `run_probe` takes the query as an argument; `main` now runs both and logs `search_row_count` alongside the existing count.
- Adds a test that replays the exact failure shape (ordinary read answers, search refused with 409) and pins that the probe exits non-zero.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why the old probe was blind.** Ordinary reads and full-text reads fail independently, by design. The engine's rebuild-required guard is deliberately narrow — the live 409 body says "ordinary (non-search) reads are unaffected" — so an ordinary-read probe is structurally incapable of seeing this. `check_omnigraph_format.py` ([agent-kit](https://github.com/mitodl/agent-kit/blob/main/bin/check_omnigraph_format.py)) also stays green, and correctly: it asserts the binary's on-disk storage format against `_OMNIGRAPH_INTERNAL_SCHEMA`, which did not move across the Lance 11 bump. Analyzer generation is outside what it covers. Nothing else watched this.

**It deliberately does not assert on hit count.** A search matching zero rows is a legitimate answer — an empty or freshly-cut-over graph would fail such an assertion forever, for no defect. What it asserts is that the full-text path *answers at all*, which is precisely what breaks: the failure mode is a refusal, not a wrong result. `test_search_probe_tolerates_zero_hits` pins this.

**No new alert rule.** Because the failure is a non-2xx, `run_probe`'s existing HTTPError handling turns it into a non-zero exit, and `WitanScheduledJobNeverSucceeded` plus `eks_general.py`'s `WorkloadJobFailed*` already alert on a failed Job. The probe's own docstring makes this the design contract; this change stays inside it and adds no machinery.

**Query literal, not a parameter.** The search term is inlined for the same reason the existing query takes no parameters: there is nothing for a caller to get wrong, so a failure is the server's answer rather than this script's input.

</details>

### How can this be tested?

Automated, run on this branch:

- `uv run pytest tests/ol_infrastructure/applications/omnigraph/` — 116 passed, including the two new tests.
- `uv run pre-commit run --files <the two changed files>` — ruff format, ruff check, mypy and detect-secrets all pass.

The new tests are the meaningful check, since they encode the regression: `test_main_fails_when_the_full_text_index_needs_a_rebuild` stubs a server that answers the ordinary read and returns 409 on the search, which is what CI actually did, and asserts `main()` returns 1. Reverting the `SEARCH_PROBE_QUERY` call in `main` fails it.

Against a live environment, the probe cannot currently be made to fail on demand: CI's indexes were rebuilt on 2026-09-08 (16/16 graphs) and all three tiers now answer BM25 normally, verified by comparing top-5 slug lists for cluster/clusters, write/writes and migration/migrations. Reproducing the 409 would mean deliberately breaking an index, which is not worth doing to exercise a unit-tested path.

### Additional Context

This is the monitoring half of the CI incident; the rebuild itself is already done and verified. Two related gaps are **not** addressed here and remain open:

- The 2026-09-01 cutover enumerated tiers by hand and missed one. All three tiers demonstrably run the identical `omnigraph-server` image digest, so "which environments are on this binary" is answerable mechanically — nothing forces that enumeration.
- There is still no runbook section for analyzer-generation maintenance. `docs/omnigraph-store-maintenance-runbook.md` covers only optimize/cleanup/repair, and the break-glass runbook routes through the wrong path: this is a direct-storage, IAM-gated command on the `omnigraph-server` ServiceAccount, and Cedar is not what authorizes it.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAaMFjgdwKPKuSUsXe7Ky1
