### PR TITLE
fix(rootly): skip pulumi refresh to avoid Rootly API rate limiting

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -500,6 +500,13 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         additional_watched_paths=["sdks/rootly/"],
         stages=["default"],
         topology="preview-gated",
+        # The stack manages ~160 Rootly-API-backed resources. `pulumi refresh`
+        # fans out GETs for all of them at once, which blows past Rootly's
+        # per-account rate/concurrency limits and fails every read with an
+        # empty error message before `up` even runs. Same failure mode as
+        # the Sentry stack above; skipping refresh avoids the burst and lets
+        # `up` still diff/apply whatever actually changed.
+        refresh_stack=False,
     ),
     "sentry": SimplePulumiParams(
         app_name="sentry",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sets `refresh_stack=False` for the `rootly` Pulumi pipeline. `pulumi refresh` fans out a GET for each of the stack's ~160 Rootly-API-backed resources concurrently, which blows past Rootly's rate/concurrency limits and fails every single read with an empty error message before `up` even runs.

`preview-ol-saas-rootly-default` has failed this way on every run since build #17 (2026-09-01). Rotating the Rootly API key today (97b93a9e8) did not change the failure signature: build #22 (before rotation) and build #23 (after) both error identically on all 158 resources in ~2 seconds. This is the same failure mode already documented and fixed for the Sentry stack (`refresh_stack=False` at pipeline.py, added because Sentry's ~350-resource refresh hit the same class of problem) — Rootly just never got the same treatment when its pipeline was added.

<details>
<summary><b>Implementation details</b></summary>
<br>

Compared `fly -t odl-inf watch` logs for build #22 and #23 of `preview-ol-saas-rootly-default`: identical `Error reading <resource_type>: <id>:` failures (empty error detail) across every resource type (Service, Severity, Cause, Dashboard, EscalationLevel, etc.), all during the initial `pulumi refresh` step, `Resources: 2 unchanged / 158 errored`, `Duration: 2s`. Since the pre- and post-key-rotation builds fail identically, the credential itself isn't the variable — the refresh burst against Rootly's API is.

`SimplePulumiParams.refresh_stack` already exists for exactly this class of problem (see the Sentry entry's comment in the same file). Setting it for `rootly` skips the pre-flight `pulumi refresh` in both the preview and deploy jobs; `pulumi up`/`preview` still diffs and applies whatever actually changed.
</details>

### How can this be tested?
- `uv run ruff check`, `uv run mypy`, and `uv run pre-commit run` all pass on the changed file.
- Rendered the pipeline locally (`python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py rootly`) and confirmed the generated job plan has `"refresh_stack": false` wired into both `preview-ol-saas-rootly-default` and `deploy-ol-saas-rootly-default`.
- Not yet verified against a live Concourse run — merging this will trigger `preview-ol-saas-rootly-default` for real; that run succeeding (no refresh burst, clean diff) is the final confirmation.

### Additional Context
Once this merges and a preview run succeeds, `docs/rootly/KNOWN_ISSUES.md`-style tracking isn't needed — this is a one-line config fix, not a new workaround requiring documentation.