### PR TITLE
fix(mit-learn): set NEXT_PUBLIC_HUBSPOT_PORTAL_ID as runtime env var

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -117,8 +117,17 @@ stay_updated_hubspot_form_ids = {
     "production": "a5d18493-dcdb-4482-ad10-16ab66a35526",
 }
 
+# HubSpot tracking portal: xprodev for dev/RC, xPRO prod for production
+# (mitodl/hq#10735). Public value (in the js.hs-scripts.com URL), not a secret.
+hubspot_portal_ids = {
+    "ci": "23128026",
+    "qa": "23128026",
+    "production": "4994459",
+}
+
 try:
     stay_updated_hubspot_form_id = stay_updated_hubspot_form_ids[stack_info.env_suffix]
+    hubspot_portal_id = hubspot_portal_ids[stack_info.env_suffix]
 except KeyError as exc:
     msg = f"Unsupported MIT Learn Next.js environment: {stack_info.env_suffix}"
     raise ValueError(msg) from exc
@@ -178,6 +187,7 @@ raw_env_vars = {
     "NEXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE": "0.25",
     "NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE": "0.001",
     "NEXT_PUBLIC_SITE_NAME": "MIT Learn",
+    "NEXT_PUBLIC_HUBSPOT_PORTAL_ID": hubspot_portal_id,
     "NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID": stay_updated_hubspot_form_id,
     "NEXT_PUBLIC_VERSION": MIT_LEARN_NEXTJS_DOCKER_TAG,
     "NEXT_PUBLIC_FEATURE_product_page_courses": "false",


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/13258

Related ticket and PRs:

- Original feature ticket: https://github.com/mitodl/hq/issues/10735
- Added the tracking code: https://github.com/mitodl/mit-learn/pull/3152
- Moved env reads to runtime: https://github.com/mitodl/mit-learn/pull/3364

### Description (What does it do?)

Restores the HubSpot tracking code on `learn.mit.edu`, which HubSpot's validator reports as missing.

- The tracking `<Script>` in mit-learn's [`(site)/layout.tsx`](https://github.com/mitodl/mit-learn/blob/91789c790ff3b592e23c4f56186c34ceb6017b7f/frontends/main/src/app/%28site%29/layout.tsx#L93) only renders when **`env("NEXT_PUBLIC_HUBSPOT_PORTAL_ID")`** resolves at runtime.
- Since mit-learn#3364, `NEXT_PUBLIC_*` values are read at runtime via the `env()` helper (from the pod env + `x-public-env` meta) rather than inlined at build time. This var isn't set in the app's env, so `env()` resolves to `undefined` and the script isn't rendered.
- Adds **`NEXT_PUBLIC_HUBSPOT_PORTAL_ID`** per environment, mirroring the existing [`stay_updated_hubspot_form_ids`](https://github.com/mitodl/ol-infrastructure/blob/073399b0c/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py#L114) pattern. Public value (it ships in the `js.hs-scripts.com` URL), so plain config, not a secret.

**Portal IDs:** production `4994459` (xPRO prod account) is already used in Learn at [`UAILandingPage.tsx:522`](https://github.com/mitodl/mit-learn/blob/91789c790ff3b592e23c4f56186c34ceb6017b7f/frontends/main/src/app-pages/UAILandingPage/UAILandingPage.tsx#L522), and matches the `notificationPortalId=4994459` in [hq#13258](https://github.com/mitodl/hq/issues/13258) and xPRO's [`Pulumi.Production.yaml`](https://github.com/mitodl/ol-infrastructure/blob/ff99e27c393f65c12fd2fe729285300648e45aa3/src/ol_infrastructure/applications/xpro/Pulumi.Production.yaml#L25); RC/CI use `23128026` (xprodev, per mitodl/hq#10735).

### Screenshots (if appropriate):
<img width="1405" height="460" alt="Screenshot 2026-09-10 at 4 48 12 PM" src="https://github.com/user-attachments/assets/98a86c80-4a7c-48ca-b6ef-02f0d5a00cf8" />

### How can this be tested?

In the mit-learn repo, start the frontend with the portal ID set:

```bash
NEXT_PUBLIC_HUBSPOT_PORTAL_ID=4994459 yarn workspace main dev
```

Then check the served HTML:

```bash
curl -s http://localhost:8062/ | grep -o 'js.hs-scripts.com/[0-9]*\.js'
```

- **With the var →** prints `js.hs-scripts.com/4994459.js`.
- **Unset it and restart →** the tag is absent (reproduces the bug).