### PR TITLE
fix(apisix): let a Gateway API route combine shared plugin defaults with its own plugins

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -61,18 +61,6 @@ def create_meilisearch_resources(
             resource_suffix="ol-shared-plugins",
             k8s_namespace=namespace,
             k8s_labels=k8s_global_labels,
-            # OLApisixHTTPRoute attaches only the shared PluginConfig via
-            # ExtensionRef when shared_plugin_config_name is set, ignoring the
-            # route's own `plugins` list entirely -- including the request-id
-            # plugin OLApisixHTTPRouteConfig's validator would otherwise add.
-            # Include it here explicitly so tracing/correlation still works.
-            plugins=[
-                {
-                    "name": "request-id",
-                    "enable": True,
-                    "config": {"include_in_response": True},
-                },
-            ],
         ),
     )
 
@@ -87,8 +75,7 @@ def create_meilisearch_resources(
                 paths=["/*"],
                 backend_service_name="meilisearch",
                 backend_service_port=7700,
-                shared_plugin_config_name=meilisearch_shared_plugins.resource_name,
-                plugins=[],
+                shared_plugins=meilisearch_shared_plugins,
             ),
         ],
     )

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -284,16 +284,11 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
     )
 
     # APISIX shared plugins (cors, redirect, response-rewrite, prometheus,
-    # opentelemetry, request-id) — creates both v2 ApisixPluginConfig (legacy)
-    # and v1alpha1 PluginConfig (Gateway API) resources under the same name so
-    # OLApisixHTTPRoute can reference it via ExtensionRef.
-    #
-    # OLApisixHTTPRoute attaches only the shared PluginConfig via ExtensionRef
-    # when shared_plugin_config_name is set, ignoring the route's own
-    # `plugins` list entirely -- including the request-id plugin
-    # OLApisixHTTPRouteConfig's validator would otherwise add. request-id is
-    # not part of OLApisixSharedPlugins' defaults, so it's added explicitly
-    # here to keep request tracing/correlation working.
+    # opentelemetry, gzip) — creates both v2 ApisixPluginConfig (legacy) and
+    # v1alpha1 PluginConfig (Gateway API) resources under the same name.
+    # OLApisixHTTPRoute merges this list into each referencing route's own
+    # plugins, so request-id (added by OLApisixHTTPRouteConfig's validator) no
+    # longer has to be restated here.
     shared_plugins = OLApisixSharedPlugins(
         name=f"ol-{base_name}-external-service-apisix-plugins",
         plugin_config=OLApisixSharedPluginsConfig(
@@ -302,13 +297,6 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
             k8s_namespace=namespace,
             k8s_labels=application_labels,
             enable_defaults=True,
-            plugins=[
-                {
-                    "name": "request-id",
-                    "enable": True,
-                    "config": {"include_in_response": True},
-                },
-            ],
         ),
     )
 
@@ -339,8 +327,7 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
         route_configs=[
             OLApisixHTTPRouteConfig(
                 route_name=base_name,
-                shared_plugin_config_name=shared_plugins.resource_name,
-                plugins=[],
+                shared_plugins=shared_plugins,
                 hosts=[domain_name],
                 paths=["/*"],
                 backend_service_name="proxy-public",

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -37,7 +37,11 @@ from ol_infrastructure.components.aws.mediaconvert import (
     OLMediaConvert,
 )
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
-from ol_infrastructure.components.services.apisix import OLApisixPluginConfig
+from ol_infrastructure.components.services.apisix import (
+    OLApisixPluginConfig,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -704,6 +708,21 @@ cert_manager_certificate = OLCertManagerCert(
     ),
 )
 
+# Shared plugin defaults for every route below: prometheus (per-route series),
+# opentelemetry (OTLP spans), gzip (these routes served every response
+# uncompressed), cors, the http->https redirect and Referrer-Policy. Each route
+# also keeps its own plugins -- OLApisixHTTPRoute merges the two lists, with the
+# route's entries winning by name.
+ocw_studio_shared_plugins = OLApisixSharedPlugins(
+    f"ocw-studio-{stack_info.env_suffix}-ol-shared-plugins",
+    plugin_config=OLApisixSharedPluginsConfig(
+        application_name="ocw-studio",
+        resource_suffix="ol-shared-plugins",
+        k8s_namespace=ocw_studio_namespace,
+        k8s_labels=k8s_app_labels,
+    ),
+)
+
 # The `location` blocks that used to live in the nginx sidecar. HTTPRoute has no
 # priority field -- APISix resolves overlapping rules by longest matching path
 # prefix -- so /static/hash.txt outranks /static, which outranks /*, which is the
@@ -726,6 +745,7 @@ ocw_studio_apisix_httproute = OLApisixHTTPRoute(
         # is the closer translation.
         OLApisixHTTPRouteConfig(
             route_name="static-hash",
+            shared_plugins=ocw_studio_shared_plugins,
             hosts=[app_domain],
             paths=["/static/hash.txt"],
             backend_service_name=ocw_studio_k8s_app.application_lb_service_name,
@@ -740,12 +760,13 @@ ocw_studio_apisix_httproute = OLApisixHTTPRoute(
             ],
         ),
         # Granian serves static without a CORS header; the sidecar added a
-        # blanket one. Preserved rather than dropped because this app has no
-        # shared plugin config supplying `cors`, so removing the sidecar would
-        # otherwise silently take the header away from cross-origin font and
-        # asset loads.
+        # blanket one. Kept even though the shared config now supplies `cors`:
+        # that plugin only answers requests that carry an Origin, while this
+        # header went out unconditionally, and static assets are exactly the
+        # thing a cross-origin font or stylesheet load fetches without one.
         OLApisixHTTPRouteConfig(
             route_name="static",
+            shared_plugins=ocw_studio_shared_plugins,
             hosts=[app_domain],
             paths=["/static/*"],
             backend_service_name=ocw_studio_k8s_app.application_lb_service_name,
@@ -776,6 +797,7 @@ ocw_studio_apisix_httproute = OLApisixHTTPRoute(
         # route never serves anything.
         OLApisixHTTPRouteConfig(
             route_name="dnt-policy",
+            shared_plugins=ocw_studio_shared_plugins,
             hosts=[app_domain],
             paths=["/.well-known/dnt-policy.txt"],
             path_match_type="Exact",
@@ -797,6 +819,7 @@ ocw_studio_apisix_httproute = OLApisixHTTPRoute(
         ),
         OLApisixHTTPRouteConfig(
             route_name="passthrough",
+            shared_plugins=ocw_studio_shared_plugins,
             hosts=[app_domain],
             paths=["/*"],
             backend_service_name=ocw_studio_k8s_app.application_lb_service_name,

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -15,6 +15,10 @@ from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBindingConfig,
 )
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
+from ol_infrastructure.components.services.apisix import (
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -1016,11 +1020,31 @@ cert_manager_certificate = OLCertManagerCert(
     ),
 )
 
+# The OAuth2 callback below referenced no plugin config at all, so it emitted
+# no prometheus series and no OTLP span -- the one internet-facing path of a
+# query engine, invisible on every dashboard.
+#
+# enable_cors=False: the only client is a JDBC driver completing a token
+# exchange, not a browser making a cross-origin call, so referencing this config
+# for prometheus/opentelemetry/gzip must not also hand the host a wildcard
+# origin grant.
+starrocks_shared_plugins = OLApisixSharedPlugins(
+    f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-ol-shared-plugins",
+    plugin_config=OLApisixSharedPluginsConfig(
+        application_name=f"{stack_info.env_prefix}-starrocks",
+        resource_suffix="ol-shared-plugins",
+        k8s_namespace=namespace,
+        k8s_labels=k8s_app_labels.model_dump(),
+        enable_cors=False,
+    ),
+)
+
 starrocks_apisix_httproute = OLApisixHTTPRoute(
     f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-apisix-httproute",
     route_configs=[
         OLApisixHTTPRouteConfig(
             route_name=f"{stack_info.env_prefix}-starrocks",
+            shared_plugins=starrocks_shared_plugins,
             hosts=[starrocks_config.require("domain")],
             # Publish ONLY the OAuth2 callback. The JDBC OAuth2 flow completes
             # its token exchange at this path, and nothing else on the FE's HTTP

--- a/src/ol_infrastructure/applications/toolhive_swe/ingress.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/ingress.py
@@ -7,8 +7,13 @@ it to the APISIX gateway, while a Gateway API HTTPRoute routes every path
 (``/mcp``, ``/.well-known/*``) to the vMCP Service. APISIX does NOT participate
 in authentication — it only terminates TLS and proxies through; the vMCP is a
 pure OAuth resource server (no embedded auth server, no token endpoints of its
-own) validating bearer tokens Keycloak issued directly to MCP clients, so no
-plugins are attached.
+own) validating bearer tokens Keycloak issued directly to MCP clients.
+
+The route does carry the shared observability plugins (prometheus,
+opentelemetry, gzip, request-id) so this host is not a blind spot on the
+gateway dashboards. ``text/event-stream`` is deliberately absent from the gzip
+plugin's type list, so MCP's streaming responses are not held behind a
+compression buffer.
 
 The hostname must also be present in the operations EKS stack's
 ``eks:apisix_domains`` so external-dns points it at the APISIX NLB.
@@ -16,6 +21,10 @@ The hostname must also be present in the operations EKS stack's
 
 from pulumi import Resource, ResourceOptions
 
+from ol_infrastructure.components.services.apisix import (
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -57,21 +66,42 @@ def create_ingress_resources(
         opts=ResourceOptions(depends_on=[swe_virtualmcpserver]),
     )
 
+    # Observability defaults for the route below: prometheus (per-route series),
+    # opentelemetry (OTLP spans), gzip and request-id. Without them this host
+    # produced no metrics and no traces at the gateway at all.
+    #
+    # enable_cors=False: the callers are MCP clients holding a Keycloak bearer
+    # token, not browser pages making cross-origin calls, so picking up the
+    # observability plugins must not also grant the host a wildcard origin.
+    # enable_defaults keeps the http->https redirect and Referrer-Policy, which
+    # cost a token-authenticated API nothing.
+    vmcp_shared_plugins = OLApisixSharedPlugins(
+        f"toolhive-swe-vmcp-{stack_info.env_suffix}-ol-shared-plugins",
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name="toolhive-swe-vmcp",
+            resource_suffix="ol-shared-plugins",
+            k8s_namespace=namespace,
+            k8s_labels=k8s_global_labels,
+            enable_cors=False,
+        ),
+    )
+
     # Gateway API HTTPRoute attaching the host to the shared operations APISIX
     # gateway and routing all paths (MCP + /.well-known/*) to the vMCP Service.
-    # No plugins: token validation happens inside the vMCP.
+    # APISIX still performs no authentication: token validation happens inside
+    # the vMCP.
     vmcp_httproute = OLApisixHTTPRoute(
         f"toolhive-swe-vmcp-apisix-httproute-{stack_info.env_suffix}",
         route_configs=[
             OLApisixHTTPRouteConfig(
                 route_name="vmcp",
+                shared_plugins=vmcp_shared_plugins,
                 hosts=[vmcp_domain],
                 paths=["/*"],
                 backend_service_name=VMCP_SERVICE_NAME,
                 # Numeric port: the component maps the name "http" to 8071, which
                 # is wrong for this Service — pass the real port explicitly.
                 backend_service_port=VMCP_SERVICE_PORT,
-                plugins=[],
             ),
         ],
         k8s_namespace=namespace,

--- a/src/ol_infrastructure/applications/witan/ingress.py
+++ b/src/ol_infrastructure/applications/witan/ingress.py
@@ -28,6 +28,10 @@ from ol_infrastructure.applications.witan.deployment import (
     WITAN_PORT,
     WITAN_SERVICE_NAME,
 )
+from ol_infrastructure.components.services.apisix import (
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -72,16 +76,38 @@ def create_ingress_resources(
     # and the kubelet reaches it via the pod IP rather than through here, so
     # narrowing this to `/mcp` later costs nothing operationally — a follow-up
     # worth taking once this cutover has settled.
+
+    # Observability defaults for the route below: prometheus (per-route series),
+    # opentelemetry (OTLP spans), gzip and request-id. The route referenced no
+    # plugin config at all before, so witan's public host appeared on no
+    # gateway dashboard and produced no spans.
+    #
+    # enable_cors=False: callers are MCP clients holding a Keycloak-issued
+    # bearer token, not browser pages making cross-origin calls, so picking up
+    # the observability plugins must not also grant the host a wildcard origin.
+    # ``text/event-stream`` is not in the gzip plugin's type list, so FastMCP's
+    # streaming responses are not held behind a compression buffer.
+    witan_shared_plugins = OLApisixSharedPlugins(
+        f"witan-{stack_info.env_suffix}-ol-shared-plugins",
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name="witan",
+            resource_suffix="ol-shared-plugins",
+            k8s_namespace=namespace,
+            k8s_labels=k8s_global_labels,
+            enable_cors=False,
+        ),
+    )
+
     witan_httproute = OLApisixHTTPRoute(
         f"witan-apisix-httproute-{stack_info.env_suffix}",
         route_configs=[
             OLApisixHTTPRouteConfig(
                 route_name="witan",
+                shared_plugins=witan_shared_plugins,
                 hosts=[witan_domain],
                 paths=["/*"],
                 backend_service_name=WITAN_SERVICE_NAME,
                 backend_service_port=WITAN_PORT,
-                plugins=[],
             ),
         ],
         k8s_namespace=namespace,

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -34,7 +34,11 @@ from ol_infrastructure.applications.xpro.k8s_secrets import (
 from ol_infrastructure.components.aws.cache import OLAmazonCache, OLAmazonRedisConfig
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
-from ol_infrastructure.components.services.apisix import OLApisixPluginConfig
+from ol_infrastructure.components.services.apisix import (
+    OLApisixPluginConfig,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -651,6 +655,22 @@ if k8s_deploy:
         ),
     )
 
+    # Shared plugin defaults for every route below: prometheus (per-route
+    # series), opentelemetry (OTLP spans), gzip (these routes served every
+    # response uncompressed), cors, the http->https redirect and
+    # Referrer-Policy. Each route also keeps its own plugins --
+    # OLApisixHTTPRoute merges the two lists, with the route's entries winning
+    # by name.
+    xpro_shared_plugins = OLApisixSharedPlugins(
+        f"xpro-{stack_info.env_suffix}-ol-shared-plugins",
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name="xpro",
+            resource_suffix="ol-shared-plugins",
+            k8s_namespace=xpro_namespace,
+            k8s_labels=k8s_app_labels,
+        ),
+    )
+
     # The `location` blocks that used to live in the nginx sidecar. HTTPRoute has
     # no priority field -- APISix resolves overlapping rules by longest matching
     # path prefix -- so /static/hash.txt outranks /static, which outranks /*,
@@ -679,6 +699,7 @@ if k8s_deploy:
             # this route's Cache-Control instead.
             OLApisixHTTPRouteConfig(
                 route_name="static-hash",
+                shared_plugins=xpro_shared_plugins,
                 hosts=[app_domain],
                 paths=["/static/hash.txt"],
                 path_match_type="Exact",
@@ -696,10 +717,14 @@ if k8s_deploy:
                 ],
             ),
             # Granian serves static without a CORS header; the sidecar added a
-            # blanket one. xpro has no shared plugin config supplying `cors`, so
-            # without this the header would silently disappear.
+            # blanket one. Kept even though the shared config now supplies
+            # `cors`: that plugin only answers requests carrying an Origin,
+            # while this header went out unconditionally, and static assets are
+            # exactly what a cross-origin font or stylesheet load fetches
+            # without one.
             OLApisixHTTPRouteConfig(
                 route_name="static",
+                shared_plugins=xpro_shared_plugins,
                 hosts=[app_domain],
                 paths=["/static/*"],
                 backend_service_name=xpro_k8s_app.application_lb_service_name,
@@ -721,6 +746,7 @@ if k8s_deploy:
             # Django 404.
             OLApisixHTTPRouteConfig(
                 route_name="dnt-policy",
+                shared_plugins=xpro_shared_plugins,
                 hosts=[app_domain],
                 paths=["/.well-known/dnt-policy.txt"],
                 path_match_type="Exact",
@@ -742,6 +768,7 @@ if k8s_deploy:
             ),
             OLApisixHTTPRouteConfig(
                 route_name="passthrough",
+                shared_plugins=xpro_shared_plugins,
                 hosts=[app_domain],
                 paths=["/*"],
                 backend_service_name=xpro_k8s_app.application_lb_service_name,

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -481,8 +481,12 @@ class OLApisixSharedPlugins(ComponentResource):
       The v1alpha1 schema only accepts ``name`` and ``config`` per plugin;
       ``enable: false`` plugins are omitted entirely and ``secretRef`` is dropped.
 
-    Callers can use ``self.resource_name`` in both ``OLApisixRouteConfig`` (legacy)
-    and ``OLApisixHTTPRouteConfig`` (Gateway API) without any distinction.
+    Legacy callers pass ``self.resource_name`` to ``OLApisixRouteConfig``;
+    Gateway API callers pass the component itself to
+    ``OLApisixHTTPRouteConfig(shared_plugins=...)``, which reads
+    ``self.plugin_list`` to merge these defaults into each route's own plugins
+    (HTTPRoute allows only one ExtensionRef per rule, so the merge has to happen
+    here rather than in APISIX).
     """
 
     def __init__(
@@ -644,6 +648,14 @@ class OLApisixSharedPlugins(ComponentResource):
         self.resource_name = (
             f"{plugin_config.application_name}-{plugin_config.resource_suffix}"
         )
+        # The rendered plugin list, exposed so OLApisixHTTPRoute can merge these
+        # defaults into a route's own plugins.  A single HTTPRoute rule accepts
+        # only one ExtensionRef filter, so a Gateway API route cannot reference
+        # this config *and* its own PluginConfig the way a legacy ApisixRoute
+        # can -- the two lists have to be combined before the CRD is written.
+        self.plugin_list: list[OLApisixPluginConfig] = [
+            OLApisixPluginConfig(**p) for p in plugins
+        ]
         # v2/ApisixPluginConfig — consumed by legacy ApisixRoute/Ingress resources
         # via ``plugin_config_name`` in the route spec.
         self.shared_plugin_apisix_pluginconfig_resource = (

--- a/src/ol_infrastructure/components/services/apisix_gateway_api.py
+++ b/src/ol_infrastructure/components/services/apisix_gateway_api.py
@@ -13,12 +13,16 @@ import pulumi_kubernetes as kubernetes
 from pulumi import ComponentResource, ResourceOptions
 from pydantic import (
     BaseModel,
+    ConfigDict,
     NonNegativeInt,
     field_validator,
     model_validator,
 )
 
-from ol_infrastructure.components.services.apisix import OLApisixPluginConfig
+from ol_infrastructure.components.services.apisix import (
+    OLApisixPluginConfig,
+    OLApisixSharedPlugins,
+)
 
 
 class OLApisixHTTPRouteConfig(BaseModel):
@@ -71,9 +75,36 @@ class OLApisixHTTPRouteConfig(BaseModel):
         field is retained for compatibility but has NO effect on HTTPRoute generation.
     """
 
+    model_config = ConfigDict(
+        # Holds an OLApisixSharedPlugins component resource, which pydantic
+        # cannot generate a schema for.
+        arbitrary_types_allowed=True,
+        # Pydantic skips field validators for fields left at their default, so
+        # without this a route that passes no ``plugins`` at all silently loses
+        # the request-id plugin ensure_request_id_plugin exists to guarantee --
+        # while an otherwise identical route that spells out ``plugins=[]``
+        # keeps it.
+        validate_default=True,
+    )
+
     route_name: str
     priority: int = 0  # NOT used in Gateway API HTTPRoute - see class docstring
-    shared_plugin_config_name: str | None = None
+    shared_plugins: OLApisixSharedPlugins | None = None
+    """Shared plugin defaults (cors, prometheus, opentelemetry, gzip, ...) to
+    apply to this route, merged with ``plugins`` below.
+
+    The component itself is passed rather than its ``resource_name`` because the
+    merge happens in Pulumi: a Gateway API HTTPRoute rule accepts exactly one
+    ExtensionRef filter, so unlike a legacy ``ApisixRoute`` -- which names a
+    shared ApisixPluginConfig *and* carries its own plugins, leaving APISIX to
+    combine them -- this component has to read the shared list and write a
+    single merged PluginConfig per route.
+
+    An entry in ``plugins`` replaces the same-named shared entry outright,
+    matching what APISIX does for the legacy path.  That also makes
+    ``OLApisixPluginConfig(name="gzip", enable=False)`` the way to opt one route
+    out of a shared plugin, since disabled plugins are dropped from the rendered
+    v1alpha1 PluginConfig."""
     plugins: list[OLApisixPluginConfig] = []
     hosts: list[str] = []
     paths: list[str] = []
@@ -114,15 +145,19 @@ class OLApisixHTTPRouteConfig(BaseModel):
         cls, v: list[OLApisixPluginConfig]
     ) -> list[OLApisixPluginConfig]:
         """Ensure that the request-id plugin is always added to the plugins list."""
-        if not any(plugin.name == "request-id" for plugin in v):
-            v.append(
-                OLApisixPluginConfig(
-                    name="request-id",
-                    secretRef=None,
-                    config={"include_in_response": True},
-                )
-            )
-        return v
+        if any(plugin.name == "request-id" for plugin in v):
+            return v
+        # A new list rather than an append: with validate_default=True this also
+        # runs against the field's default, and mutating that in place would
+        # grow the class-level list on every instantiation.
+        return [
+            *v,
+            OLApisixPluginConfig(
+                name="request-id",
+                secretRef=None,
+                config={"include_in_response": True},
+            ),
+        ]
 
     @model_validator(mode="after")
     def check_backend_or_upstream(self) -> "OLApisixHTTPRouteConfig":
@@ -205,10 +240,20 @@ class OLApisixHTTPRoute(ComponentResource):
       This component uses this kind exclusively.
 
     The component automatically:
-    - Creates PluginConfig (v1alpha1) resources for unique plugin combinations
+    - Creates one PluginConfig (v1alpha1) per route, holding that route's shared
+      plugin defaults merged with its own plugin list
     - Converts APISIX path patterns to Gateway API PathPrefix matches
     - Links routes to plugins via ExtensionRef filters
     - Supports both service backends and upstreams
+
+    NOTE ON PLUGIN MERGING
+    ----------------------
+    A legacy ``ApisixRoute`` can name a shared ApisixPluginConfig *and* carry its
+    own plugins, and APISIX combines the two.  A Gateway API HTTPRoute rule
+    accepts only one ExtensionRef filter, so that is not expressible in the CRD.
+    This component therefore merges ``shared_plugins.plugin_list`` with the
+    route's ``plugins`` itself and writes the result as a single per-route
+    PluginConfig -- see ``_merged_plugins``.
     """
 
     def __init__(  # noqa: PLR0913
@@ -239,8 +284,9 @@ class OLApisixHTTPRoute(ComponentResource):
 
         resource_options = ResourceOptions(parent=self).merge(opts)
 
-        # Create PluginConfig resources for unique plugin combinations
-        self._create_plugin_configs(
+        # One PluginConfig per route, holding that route's shared defaults
+        # merged with its own plugins.
+        plugin_configs = self._create_plugin_configs(
             name, route_configs, k8s_namespace, k8s_labels, resource_options
         )
 
@@ -278,7 +324,18 @@ class OLApisixHTTPRoute(ComponentResource):
                 namespace=k8s_namespace,
             ),
             spec=spec,
-            opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+            opts=resource_options.merge(
+                ResourceOptions(
+                    delete_before_replace=True,
+                    # A PluginConfig's name is a hash of its contents, so any
+                    # plugin change renames it and the HTTPRoute's ExtensionRef
+                    # has to follow.  Without this edge Pulumi is free to update
+                    # the route first, leaving it pointed at a name that does
+                    # not exist yet -- which APISIX resolves by serving the
+                    # route with no plugins at all rather than by failing.
+                    depends_on=list(plugin_configs.values()),
+                )
+            ),
         )
 
     def _extract_unique_hostnames(
@@ -309,6 +366,32 @@ class OLApisixHTTPRoute(ComponentResource):
         sanitized_httproute_name = httproute_name.replace("_", "-").lower()
         sanitized_route_name = route_name.replace("_", "-").lower()
         return f"{sanitized_httproute_name}-{sanitized_route_name}-{plugin_hash}"
+
+    @staticmethod
+    def _merged_plugins(
+        route_config: OLApisixHTTPRouteConfig,
+    ) -> list[OLApisixPluginConfig]:
+        """Combine a route's shared plugin defaults with its own plugin list.
+
+        Shared entries come first, then the route's own; a route entry replaces
+        the same-named shared entry wholesale rather than merging their
+        ``config`` dicts, which is what APISIX itself does when a legacy
+        ApisixRoute names a shared ApisixPluginConfig and also carries a plugin
+        of the same name (verified in production on mitxonline's static-hash
+        route, where the route's Cache-Control response-rewrite wins over the
+        shared Referrer-Policy one).
+
+        Doing it here is not a stylistic choice: a single HTTPRoute rule takes
+        one ExtensionRef filter, so there is no way to point a Gateway API route
+        at two PluginConfigs and let APISIX do the combining.
+        """
+        merged: dict[str, OLApisixPluginConfig] = {}
+        if route_config.shared_plugins:
+            for plugin in route_config.shared_plugins.plugin_list:
+                merged[plugin.name] = plugin
+        for plugin in route_config.plugins:
+            merged[plugin.name] = plugin
+        return list(merged.values())
 
     @staticmethod
     def _active_plugins(
@@ -356,16 +439,11 @@ class OLApisixHTTPRoute(ComponentResource):
         plugin_configs = {}
 
         for route_config in route_configs:
-            # Skip if using shared plugin config
-            if route_config.shared_plugin_config_name:
-                continue
-
-            # Skip if no plugins (shouldn't happen due to validator adding request-id)
-            if not route_config.plugins:
-                continue
-
+            # One PluginConfig per route holding the shared defaults merged with
+            # the route's own plugins -- see _merged_plugins for why the merge
+            # cannot be left to APISIX here.
             # Only enabled plugins are written to v1alpha1 PluginConfig.
-            active = self._active_plugins(route_config.plugins)
+            active = self._active_plugins(self._merged_plugins(route_config))
             if not active:
                 continue
 
@@ -549,39 +627,28 @@ class OLApisixHTTPRoute(ComponentResource):
                 "backendRefs": backend_refs,
             }
 
-            # Add plugin config via ExtensionRef filter if plugins are configured.
-            # Both paths use kind=PluginConfig (apisix.apache.org/v1alpha1) — the
-            # type the APISIX HTTPRoute reconciler actually processes.  The legacy
+            # Point the rule at the per-route PluginConfig built above.  Uses
+            # kind=PluginConfig (apisix.apache.org/v1alpha1) — the type the
+            # APISIX HTTPRoute reconciler actually processes.  The legacy
             # v2/ApisixPluginConfig kind is silently ignored by the reconciler.
-            if route_config.shared_plugin_config_name:
+            #
+            # The same merged, enabled-plugin subset is recomputed here so the
+            # referenced name always matches the resource that was created.
+            active = self._active_plugins(self._merged_plugins(route_config))
+            if active:
+                config_name = self._generate_plugin_config_name(
+                    httproute_name, route_config.route_name, active
+                )
                 rule["filters"] = [
                     {
                         "type": "ExtensionRef",
                         "extensionRef": {
                             "group": "apisix.apache.org",
                             "kind": "PluginConfig",
-                            "name": route_config.shared_plugin_config_name,
+                            "name": config_name,
                         },
                     }
                 ]
-            elif route_config.plugins:
-                # Use the same enabled-plugin subset that was used to create
-                # the PluginConfig resource so the name always matches.
-                active = self._active_plugins(route_config.plugins)
-                if active:
-                    config_name = self._generate_plugin_config_name(
-                        httproute_name, route_config.route_name, active
-                    )
-                    rule["filters"] = [
-                        {
-                            "type": "ExtensionRef",
-                            "extensionRef": {
-                                "group": "apisix.apache.org",
-                                "kind": "PluginConfig",
-                                "name": config_name,
-                            },
-                        }
-                    ]
 
             rules.append(rule)
 

--- a/src/ol_infrastructure/components/services/apisix_gateway_api.py
+++ b/src/ol_infrastructure/components/services/apisix_gateway_api.py
@@ -285,8 +285,10 @@ class OLApisixHTTPRoute(ComponentResource):
         resource_options = ResourceOptions(parent=self).merge(opts)
 
         # One PluginConfig per route, holding that route's shared defaults
-        # merged with its own plugins.
-        plugin_configs = self._create_plugin_configs(
+        # merged with its own plugins.  Kept on the component so callers (and
+        # tests) can see what was actually created rather than recomputing the
+        # hashed names.
+        self.plugin_config_resources = self._create_plugin_configs(
             name, route_configs, k8s_namespace, k8s_labels, resource_options
         )
 
@@ -333,7 +335,7 @@ class OLApisixHTTPRoute(ComponentResource):
                     # the route first, leaving it pointed at a name that does
                     # not exist yet -- which APISIX resolves by serving the
                     # route with no plugins at all rather than by failing.
-                    depends_on=list(plugin_configs.values()),
+                    depends_on=list(self.plugin_config_resources.values()),
                 )
             ),
         )

--- a/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
@@ -27,8 +27,20 @@ except RuntimeError:
     asyncio.set_event_loop(asyncio.new_event_loop())
 
 
+PLUGIN_CONFIG_TYPE = "kubernetes:apisix.apache.org/v1alpha1:PluginConfig"
+
+# Every resource the mocks are asked to create, as (type token, metadata.name).
+# Recorded so a test can assert against the PluginConfigs the component
+# actually registered rather than against names recomputed from the same
+# helper the component used -- which would pass even if it created nothing.
+REGISTERED: list[tuple[str, str]] = []
+
+
 class K8sMocks(pulumi.runtime.Mocks):
     def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        REGISTERED.append(
+            (args.typ, (args.inputs.get("metadata") or {}).get("name", ""))
+        )
         return [args.name + "_id", args.inputs]
 
     def call(self, args: pulumi.runtime.MockCallArgs):  # noqa: ARG002
@@ -36,6 +48,12 @@ class K8sMocks(pulumi.runtime.Mocks):
 
 
 pulumi.runtime.set_mocks(K8sMocks())
+
+
+def registered_plugin_config_names() -> set[str]:
+    """metadata.name of every v1alpha1 PluginConfig the mocks have created."""
+    return {name for typ, name in REGISTERED if typ == PLUGIN_CONFIG_TYPE and name}
+
 
 from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixPluginConfig,
@@ -190,11 +208,16 @@ def test_route_without_shared_plugins_keeps_its_own():
 
 @pulumi.runtime.test
 def test_rule_extension_ref_names_the_created_plugin_config():
-    """The ExtensionRef name is recomputed from the merged list rather than
-    stored, so a mismatch between the referenced name and the PluginConfig that
-    was created would leave the route pointing at a resource that does not
-    exist -- and APISIX silently serves the route with no plugins at all.
+    """The ExtensionRef name is a hash of the merged plugin list, recomputed at
+    render time rather than stored, so a route can end up pointing at a
+    PluginConfig that was never created -- which APISIX resolves by serving the
+    route with no plugins at all rather than by failing.
+
+    The created names are read back off the mocks rather than recomputed with
+    the component's own naming helper: recomputing them would compare the
+    component against itself and still pass if it registered nothing.
     """
+    REGISTERED.clear()
     plugins = shared_plugins("merge-render")
     route_configs = [
         route(
@@ -210,31 +233,30 @@ def test_rule_extension_ref_names_the_created_plugin_config():
         ),
         route(route_name="passthrough", shared_plugins=plugins),
     ]
-    httproute_name = "merge-render-httproute"
     component = OLApisixHTTPRoute(
-        httproute_name,
+        "merge-render-httproute",
         route_configs=route_configs,
         k8s_namespace="myapp-ns",
         k8s_labels={"app": "myapp"},
     )
 
-    created = {
-        component._generate_plugin_config_name(
-            httproute_name,
-            route_config.route_name,
-            component._active_plugins(component._merged_plugins(route_config)),
-        )
-        for route_config in route_configs
-    }
-    # Distinct plugin sets hash to distinct PluginConfigs, one per route.
-    assert len(created) == len(route_configs)
-
     def check(spec):
+        # The HTTPRoute depends_on its PluginConfigs, so every one of them has
+        # been registered by the time this spec resolves.
+        created = registered_plugin_config_names()
         referenced = [
             rule["filters"][0]["extensionRef"]["name"] for rule in spec["rules"]
         ]
         assert len(referenced) == len(route_configs)
-        assert set(referenced) == created
+        # Every rule points at a PluginConfig that actually exists...
+        assert set(referenced) <= created, set(referenced) - created
+        # ...a distinct one per route, since the two routes' merged lists differ
+        assert len(set(referenced)) == len(route_configs)
+        # ...and not at the shared config itself, which is what the route
+        # referenced before the merge moved into this component.
+        assert plugins.resource_name in created
+        assert plugins.resource_name not in referenced
+
         for rule in spec["rules"]:
             extension_ref = rule["filters"][0]["extensionRef"]
             # v1alpha1 PluginConfig -- the v2 ApisixPluginConfig kind is

--- a/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
@@ -27,20 +27,8 @@ except RuntimeError:
     asyncio.set_event_loop(asyncio.new_event_loop())
 
 
-PLUGIN_CONFIG_TYPE = "kubernetes:apisix.apache.org/v1alpha1:PluginConfig"
-
-# Every resource the mocks are asked to create, as (type token, metadata.name).
-# Recorded so a test can assert against the PluginConfigs the component
-# actually registered rather than against names recomputed from the same
-# helper the component used -- which would pass even if it created nothing.
-REGISTERED: list[tuple[str, str]] = []
-
-
 class K8sMocks(pulumi.runtime.Mocks):
     def new_resource(self, args: pulumi.runtime.MockResourceArgs):
-        REGISTERED.append(
-            (args.typ, (args.inputs.get("metadata") or {}).get("name", ""))
-        )
         return [args.name + "_id", args.inputs]
 
     def call(self, args: pulumi.runtime.MockCallArgs):  # noqa: ARG002
@@ -48,11 +36,6 @@ class K8sMocks(pulumi.runtime.Mocks):
 
 
 pulumi.runtime.set_mocks(K8sMocks())
-
-
-def registered_plugin_config_names() -> set[str]:
-    """metadata.name of every v1alpha1 PluginConfig the mocks have created."""
-    return {name for typ, name in REGISTERED if typ == PLUGIN_CONFIG_TYPE and name}
 
 
 from ol_infrastructure.components.services.apisix import (  # noqa: E402
@@ -213,11 +196,12 @@ def test_rule_extension_ref_names_the_created_plugin_config():
     PluginConfig that was never created -- which APISIX resolves by serving the
     route with no plugins at all rather than by failing.
 
-    The created names are read back off the mocks rather than recomputed with
-    the component's own naming helper: recomputing them would compare the
-    component against itself and still pass if it registered nothing.
+    The created names are read off the PluginConfig resources the component
+    registered -- their own ``metadata.name``, the value that would reach the
+    cluster -- rather than recomputed with the component's naming helper:
+    recomputing them would compare the component against itself and still pass
+    if it registered nothing at all.
     """
-    REGISTERED.clear()
     plugins = shared_plugins("merge-render")
     route_configs = [
         route(
@@ -240,21 +224,22 @@ def test_rule_extension_ref_names_the_created_plugin_config():
         k8s_labels={"app": "myapp"},
     )
 
-    def check(spec):
-        # The HTTPRoute depends_on its PluginConfigs, so every one of them has
-        # been registered by the time this spec resolves.
-        created = registered_plugin_config_names()
+    created = pulumi.Output.all(
+        *[resource.metadata for resource in component.plugin_config_resources.values()]
+    ).apply(lambda metadatas: {metadata["name"] for metadata in metadatas})
+
+    def check(args):
+        spec, created_names = args
         referenced = [
             rule["filters"][0]["extensionRef"]["name"] for rule in spec["rules"]
         ]
         assert len(referenced) == len(route_configs)
         # Every rule points at a PluginConfig that actually exists...
-        assert set(referenced) <= created, set(referenced) - created
+        assert set(referenced) <= created_names, set(referenced) - created_names
         # ...a distinct one per route, since the two routes' merged lists differ
         assert len(set(referenced)) == len(route_configs)
-        # ...and not at the shared config itself, which is what the route
+        # ...and not at the shared config itself, which is what a route
         # referenced before the merge moved into this component.
-        assert plugins.resource_name in created
         assert plugins.resource_name not in referenced
 
         for rule in spec["rules"]:
@@ -264,4 +249,4 @@ def test_rule_extension_ref_names_the_created_plugin_config():
             assert extension_ref["kind"] == "PluginConfig"
             assert extension_ref["group"] == "apisix.apache.org"
 
-    return component.http_route_resource.spec.apply(check)
+    return pulumi.Output.all(component.http_route_resource.spec, created).apply(check)

--- a/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_gateway_api.py
@@ -1,0 +1,245 @@
+"""Tests for OLApisixHTTPRoute's plugin handling.
+
+A legacy ``ApisixRoute`` can name a shared ApisixPluginConfig *and* carry its
+own plugins, and APISIX combines the two. A Gateway API HTTPRoute rule accepts
+only one ExtensionRef filter, so ``OLApisixHTTPRoute`` has to do that merge
+itself before writing the v1alpha1 PluginConfig. This module verifies:
+
+1. Shared defaults and a route's own plugins both survive the merge
+2. A route-level plugin replaces the same-named shared entry outright, which is
+   what APISIX does on the legacy path
+3. ``enable=False`` on a route plugin drops a shared plugin from that one route
+4. Two routes sharing one config get their own PluginConfig, and each rule's
+   ExtensionRef names the resource that was actually created
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pulumi
+
+# Python 3.14+ compatibility
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+class K8sMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):  # noqa: ARG002
+        return {}
+
+
+pulumi.runtime.set_mocks(K8sMocks())
+
+from ol_infrastructure.components.services.apisix import (  # noqa: E402
+    OLApisixPluginConfig,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
+from ol_infrastructure.components.services.apisix_gateway_api import (  # noqa: E402
+    OLApisixHTTPRoute,
+    OLApisixHTTPRouteConfig,
+)
+
+
+def shared_plugins(name: str, **overrides) -> OLApisixSharedPlugins:
+    return OLApisixSharedPlugins(
+        name,
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name=name,
+            k8s_namespace="myapp-ns",
+            **overrides,
+        ),
+    )
+
+
+def route(**overrides) -> OLApisixHTTPRouteConfig:
+    return OLApisixHTTPRouteConfig(
+        route_name=overrides.pop("route_name", "web"),
+        hosts=["app.example.com"],
+        paths=["/*"],
+        backend_service_name="myapp",
+        backend_service_port=8080,
+        **overrides,
+    )
+
+
+def merged_names(route_config: OLApisixHTTPRouteConfig) -> list[str]:
+    return [p.name for p in OLApisixHTTPRoute._merged_plugins(route_config)]
+
+
+def merged_by_name(
+    route_config: OLApisixHTTPRouteConfig,
+) -> dict[str, dict[str, Any]]:
+    return {p.name: p.config for p in OLApisixHTTPRoute._merged_plugins(route_config)}
+
+
+# ─── the merge itself ──────────────────────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_shared_and_route_plugins_both_survive():
+    """The bug this replaced: setting the shared config silently discarded the
+    route's own plugin list, including the request-id plugin the config class's
+    own validator adds.
+    """
+    route_config = route(
+        shared_plugins=shared_plugins("merge-both"),
+        plugins=[
+            OLApisixPluginConfig(
+                name="mocking",
+                secretRef=None,
+                config={"response_status": 204, "response_example": ""},
+            ),
+        ],
+    )
+    names = merged_names(route_config)
+    # From the shared config
+    for expected in ("cors", "prometheus", "gzip", "redirect"):
+        assert expected in names, expected
+    # From the route, plus the validator's addition
+    assert "mocking" in names
+    assert "request-id" in names
+
+
+@pulumi.runtime.test
+def test_route_plugin_replaces_same_named_shared_plugin():
+    """APISIX replaces rather than deep-merges a same-named plugin on the legacy
+    path (verified in production on mitxonline's static-hash route, whose
+    Cache-Control response-rewrite wins over the shared Referrer-Policy one).
+    The Pulumi-side merge has to behave identically or moving a route from
+    ApisixRoute to HTTPRoute would change its headers.
+    """
+    route_config = route(
+        shared_plugins=shared_plugins("merge-override"),
+        plugins=[
+            OLApisixPluginConfig(
+                name="response-rewrite",
+                secretRef=None,
+                config={"headers": {"set": {"Cache-Control": "private, no-cache"}}},
+            ),
+        ],
+    )
+    configs = merged_by_name(route_config)
+    assert merged_names(route_config).count("response-rewrite") == 1
+    headers = configs["response-rewrite"]["headers"]["set"]
+    assert headers == {"Cache-Control": "private, no-cache"}
+    assert "Referrer-Policy" not in headers
+
+
+@pulumi.runtime.test
+def test_route_can_opt_out_of_a_shared_plugin():
+    """A disabled route-level entry replaces the shared one and is then dropped
+    from the rendered v1alpha1 spec, which is the only per-route escape hatch
+    now that every route gets the shared list merged in.
+    """
+    route_config = route(
+        shared_plugins=shared_plugins("merge-optout"),
+        plugins=[OLApisixPluginConfig(name="gzip", secretRef=None, enable=False)],
+    )
+    assert "gzip" in merged_names(route_config)
+    active = OLApisixHTTPRoute._active_plugins(
+        OLApisixHTTPRoute._merged_plugins(route_config)
+    )
+    assert "gzip" not in [p.name for p in active]
+    # The rest of the shared list is untouched by the opt-out.
+    assert "prometheus" in [p.name for p in active]
+
+
+@pulumi.runtime.test
+def test_request_id_survives_an_omitted_plugins_list():
+    """Pydantic skips field validators for a field left at its default, so
+    before ``validate_default`` a route that spelled out ``plugins=[]`` got
+    request-id and an otherwise identical route that omitted the argument did
+    not -- an invisible difference that decided whether a route's requests were
+    correlatable.
+    """
+    assert merged_names(route()) == ["request-id"]
+    assert "request-id" in merged_names(
+        route(shared_plugins=shared_plugins("merge-default"))
+    )
+
+
+@pulumi.runtime.test
+def test_request_id_default_is_not_accumulated_across_instances():
+    """The validator now returns a new list instead of appending, because with
+    validate_default=True an in-place append would grow the field's own default
+    on every instantiation.
+    """
+    for _ in range(3):
+        assert merged_names(route()) == ["request-id"]
+
+
+@pulumi.runtime.test
+def test_route_without_shared_plugins_keeps_its_own():
+    """Routes that reference no shared config are unaffected by the merge."""
+    route_config = route(
+        plugins=[OLApisixPluginConfig(name="mocking", secretRef=None, config={})]
+    )
+    assert sorted(merged_names(route_config)) == ["mocking", "request-id"]
+
+
+# ─── the rendered resources ────────────────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_rule_extension_ref_names_the_created_plugin_config():
+    """The ExtensionRef name is recomputed from the merged list rather than
+    stored, so a mismatch between the referenced name and the PluginConfig that
+    was created would leave the route pointing at a resource that does not
+    exist -- and APISIX silently serves the route with no plugins at all.
+    """
+    plugins = shared_plugins("merge-render")
+    route_configs = [
+        route(
+            route_name="static",
+            shared_plugins=plugins,
+            plugins=[
+                OLApisixPluginConfig(
+                    name="response-rewrite",
+                    secretRef=None,
+                    config={"headers": {"set": {"Cache-Control": "private"}}},
+                ),
+            ],
+        ),
+        route(route_name="passthrough", shared_plugins=plugins),
+    ]
+    httproute_name = "merge-render-httproute"
+    component = OLApisixHTTPRoute(
+        httproute_name,
+        route_configs=route_configs,
+        k8s_namespace="myapp-ns",
+        k8s_labels={"app": "myapp"},
+    )
+
+    created = {
+        component._generate_plugin_config_name(
+            httproute_name,
+            route_config.route_name,
+            component._active_plugins(component._merged_plugins(route_config)),
+        )
+        for route_config in route_configs
+    }
+    # Distinct plugin sets hash to distinct PluginConfigs, one per route.
+    assert len(created) == len(route_configs)
+
+    def check(spec):
+        referenced = [
+            rule["filters"][0]["extensionRef"]["name"] for rule in spec["rules"]
+        ]
+        assert len(referenced) == len(route_configs)
+        assert set(referenced) == created
+        for rule in spec["rules"]:
+            extension_ref = rule["filters"][0]["extensionRef"]
+            # v1alpha1 PluginConfig -- the v2 ApisixPluginConfig kind is
+            # silently ignored by the HTTPRoute reconciler.
+            assert extension_ref["kind"] == "PluginConfig"
+            assert extension_ref["group"] == "apisix.apache.org"
+
+    return component.http_route_resource.spec.apply(check)


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up to #5736, which fixed all 52 legacy `OLApisixRouteConfig` blocks but could not touch the Gateway API ones.

### Description (What does it do?)

- `OLApisixHTTPRoute` can now apply shared plugin defaults *and* a route's own plugins to the same rule. It could not before: setting the shared config name discarded the route's plugin list entirely, including the `request-id` plugin `OLApisixHTTPRouteConfig`'s own validator adds.
- `OLApisixHTTPRouteConfig.shared_plugin_config_name: str` is replaced by `shared_plugins: OLApisixSharedPlugins`, because the merge has to happen in Pulumi rather than in APISIX (see implementation details).
- Attaches shared plugins to the 11 HTTPRoute blocks that referenced none, so they were serving with only `request-id`: no per-route prometheus series, no OTLP spans, uncompressed responses.
  - `ocw_studio`, `xpro` — `static-hash`, `static`, `dnt-policy`, `passthrough` (4 each)
  - `starrocks` — `{env_prefix}-starrocks`
  - `toolhive_swe` — `vmcp`
  - `witan` — `witan`
- `enable_cors=False` on starrocks, the swe vMCP and witan: an OAuth2 callback for a JDBC driver and two bearer-token MCP endpoints have no cross-origin browser caller, so picking up the observability plugins should not also widen their origin policy. Same judgment #5736 applied to Dagster/Airbyte/Leek/gwarek.
- Removes the `request-id`-in-the-shared-config workaround from `jupyterhub_data` and `edxapp/meilisearch`, which existed only to route around this limitation.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why the merge happens in Pulumi.** A Gateway API HTTPRoute rule accepts exactly one `ExtensionRef` filter, so a route cannot point at a shared PluginConfig *and* its own the way a legacy `ApisixRoute` names a shared `ApisixPluginConfig` alongside its own `plugins` and lets APISIX combine them. `OLApisixSharedPlugins` now exposes its rendered list as `self.plugin_list`, and `OLApisixHTTPRoute._merged_plugins` combines it with the route's own into a single per-route PluginConfig — which is why the config field takes the component rather than its `resource_name`.

**Merge semantics.** Shared entries first, then the route's own; a route entry replaces the same-named shared entry wholesale rather than deep-merging its `config`. That mirrors what APISIX does on the legacy path, per #5736. The visible consequence is that a route carrying its own `response-rewrite` (the `Cache-Control` and `Access-Control-Allow-Origin` ones on `static`/`static-hash`) does not also get the shared `Referrer-Policy: origin` — matching how those same routes behave today on mitxonline's legacy `ApisixRoute`. `passthrough`, which serves the HTML, keeps it.

A side effect worth knowing: because every route now gets a merged config, `OLApisixPluginConfig(name="gzip", enable=False)` is a real per-route opt-out from a shared plugin, since disabled plugins are dropped from the rendered v1alpha1 spec.

**Two things that fell out of the change:**

- `depends_on` from the HTTPRoute to its PluginConfigs. A PluginConfig's name is a hash of its contents, so any plugin change renames it and the `ExtensionRef` has to follow. Without the edge Pulumi may update the route first, briefly pointing it at a name that does not exist — which APISIX resolves by serving the route with no plugins rather than by failing.
- `validate_default=True` on `OLApisixHTTPRouteConfig`. Pydantic skips field validators for a field left at its default, so dropping an explicit `plugins=[]` at a call site silently dropped `request-id` too. Caught in `pulumi preview` on `jupyterhub_data`, where the new merged config came out without it. The validator also returns a new list instead of appending, so validating the default cannot grow the class-level default.

`enable_gzip` is left on for the two MCP endpoints: `text/event-stream` is deliberately absent from the gzip plugin's `types` list, so streaming responses are not held behind a compression buffer.

</details>

### How can this be tested?

`pulumi preview` was run against CI for every affected stack, plus `witan` QA to confirm the `opentelemetry` CI gate still holds. Each preview shows the new per-route PluginConfig, the `ExtensionRef` following it, and the old one being deleted. Nothing has been deployed.

| Stack | Result |
|---|---|
| `ol-application-witan` CI, QA | +4 / ~1 / -1 |
| `ol-application-toolhive-swe` CI | +4 / ~1 / -1 |
| `ol-application-starrocks` lakehouse.CI | +4 / ~2 / -1 |
| `ol-application-ocw-studio` CI | +7 / ~2 / -4 |
| `ol-application-xpro` CI | +7 / ~2 / -4 |
| `ol-application-jupyterhub-data` CI | +1 / ~4 |
| `ol-application-edxapp` mitxonline.CI | +1 / ~3 |

(the extra `~` in some stacks is pre-existing kubeconfig/provider key-ordering churn, not part of this change)

Rendered plugin lists from the CI previews, e.g.:

```
create ocw-studio-apisix-httproute-ci-dnt-policy    => redirect, cors, response-rewrite, prometheus, gzip, mocking, request-id
delete ocw-studio-apisix-httproute-ci-dnt-policy    => mocking, request-id
create witan-apisix-httproute-qa-witan              => redirect, response-rewrite, prometheus, opentelemetry, gzip, request-id
delete witan-apisix-httproute-qa-witan              => request-id
```

New unit tests in `tests/ol_infrastructure/components/services/test_apisix_gateway_api.py` cover the merge, same-name override, the `enable=False` opt-out, the omitted-`plugins` case, and that each rule's `ExtensionRef` names a PluginConfig that is actually created. `pytest tests/ol_infrastructure/components/services/` is green (146 passed); `pre-commit run` (ruff, ruff-format, mypy) is clean. The 12 failures in `tests/ol_concourse/test_versions_map.py` are pre-existing on `main`.

To validate after deploy: the four `ocw-studio` / `xpro` routes and the three internal hosts should start showing per-route series in `apisix_http_status` (the `prometheus` plugin runs in the log phase, so even the mocked 204 `dnt-policy` records), spans should appear in Tempo for those hosts, and `/static/*` responses should come back `Content-Encoding: gzip`. Worth spot-checking that `/static/hash.txt` still returns `Cache-Control: private, no-cache` and that the `dnt-policy` 204 is still served at the gateway.

### Additional Context

Deploy order does not matter across stacks — each stack owns its own shared config and its own routes.

Reviewer attention is most useful on two judgment calls: the `enable_cors=False` picks for starrocks / vMCP / witan, and keeping the unconditional `Access-Control-Allow-Origin: *` `response-rewrite` on `ocw_studio`/`xpro` `static` now that `cors` is also attached. Keeping it preserves today's behavior exactly (the `cors` plugin only answers requests that carry an `Origin`); dropping it would let credentialed cross-origin static fetches start succeeding, which is a widening I did not want to slip in here.
