### PR TITLE
fix(apisix): quote request_uri in the access log format

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -604,7 +604,16 @@ def setup_apisix(
                             "request_length=$request_length "
                             "request_method=$request_method "
                             "request_time=$request_time "
-                            "request_uri=$request_uri "
+                            # Quoted because Loki's logfmt parser silently
+                            # DROPS a key whose unquoted value contains "=":
+                            # every URI with a query string ("?limit=12")
+                            # parsed to an empty request_uri, with no
+                            # __error__ raised to make the loss visible.  The
+                            # already-quoted $request on the same line kept
+                            # its full URI, which is what this mirrors.  Safe
+                            # with accessLogFormatEscape "default": nginx
+                            # escapes any literal quote in the URI as \".
+                            'request_uri="$request_uri" '
                             "status=$status "
                             "upstream_addr=$upstream_addr "
                             "upstream_connect_time=$upstream_connect_time "


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Wraps `$request_uri` in double quotes in the APISIX access log format, so Grafana/Loki can actually parse it.

- Loki's `logfmt` parser silently **drops** a key whose unquoted value contains an `=`. Every request with a query string has been logging a `request_uri` that parses to empty.
- No `__error__` label is set, so nothing surfaced the loss — the field just isn't there after `| logfmt`.
- Quoting matches what the format already does for every other free-form field (`time_local`, `http_referer`, `http_user_agent`, `request`, `cookie_names`, `cookie_sizes`).

<details>
<summary><b>Implementation details</b></summary>
<br>

Verified on `applications-production` against `grafanacloud-mitolproduction-logs` before making the change. Piping the current log line through `| logfmt` and re-rendering the parsed fields:

```
{app_kubernetes_io_name="apache-apisix", cluster="applications-production"}
  | logfmt
  | line_format "URI=[{{.request_uri}}] STATUS=[{{.status}}] RAW=[{{.request}}]"
```

```
URI=[/user/.../checkpoints?1788973122846]  STATUS=[200]  RAW=[GET /user/.../checkpoints?1788973122846 HTTP/2.0]
URI=[]                                     STATUS=[200]  RAW=[GET /api/v1/topics/?parent_topic_id=774 HTTP/2.0]
URI=[]                                     STATUS=[200]  RAW=[GET /api/v1/learning_resources/7536/items/?limit=12 HTTP/2.0]
```

This isolates the trigger precisely:

- A `?` alone is fine — `?1788973122846` has no `=` and parses.
- A single `=` is enough to drop the field — `?limit=12` needs no `&`.
- `&` is not implicated; a URI with `&` but no `=` does not occur in practice and is not the cause.
- Fields *after* `request_uri` are unaffected: `status` and `http_user_agent` still parse. The value is dropped, not shifted.
- `sum by (__error__) (count_over_time({...} | logfmt [5m]))` returns a single series with no `__error__` over 42,023 lines — the parser reports success while discarding the field.

The last column is the fix, already running in production on the same log line: `request="$request"` is quoted, contains the identical URI including its query string, and parses intact. This change makes `request_uri` behave the same way.

Quoting is safe under the existing `accessLogFormatEscape: "default"`. nginx's default escaping replaces a literal `"` with `\"` and bytes outside `0x20`–`0x7E` with `\xNN`, and Loki's logfmt reader understands both inside a quoted value, so a URI containing a quote cannot break out of the field.

Alternatives considered and rejected:

- **Drop `request_uri` entirely** as redundant with `$request` (`"$request_method $request_uri $server_protocol"`). Rejected: breaks any saved query keyed on `request_uri` and forces a substring extraction instead.
- **Switch `accessLogFormatEscape` to `json`.** Rejected: it escapes values but does not add the surrounding quotes logfmt needs, so it would not fix the parse, and it changes escaping for every other field at once.

</details>

### How can this be tested?

Not yet deployed — this needs `pulumi up` on the EKS stacks, and the format only takes effect once the APISIX pods roll (the Helm values change alters the pod spec, so the release update handles it).

What has been run locally:

- `pre-commit` on the commit: `ruff format`, `ruff check`, `mypy` all pass.
- Parsed the file with `ast` and dumped the assembled `accessLogFormat` literal to confirm the implicit string concatenation across the new comment still yields one unbroken format string, changed only at `request_uri`.

To validate after deploy, run against the target cluster and confirm the second and third rows now show a populated `URI=[...]`:

```
{app_kubernetes_io_name="apache-apisix", cluster="applications-production"}
  |= "?" | logfmt
  | line_format "URI=[{{.request_uri}}] STATUS=[{{.status}}]"
```

### Additional Context

One consequence worth knowing before rollout: existing Loki queries that match the **raw line**, e.g. `|= "request_uri=/api/"`, will stop matching once the pods roll, because the value is now preceded by a quote. Queries that filter **after** `| logfmt` (`| request_uri=~"/api/.*"`) are unaffected — and those are the ones that were broken to begin with.

I grepped the repo for other consumers: `request_uri` appears in only one other place, as prose in an alert description (`src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/apisix_oidc.py`), not in any query expression. Nothing else in this repo needs a companion change. Saved dashboards and ad-hoc queries outside the repo are not covered by that grep.
