### PR TITLE
fix: trace SOPS secret deployments in where-is-my-pr

### DIFF
--- a/scripts/where-is-my-pr
+++ b/scripts/where-is-my-pr
@@ -549,12 +549,14 @@ def _read_pipeline_routes(
     path = _pipeline_path(pipeline["name"], "/config")
     data = _fly_curl(f"/api/v1{path}{query}")
     if not isinstance(data, dict) or not isinstance(data.get("config"), dict):
-        return [], f"{pipeline['name']}{query}"
+        # The selector is needed for the request, but not for diagnostics.
+        # Do not echo arbitrary instance-variable values on an error path.
+        return [], str(pipeline["name"])
     return _routes_from_config(pipeline["name"], data["config"], query), None
 
 
-def _discover_secret_routes() -> tuple[list[SecretsRoute], list[str]]:
-    """Discover all visible pipelines once, with bounded concurrent API reads."""
+def _discover_pulumi_routes() -> tuple[list[SecretsRoute], list[str]]:
+    """Discover Pulumi routing metadata, not secret values, with bounded API reads."""
     pipelines = _fly_curl(f"/api/v1/teams/{CONCOURSE_TEAM}/pipelines")
     if not isinstance(pipelines, list):
         return [], ["pipeline list unavailable"]
@@ -649,15 +651,12 @@ def _report_sops_secrets(pr: PullRequest, paths: list[str]) -> None:
             print(f"      Candidate projects: {', '.join(sorted(projects))}")
         else:
             relative = path.removeprefix(f"{SECRETS_ROOT}/")
-            reasons = {
-                reason
-                for pattern, reason in DEPLOY_CREDENTIAL_SECRETS.items()
-                if _secret_entry_matches(relative, pattern)
-            }
-            if reasons:
-                print(
-                    f"      Provider credentials only: {'; '.join(sorted(reasons))}; no content deploy expected."
-                )
+            credential_only = any(
+                _secret_entry_matches(relative, pattern)
+                for pattern in DEPLOY_CREDENTIAL_SECRETS
+            )
+            if credential_only:
+                print("      Provider credentials only; no content deploy expected.")
             else:
                 print(
                     "      ?  No registered Pulumi consumer; deployment route unknown."
@@ -672,7 +671,7 @@ def _report_sops_secrets(pr: PullRequest, paths: list[str]) -> None:
             f"    Log in: fly -t {CONCOURSE_TEAM} login -c {CONCOURSE_URL} -n {CONCOURSE_TEAM}"
         )
         return
-    routes, failures = _discover_secret_routes()
+    routes, failures = _discover_pulumi_routes()
     for failure in failures:
         print(f"    ?  Could not inspect {failure}; discovery is incomplete.")
     grouped: dict[SecretsRoute, list[str]] = {}

--- a/scripts/where-is-my-pr
+++ b/scripts/where-is-my-pr
@@ -32,6 +32,12 @@ find which apps' Pulumi code (``src/ol_infrastructure/applications/{app}/``)
 or shared infrastructure code (``PULUMI_WATCHED_PATHS`` -- consumed by every
 app's ``ol-infra-{app}`` pipeline resource) it touches, and each affected
 app pipeline's stages are checked for whether they've picked up this commit.
+
+Concourse ``concourse/operations.<env>.yaml`` and global Vault
+``vault/secrets.<env>.yaml`` files under ``src/bridge/secrets/`` are routed to
+``packer-pulumi-concourse`` and ``packer-pulumi-vault`` respectively. Only the
+file's environment is checked, using successful deploy builds (never previews).
+This reports pipeline evidence, not a read-back of secret values from Vault.
 """
 
 import json
@@ -67,6 +73,43 @@ APPLICATIONS_DIR_RE = re.compile(r"^src/ol_infrastructure/applications/([^/]+)/"
 PR_URL_RE = re.compile(
     r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)"
 )
+
+
+@dataclass(frozen=True)
+class SecretsRoute:
+    """A known SOPS file family and the Pulumi job that writes it into Vault."""
+
+    file_prefix: str
+    pipeline: str
+    project: str
+    job_suffix: str
+    resource: str
+    vault_mount: str
+
+
+# Keep these explicit: not every SOPS file is Vault content. Some are only
+# provider credentials, and other applications manage their own secret mounts.
+# Sources: infrastructure/{concourse,vault}/pipeline.py and the two Pulumi
+# entrypoints below. tests/test_where_is_my_pr.py checks generated job names.
+SECRETS_ROUTES = (
+    SecretsRoute(
+        file_prefix="src/bridge/secrets/concourse/operations",
+        pipeline="packer-pulumi-concourse",
+        project="applications/concourse",
+        job_suffix="ol-infrastructure-concourse-application",
+        resource="ol-infrastructure-pulumi",
+        vault_mount="secret-concourse",
+    ),
+    SecretsRoute(
+        file_prefix="src/bridge/secrets/vault/secrets",
+        pipeline="packer-pulumi-vault",
+        project="substructure/vault/secrets",
+        job_suffix="ol-substructure-vault-secrets-operations",
+        resource="ol-infrastructure-pulumi-substructure",
+        vault_mount="secret-global",
+    ),
+)
+SECRETS_ENVIRONMENTS = {"ci": "CI", "qa": "QA", "production": "Production"}
 
 
 @dataclass
@@ -357,9 +400,71 @@ def _report_ol_infra_app(pr: PullRequest, app_name: str) -> None:
         )
 
 
+def _matching_secrets_route(path: str) -> tuple[SecretsRoute, str] | None:
+    """Match only known content-bearing files, without reading secret values."""
+    for route in SECRETS_ROUTES:
+        for env in SECRETS_ENVIRONMENTS:
+            if path == f"{route.file_prefix}.{env}.yaml":
+                return route, env
+    return None
+
+
+def _report_vault_secrets(
+    pr: PullRequest, path: str, route: SecretsRoute, env: str
+) -> None:
+    """Explain a SOPS-to-Vault route and check its environment's deploy build."""
+    pipeline_url = f"{CONCOURSE_URL}/teams/{CONCOURSE_TEAM}/pipelines/{route.pipeline}"
+    deploy_job = f"deploy-{route.job_suffix}-{env}"
+    print(f"\n=== Vault secrets: {SECRETS_ENVIRONMENTS[env]} ({route.pipeline}) ===")
+    print(f"    {path}")
+    print(f"    -> Pulumi src/ol_infrastructure/{route.project}/")
+    print(f"    -> Vault {route.vault_mount} ({SECRETS_ENVIRONMENTS[env]})")
+    print(f"    Deploy: {pipeline_url}/jobs/{deploy_job}")
+    if env == "ci":
+        print("    CI deploys automatically when its pipeline inputs are ready.")
+    else:
+        preview_job = f"preview-{route.job_suffix}-{env}"
+        print(f"    Preview: {pipeline_url}/jobs/{preview_job}")
+        print(
+            "    QA/Production require a manual deploy after preview; preview does not write secrets."
+        )
+    print(
+        "    Successful deploy ancestry is pipeline evidence, not a Vault value read-back."
+    )
+
+    if not _fly_ready():
+        print(
+            "    ?  fly not logged in to 'infrastructure' -- can't verify live builds"
+        )
+        print(
+            f"    Log in: fly -t {CONCOURSE_TEAM} login -c {CONCOURSE_URL} -n {CONCOURSE_TEAM}"
+        )
+        return
+
+    live = _live_stage(pr, route.pipeline, deploy_job, [route.resource])
+    if live is None:
+        print(
+            "    ?  Could not verify a successful deploy build/input (API unavailable or no usable build in the last 10)."
+        )
+        return
+    print(
+        _format_stage(
+            "Vault deploy",
+            live.reached,
+            f"build #{live.build_name} used ol-infra {live.deployed_commit[:8]}",
+        )
+    )
+    print(f"    Build: {pipeline_url}/jobs/{deploy_job}/builds/{live.build_name}")
+
+
 def _report_ol_infrastructure_pr(pr: PullRequest) -> None:
     paths = _changed_files(pr.owner, pr.repo, pr.number)
-    direct, shared_hit, other = _impacted_apps(paths)
+    secret_paths = {
+        path: match for path in paths if (match := _matching_secrets_route(path))
+    }
+    direct, shared_hit, other = _impacted_apps(
+        [path for path in paths if path not in secret_paths]
+    )
     impacted = direct | (set(APPS) if shared_hit else set())
 
     if direct:
@@ -370,14 +475,17 @@ def _report_ol_infrastructure_pr(pr: PullRequest) -> None:
             f"{', '.join(PULUMI_WATCHED_PATHS)}) -- every app pipeline's "
             "ol-infra-{app} resource picks this up."
         )
-    if not impacted:
-        print("\nNo changed files map to a known app pipeline.")
+    for path, (route, env) in sorted(secret_paths.items()):
+        _report_vault_secrets(pr, path, route, env)
+
+    if not impacted and not secret_paths:
+        print("\nNo changed files map to a known deployment pipeline.")
 
     for app_name in sorted(impacted):
         _report_ol_infra_app(pr, app_name)
 
     if other:
-        print("\nOther changed files (no known app pipeline mapping):")
+        print("\nOther changed files (no known deployment pipeline mapping):")
         for path in other:
             print(f"    {path}")
 

--- a/scripts/where-is-my-pr
+++ b/scripts/where-is-my-pr
@@ -33,26 +33,38 @@ or shared infrastructure code (``PULUMI_WATCHED_PATHS`` -- consumed by every
 app's ``ol-infra-{app}`` pipeline resource) it touches, and each affected
 app pipeline's stages are checked for whether they've picked up this commit.
 
-Concourse ``concourse/operations.<env>.yaml`` and global Vault
-``vault/secrets.<env>.yaml`` files under ``src/bridge/secrets/`` are routed to
-``packer-pulumi-concourse`` and ``packer-pulumi-vault`` respectively. Only the
-file's environment is checked, using successful deploy builds (never previews).
-This reports pipeline evidence, not a read-back of secret values from Vault.
+SOPS files under ``src/bridge/secrets/`` are mapped to candidate Pulumi consumers
+using ``PROJECT_SECRETS`` (including shared files and provider-credential
+exceptions). Live Concourse configurations supply the actual project, stack,
+deploy job and git input, without hard-coded pipeline names. Environment and
+stack-group names in filenames narrow the checks; shared files check all matching
+stacks. Registry watches can cover entire directories: successful build ancestry
+is pipeline evidence, not proof a particular key was written to Vault. No SOPS
+decryption or Vault read-back is performed.
 """
 
 import json
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import cyclopts
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from bridge.settings.apps import APPS, github_repo, repo_main_branch
 from ol_concourse.pipelines.constants import PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.secrets_map import (
+    DEPLOY_CREDENTIAL_SECRETS,
+    PROJECT_SECRETS,
+    SECRETS_ROOT,
+)
 
 app = cyclopts.App(
     help="Show which ol-infrastructure deployment pipeline stages a GitHub PR has reached."
@@ -77,39 +89,27 @@ PR_URL_RE = re.compile(
 
 @dataclass(frozen=True)
 class SecretsRoute:
-    """A known SOPS file family and the Pulumi job that writes it into Vault."""
+    """A deployed Pulumi update and the checkout supplying its source directory."""
 
-    file_prefix: str
     pipeline: str
     project: str
-    job_suffix: str
+    stack: str
+    job: str
     resource: str
-    vault_mount: str
+    input_name: str
+    previews: tuple[str, ...] = ()
+    instance_query: str = ""
+
+    def job_url(self, job: str, build: str | None = None) -> str:
+        """Return a link, including the pipeline instance selector when present."""
+        tail = f"/jobs/{quote(job, safe='')}"
+        if build is not None:
+            tail += f"/builds/{quote(build, safe='')}"
+        path = _pipeline_path(self.pipeline, tail)
+        return f"{CONCOURSE_URL}{path}{self.instance_query}"
 
 
-# Keep these explicit: not every SOPS file is Vault content. Some are only
-# provider credentials, and other applications manage their own secret mounts.
-# Sources: infrastructure/{concourse,vault}/pipeline.py and the two Pulumi
-# entrypoints below. tests/test_where_is_my_pr.py checks generated job names.
-SECRETS_ROUTES = (
-    SecretsRoute(
-        file_prefix="src/bridge/secrets/concourse/operations",
-        pipeline="packer-pulumi-concourse",
-        project="applications/concourse",
-        job_suffix="ol-infrastructure-concourse-application",
-        resource="ol-infrastructure-pulumi",
-        vault_mount="secret-concourse",
-    ),
-    SecretsRoute(
-        file_prefix="src/bridge/secrets/vault/secrets",
-        pipeline="packer-pulumi-vault",
-        project="substructure/vault/secrets",
-        job_suffix="ol-substructure-vault-secrets-operations",
-        resource="ol-infrastructure-pulumi-substructure",
-        vault_mount="secret-global",
-    ),
-)
-SECRETS_ENVIRONMENTS = {"ci": "CI", "qa": "QA", "production": "Production"}
+SECRETS_ENV_RE = re.compile(r"[.-](ci|qa|production)\.(yaml|yml|json|env)$")
 
 
 @dataclass
@@ -211,6 +211,7 @@ def _fly_curl(path: str) -> Any | None:
         )
         return json.loads(result.stdout)
     except (
+        OSError,
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
         json.JSONDecodeError,
@@ -218,10 +219,17 @@ def _fly_curl(path: str) -> Any | None:
         return None
 
 
-def _latest_successful_build(pipeline: str, job: str) -> dict[str, Any] | None:
-    builds = _fly_curl(
-        f"/api/v1/teams/{CONCOURSE_TEAM}/pipelines/{pipeline}/jobs/{job}/builds?limit=10"
-    )
+def _pipeline_path(pipeline: str, tail: str = "") -> str:
+    """Construct a Concourse pipeline path shared by API and UI URLs."""
+    return f"/teams/{CONCOURSE_TEAM}/pipelines/{quote(pipeline, safe='')}{tail}"
+
+
+def _latest_successful_build(
+    pipeline: str, job: str, instance_query: str = ""
+) -> dict[str, Any] | None:
+    path = _pipeline_path(pipeline, f"/jobs/{quote(job, safe='')}/builds")
+    query = f"{instance_query}&limit=10" if instance_query else "?limit=10"
+    builds = _fly_curl(f"/api/v1{path}{query}")
     if not builds:
         return None
     return next((b for b in builds if b.get("status") == "succeeded"), None)
@@ -254,9 +262,13 @@ class LiveStage:
 
 
 def _live_stage(
-    pr: PullRequest, pipeline: str, job: str, candidate_resources: list[str]
+    pr: PullRequest,
+    pipeline: str,
+    job: str,
+    candidate_resources: list[str],
+    instance_query: str = "",
 ) -> LiveStage | None:
-    build = _latest_successful_build(pipeline, job)
+    build = _latest_successful_build(pipeline, job, instance_query)
     if build is None:
         return None
     commit = _build_resource_commit(build["id"], candidate_resources)
@@ -338,8 +350,10 @@ def _matching_deployments(owner: str, repo: str, commit: str) -> list[dict[str, 
 
 
 def _changed_files(owner: str, repo: str, number: int) -> list[str]:
-    files = _gh_json("api", "--paginate", f"repos/{owner}/{repo}/pulls/{number}/files")
-    return [f["filename"] for f in files]
+    pages = _gh_json(
+        "api", "--paginate", "--slurp", f"repos/{owner}/{repo}/pulls/{number}/files"
+    )
+    return [f["filename"] for page in pages for f in page]
 
 
 def _impacted_apps(paths: list[str]) -> tuple[set[str], bool, list[str]]:
@@ -400,48 +414,211 @@ def _report_ol_infra_app(pr: PullRequest, app_name: str) -> None:
         )
 
 
-def _matching_secrets_route(path: str) -> tuple[SecretsRoute, str] | None:
-    """Match only known content-bearing files, without reading secret values."""
-    for route in SECRETS_ROUTES:
-        for env in SECRETS_ENVIRONMENTS:
-            if path == f"{route.file_prefix}.{env}.yaml":
-                return route, env
-    return None
+def _is_secrets_file(path: str) -> bool:
+    """Recognize secret data paths, not the Python helpers alongside them."""
+    return path.startswith(f"{SECRETS_ROOT}/") and Path(path).suffix in {
+        ".yaml",
+        ".yml",
+        ".json",
+        ".env",
+    }
 
 
-def _report_vault_secrets(
-    pr: PullRequest, path: str, route: SecretsRoute, env: str
-) -> None:
-    """Explain a SOPS-to-Vault route and check its environment's deploy build."""
-    pipeline_url = f"{CONCOURSE_URL}/teams/{CONCOURSE_TEAM}/pipelines/{route.pipeline}"
-    deploy_job = f"deploy-{route.job_suffix}-{env}"
-    print(f"\n=== Vault secrets: {SECRETS_ENVIRONMENTS[env]} ({route.pipeline}) ===")
-    print(f"    {path}")
-    print(f"    -> Pulumi src/ol_infrastructure/{route.project}/")
-    print(f"    -> Vault {route.vault_mount} ({SECRETS_ENVIRONMENTS[env]})")
-    print(f"    Deploy: {pipeline_url}/jobs/{deploy_job}")
-    if env == "ci":
-        print("    CI deploys automatically when its pipeline inputs are ready.")
-    else:
-        preview_job = f"preview-{route.job_suffix}-{env}"
-        print(f"    Preview: {pipeline_url}/jobs/{preview_job}")
-        print(
-            "    QA/Production require a manual deploy after preview; preview does not write secrets."
-        )
-    print(
-        "    Successful deploy ancestry is pipeline evidence, not a Vault value read-back."
+def _secret_entry_matches(relative: str, entry: str) -> bool:
+    """Match registry directories, exact files or path-segment-local globs."""
+    if entry.endswith("/"):
+        return relative.startswith(entry)
+    parts, patterns = relative.split("/"), entry.split("/")
+    return len(parts) == len(patterns) and all(
+        fnmatchcase(part, pattern) for part, pattern in zip(parts, patterns)
     )
 
-    if not _fly_ready():
-        print(
-            "    ?  fly not logged in to 'infrastructure' -- can't verify live builds"
-        )
-        print(
-            f"    Log in: fly -t {CONCOURSE_TEAM} login -c {CONCOURSE_URL} -n {CONCOURSE_TEAM}"
-        )
-        return
 
-    live = _live_stage(pr, route.pipeline, deploy_job, [route.resource])
+def _secret_projects(path: str) -> set[str]:
+    """Reverse the audited watched-path registry, including credential overrides."""
+    relative = path.removeprefix(f"{SECRETS_ROOT}/")
+    return {
+        project
+        for project, entries in PROJECT_SECRETS.items()
+        if any(_secret_entry_matches(relative, entry) for entry in entries)
+    }
+
+
+def _plan_steps(plan: Any) -> Iterator[dict[str, Any]]:
+    """Walk required plan steps, never optional/error hooks or try wrappers.
+
+    A successful job does not prove that an update inside ``try`` or an error
+    hook succeeded. Only normal steps can provide deployment evidence.
+    """
+    if isinstance(plan, list):
+        for step in plan:
+            yield from _plan_steps(step)
+    elif isinstance(plan, dict):
+        yield plan
+        for key in ("do", "aggregate", "in_parallel"):
+            nested = plan.get(key, [])
+            if isinstance(nested, dict):
+                nested = nested.get("steps", [])
+            yield from _plan_steps(nested)
+
+
+def _routes_from_config(
+    pipeline: str, config: dict[str, Any], instance_query: str = ""
+) -> list[SecretsRoute]:
+    """Read Pulumi project/stack/input identities from actual pipeline config."""
+    resources = {r["name"]: r for r in config.get("resources", [])}
+    updates: list[SecretsRoute] = []
+    previews: set[str] = set()
+    dependencies: dict[str, set[str]] = {}
+    for job in config.get("jobs", []):
+        steps = list(_plan_steps(job.get("plan", [])))
+        gets = {s["get"]: s for s in steps if "get" in s}
+        dependencies[job["name"]] = {
+            name for step in gets.values() for name in step.get("passed", [])
+        }
+        for step in steps:
+            if "put" not in step:
+                continue
+            resource = resources.get(step.get("resource", step["put"]), {})
+            if resource.get("type") != "pulumi-provisioner":
+                continue
+            params = {**resource.get("source", {}), **step.get("params", {})}
+            # The resource's source_dir points to an input *alias*, not
+            # necessarily the resource name (get: checkout, resource: infra).
+            checkout, separator, project = str(params.get("source_dir", "")).partition(
+                "/src/ol_infrastructure/"
+            )
+            project = project.rstrip("/") + "/"
+            stack = params.get("stack_name")
+            if (
+                not separator
+                or project not in PROJECT_SECRETS
+                or not isinstance(stack, str)
+            ):
+                continue
+            git_get = gets.get(checkout.removeprefix("./"), {})
+            git_resource = resources.get(
+                git_get.get("resource", git_get.get("get")), {}
+            )
+            uri = (
+                git_resource.get("source", {})
+                .get("uri", "")
+                .removesuffix(".git")
+                .rstrip("/")
+            )
+            if git_resource.get("type") != "git" or uri not in {
+                f"https://github.com/{OL_INFRA_REPO}",
+                f"git@github.com:{OL_INFRA_REPO}",
+                f"ssh://git@github.com/{OL_INFRA_REPO}",
+            }:
+                continue
+            if params.get("preview") is True or params.get("action") == "preview":
+                previews.add(job["name"])
+            elif (
+                params.get("action") == "update"
+                and params.get("preview", False) is False
+            ):
+                updates.append(
+                    SecretsRoute(
+                        pipeline=pipeline,
+                        project=project,
+                        stack=stack,
+                        job=job["name"],
+                        resource=git_resource["name"],
+                        input_name=git_get["get"],
+                        instance_query=instance_query,
+                    )
+                )
+    return [
+        replace(route, previews=tuple(sorted(dependencies[route.job] & previews)))
+        for route in updates
+    ]
+
+
+def _read_pipeline_routes(
+    pipeline: dict[str, Any],
+) -> tuple[list[SecretsRoute], str | None]:
+    """Fetch one pipeline, retaining only non-secret routing metadata."""
+    query = urlencode(
+        {
+            f"vars.{key}": json.dumps(value)
+            for key, value in sorted((pipeline.get("instance_vars") or {}).items())
+        }
+    )
+    query = f"?{query}" if query else ""
+    path = _pipeline_path(pipeline["name"], "/config")
+    data = _fly_curl(f"/api/v1{path}{query}")
+    if not isinstance(data, dict) or not isinstance(data.get("config"), dict):
+        return [], f"{pipeline['name']}{query}"
+    return _routes_from_config(pipeline["name"], data["config"], query), None
+
+
+def _discover_secret_routes() -> tuple[list[SecretsRoute], list[str]]:
+    """Discover all visible pipelines once, with bounded concurrent API reads."""
+    pipelines = _fly_curl(f"/api/v1/teams/{CONCOURSE_TEAM}/pipelines")
+    if not isinstance(pipelines, list):
+        return [], ["pipeline list unavailable"]
+    routes: list[SecretsRoute] = []
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for found, failure in pool.map(_read_pipeline_routes, pipelines):
+            routes.extend(found)
+            if failure:
+                failures.append(failure)
+    return routes, failures
+
+
+def _routes_for_secret(path: str, routes: list[SecretsRoute]) -> list[SecretsRoute]:
+    """Narrow candidate consumers by environment and known stack-group tokens."""
+    projects = _secret_projects(path)
+    env = SECRETS_ENV_RE.search(path)
+    candidates = [
+        r
+        for r in routes
+        if r.project in projects
+        and (not env or r.stack.rsplit(".", 1)[-1].lower() == env[1])
+    ]
+    selected: list[SecretsRoute] = []
+    for project in sorted(projects):
+        project_routes = [r for r in candidates if r.project == project]
+        # Only infer a group if an existing stack prefix occurs in the path.
+        # Longest wins: mitx-staging must not accidentally also select mitx.
+        # Include groups with no deploy in the requested environment, rather
+        # than falling back to a shorter group which happens to have one.
+        groups = {
+            r.stack.rpartition(".")[0].lower() for r in routes if r.project == project
+        } - {""}
+        matches = [
+            g
+            for g in groups
+            if re.search(rf"(?:^|[/.-]){re.escape(g)}(?=[/.-]|$)", path)
+        ]
+        group = max(matches, key=len) if matches else None
+        selected.extend(
+            r
+            for r in project_routes
+            if group is None or r.stack.rpartition(".")[0].lower() == group
+        )
+    return selected
+
+
+def _report_secret_deploy(
+    pr: PullRequest, route: SecretsRoute, paths: list[str]
+) -> None:
+    """Report one candidate deploy once, even when it consumes several files."""
+    print(f"\n=== SOPS consumer: {route.project} {route.stack} ({route.pipeline}) ===")
+    for path in paths:
+        print(f"    {path}")
+    print(f"    -> Pulumi src/ol_infrastructure/{route.project} (stack {route.stack})")
+    print(f"    Deploy: {route.job_url(route.job)}")
+    for preview in route.previews:
+        print(f"    Preview: {route.job_url(preview)}")
+    if route.previews:
+        print(
+            "    Deploy is gated on preview; check its approval inputs. Preview does not write secrets."
+        )
+    inputs = list(dict.fromkeys((route.input_name, route.resource)))
+    live = _live_stage(pr, route.pipeline, route.job, inputs, route.instance_query)
     if live is None:
         print(
             "    ?  Could not verify a successful deploy build/input (API unavailable or no usable build in the last 10)."
@@ -449,19 +626,73 @@ def _report_vault_secrets(
         return
     print(
         _format_stage(
-            "Vault deploy",
+            "Deploy",
             live.reached,
             f"build #{live.build_name} used ol-infra {live.deployed_commit[:8]}",
         )
     )
-    print(f"    Build: {pipeline_url}/jobs/{deploy_job}/builds/{live.build_name}")
+    print(f"    Build: {route.job_url(route.job, live.build_name)}")
+
+
+def _report_sops_secrets(pr: PullRequest, paths: list[str]) -> None:
+    """Explain every SOPS path, including credentials and missing deployment routes."""
+    print(
+        "\nSOPS routing uses PROJECT_SECRETS candidate consumers (directory-level watches)."
+    )
+    print(
+        "Successful deploy ancestry is pipeline evidence, not proof a key was written to Vault."
+    )
+    consumers = {path: _secret_projects(path) for path in paths}
+    for path, projects in consumers.items():
+        print(f"    {path}")
+        if projects:
+            print(f"      Candidate projects: {', '.join(sorted(projects))}")
+        else:
+            relative = path.removeprefix(f"{SECRETS_ROOT}/")
+            reasons = {
+                reason
+                for pattern, reason in DEPLOY_CREDENTIAL_SECRETS.items()
+                if _secret_entry_matches(relative, pattern)
+            }
+            if reasons:
+                print(
+                    f"      Provider credentials only: {'; '.join(sorted(reasons))}; no content deploy expected."
+                )
+            else:
+                print(
+                    "      ?  No registered Pulumi consumer; deployment route unknown."
+                )
+    if not any(consumers.values()):
+        return
+    if not _fly_ready():
+        print(
+            "    ?  fly not logged in to 'infrastructure' -- can't discover pipelines or verify builds"
+        )
+        print(
+            f"    Log in: fly -t {CONCOURSE_TEAM} login -c {CONCOURSE_URL} -n {CONCOURSE_TEAM}"
+        )
+        return
+    routes, failures = _discover_secret_routes()
+    for failure in failures:
+        print(f"    ?  Could not inspect {failure}; discovery is incomplete.")
+    grouped: dict[SecretsRoute, list[str]] = {}
+    for path, projects in consumers.items():
+        matches = _routes_for_secret(path, routes)
+        for project in sorted(projects - {r.project for r in matches}):
+            print(
+                f"    ?  {path}: no matching deploy discovered for {project} in this file's scope."
+            )
+        for route in set(matches):
+            grouped.setdefault(route, []).append(path)
+    for route in sorted(
+        grouped, key=lambda r: (r.project, r.pipeline, r.instance_query, r.stack, r.job)
+    ):
+        _report_secret_deploy(pr, route, grouped[route])
 
 
 def _report_ol_infrastructure_pr(pr: PullRequest) -> None:
     paths = _changed_files(pr.owner, pr.repo, pr.number)
-    secret_paths = {
-        path: match for path in paths if (match := _matching_secrets_route(path))
-    }
+    secret_paths = [path for path in paths if _is_secrets_file(path)]
     direct, shared_hit, other = _impacted_apps(
         [path for path in paths if path not in secret_paths]
     )
@@ -475,8 +706,8 @@ def _report_ol_infrastructure_pr(pr: PullRequest) -> None:
             f"{', '.join(PULUMI_WATCHED_PATHS)}) -- every app pipeline's "
             "ol-infra-{app} resource picks this up."
         )
-    for path, (route, env) in sorted(secret_paths.items()):
-        _report_vault_secrets(pr, path, route, env)
+    if secret_paths:
+        _report_sops_secrets(pr, secret_paths)
 
     if not impacted and not secret_paths:
         print("\nNo changed files map to a known deployment pipeline.")

--- a/src/bridge/secrets/concourse/operations.qa.yaml
+++ b/src/bridge/secrets/concourse/operations.qa.yaml
@@ -1,3 +1,4 @@
+---
 web:
   admin_password: ENC[AES256_GCM,data:3ZRoz1QNh+JXOr/KK3GJLXkqchSDpmZEbdCW8CWNA28n/pDA38M=,iv:k+L1g6dIzl2sN7323IBW3G7pCAhWq8JqBQKrWpP0Yz8=,tag:RE8Kr1MaHROZI8BH0JaknA==,type:str]
   encryption_key: ENC[AES256_GCM,data:pFeaxtn8Bw18RDufOAtM8mujKEXcg4EUh+ggxTNJUAg=,iv:ZXJ6pBKTvQzIpeBAf4mzYIAPXRM2YTnjA68F7ioTvPg=,tag:KZQGpAQi9/7+IiaSV4GOpA==,type:str]
@@ -61,16 +62,16 @@ pipelines:
     api_token: ENC[AES256_GCM,data:N9Xqo7wroXNQCyaB0mVKErRo/R//4Rd2YyMqrgFIXWE=,iv:NZiJxvtggO1ltqW7VjT5WuxQ1/N/aK5+5ylfXv8MH90=,tag:RoWId+1fftyapQ0Sv4MFwg==,type:str]
 sops:
   hc_vault:
-    - created_at: "2026-04-10T16:43:53Z"
-      enc: vault:v1:920tlGfctxJnize8zutcu8OYZTBTQHao+0iQCtXpUBUh24Q0JFHI3XRWCHxydx3EjxU6ylAbJLk7bVCp
-      engine_path: infrastructure
-      key_name: sops
-      vault_address: https://vault-qa.odl.mit.edu
+  - created_at: "2026-04-10T16:43:53Z"
+    enc: vault:v1:920tlGfctxJnize8zutcu8OYZTBTQHao+0iQCtXpUBUh24Q0JFHI3XRWCHxydx3EjxU6ylAbJLk7bVCp
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-qa.odl.mit.edu
   kms:
-    - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
-      aws_profile: ""
-      created_at: "2026-04-10T16:43:53Z"
-      enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHVClfAZFHrCGJU84GlexTnAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLjji+NUtNJWO2Sf4AgEQgDvqXX5m6YrpxId8xgPhcbg5O0n7NyK3/3TUFPWq8+wVj1ms1ihyNGoAwTUJQ6NxMoQg+njLlXcByanViw==
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    aws_profile: ""
+    created_at: "2026-04-10T16:43:53Z"
+    enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHVClfAZFHrCGJU84GlexTnAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLjji+NUtNJWO2Sf4AgEQgDvqXX5m6YrpxId8xgPhcbg5O0n7NyK3/3TUFPWq8+wVj1ms1ihyNGoAwTUJQ6NxMoQg+njLlXcByanViw==
   lastmodified: "2026-09-10T14:05:25Z"
   mac: ENC[AES256_GCM,data:JXoY9Bz5q8SBKySxIF4XqTn592nv+9WOL+1rfWSCkbKnKRZXNA0VMlWJX92HwfLhGj3A+MrcGpfrpDEnKZLP1DZkwwXekB5NZHzZIzduM7QdB+fbp++SnfAjcCbYxVToocd6rhbnKUNOthjN4jZnIfNe0dS0twvod7C8LFpCWvk=,iv:T1Fo/hFon5G9l9Wc9HmhuT7RzvS9PlFj5Sn23hTs7RE=,tag:0lsR5Vh6Lu+GD4tXi9QDyA==,type:str]
   unencrypted_suffix: _unencrypted

--- a/tests/test_where_is_my_pr.py
+++ b/tests/test_where_is_my_pr.py
@@ -369,7 +369,7 @@ def test_discovery_and_instance_urls(
         ]
     )
     monkeypatch.setattr(script, "_fly_curl", api)
-    routes, failures = script._discover_secret_routes()
+    routes, failures = script._discover_pulumi_routes()
     assert not failures
     assert len(routes) == 1
     route = routes[0]
@@ -390,7 +390,7 @@ def test_discovery_failures_are_explicit(
 ) -> None:
     """An unavailable API must not be confused with absence of consumers."""
     monkeypatch.setattr(script, "_fly_curl", Mock(return_value=response))
-    routes, failures = script._discover_secret_routes()
+    routes, failures = script._discover_pulumi_routes()
     assert not routes
     assert failures == ["pipeline list unavailable"]
     routes, failure = script._read_pipeline_routes({"name": "unavailable"})
@@ -411,7 +411,7 @@ def test_report_uses_live_deploy_evidence(  # noqa: PLR0913
     """Reuse successful-build ancestry and report a shared deploy just once."""
     routes = script._routes_from_config("app", config)
     monkeypatch.setattr(
-        script, "_discover_secret_routes", Mock(return_value=(routes, []))
+        script, "_discover_pulumi_routes", Mock(return_value=(routes, []))
     )
     live = Mock(return_value=script.LiveStage(reached, "42", None, "b" * 40))
     monkeypatch.setattr(script, "_live_stage", live)
@@ -435,6 +435,55 @@ def test_report_uses_live_deploy_evidence(  # noqa: PLR0913
         if reached
         else "not yet reached"
     ) in output
+
+
+def test_credential_diagnostics_do_not_echo_registry_values(
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Use registry membership for classification, not its values for output."""
+    monkeypatch.setattr(
+        script,
+        "DEPLOY_CREDENTIAL_SECRETS",
+        {
+            "pulumi/vault.*.*.yaml": "do-not-echo-description",
+        },
+    )
+    script._report_sops_secrets(
+        pr, ["src/bridge/secrets/pulumi/vault.operations.qa.yaml"]
+    )
+    output = capsys.readouterr().out
+    assert "Provider credentials only" in output
+    assert "do-not-echo-description" not in output
+
+
+def test_failed_discovery_does_not_echo_instance_values(
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Keep instance values in the API request, not in failure diagnostics."""
+    api = Mock(
+        side_effect=[
+            [
+                {
+                    "name": "unavailable",
+                    "instance_vars": {"branch": "do-not-log-selector"},
+                }
+            ],
+            None,
+        ]
+    )
+    monkeypatch.setattr(script, "_fly_curl", api)
+    script._report_sops_secrets(pr, ["src/bridge/secrets/mitxonline/secrets.qa.yaml"])
+    output = capsys.readouterr().out
+    assert "do-not-log-selector" in api.call_args.args[0]
+    assert "Could not inspect unavailable" in output
+    assert "discovery is incomplete" in output
+    assert "do-not-log-selector" not in output
 
 
 def test_credentials_unknown_and_logged_out(
@@ -472,7 +521,7 @@ def test_missing_build_and_discovery_are_unknown(
     routes = script._routes_from_config("app", config)
     monkeypatch.setattr(
         script,
-        "_discover_secret_routes",
+        "_discover_pulumi_routes",
         Mock(return_value=(routes, ["unavailable-pipeline"])),
     )
     monkeypatch.setattr(script, "_live_stage", Mock(return_value=None))

--- a/tests/test_where_is_my_pr.py
+++ b/tests/test_where_is_my_pr.py
@@ -1,10 +1,11 @@
-"""Regression tests for the read-only PR deployment tracing script."""
+"""Regression tests for registry-driven, read-only SOPS deployment tracing."""
 
 import importlib.util
 import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -12,7 +13,7 @@ import pytest
 
 @pytest.fixture
 def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
-    """Load the extensionless script without invoking its CLI."""
+    """Load the extensionless script without invoking its CLI or external tools."""
     path = Path(__file__).resolve().parents[1] / "scripts" / "where-is-my-pr"
     loader = SourceFileLoader("where_is_my_pr", str(path))
     spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -20,7 +21,6 @@ def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, loader.name, module)
     loader.exec_module(module)
-    # No test may accidentally reach GitHub or Concourse.
     monkeypatch.setattr(
         module, "_gh_json", Mock(side_effect=AssertionError("GitHub call"))
     )
@@ -33,12 +33,12 @@ def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
 @pytest.fixture
 def pr(script: ModuleType) -> object:
-    """Create a merged infrastructure PR like #5809 without secret values."""
+    """Create a merged infrastructure PR without secret values."""
     return script.PullRequest(
         owner="mitodl",
         repo="ol-infrastructure",
         number=5809,
-        title="Replicate the Fastly purge key into QA",
+        title="Update secrets",
         state="MERGED",
         merged=True,
         commit="a" * 40,
@@ -46,142 +46,463 @@ def pr(script: ModuleType) -> object:
     )
 
 
-@pytest.mark.parametrize("env", ["ci", "qa", "production"])
-@pytest.mark.parametrize("family", ["concourse/operations", "vault/secrets"])
-def test_routes_match_generated_pipeline(
-    script: ModuleType,
-    env: str,
-    family: str,
+@pytest.mark.parametrize(
+    ("relative", "projects"),
+    [
+        (
+            "concourse/operations.qa.yaml",
+            {"applications/concourse/", "applications/release_bot/"},
+        ),
+        (
+            "vault/secrets.qa.yaml",
+            {"substructure/vault/secrets/", "applications/learn_ai/"},
+        ),
+        ("mitxonline/secrets.production.yaml", {"applications/mitxonline/"}),
+        ("witan/secrets.qa.yaml", {"applications/witan/"}),
+        ("pulumi/consul.qa.yaml", {"infrastructure/consul/"}),
+        ("pulumi/mongodb_atlas.mitxonline.qa.yaml", {"applications/edxapp/"}),
+        ("pulumi/mongodb_atlas.yaml", set()),
+        ("pulumi/vault.operations.qa.yaml", set()),
+        ("unmapped/secrets.qa.yaml", set()),
+    ],
+)
+def test_registry_consumers(
+    script: ModuleType, relative: str, projects: set[str]
 ) -> None:
-    """Guard explicit mappings against actual pipeline jobs, inputs and watches."""
-    from ol_concourse.pipelines.infrastructure.concourse.pipeline import (  # noqa: PLC0415
-        concourse_pipeline,
+    """Reverse registry entries, respecting credential overrides."""
+    assert script._secret_projects(f"src/bridge/secrets/{relative}") == projects
+
+
+@pytest.mark.parametrize(
+    ("relative", "entry", "expected"),
+    [
+        ("fastly.yaml", "fastly.yaml", True),
+        ("nested/fastly.yaml", "fastly.yaml", False),
+        ("concourse/operations.qa.yaml", "concourse/", True),
+        ("concourse-other/operations.qa.yaml", "concourse/", False),
+        (
+            "pulumi/mongodb_atlas.mitxonline.qa.yaml",
+            "pulumi/mongodb_atlas.*.*.yaml",
+            True,
+        ),
+        (
+            "pulumi/mongodb_atlas.mitxonline/nested.qa.yaml",
+            "pulumi/mongodb_atlas.*.*.yaml",
+            False,
+        ),
+    ],
+)
+def test_registry_path_boundaries(
+    *,
+    script: ModuleType,
+    relative: str,
+    entry: str,
+    expected: bool,
+) -> None:
+    """Do not let filename globs cross directory boundaries."""
+    assert script._secret_entry_matches(relative, entry) is expected
+
+
+def test_changed_files_pagination(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slurp paginated GitHub arrays into valid JSON for large secrets PRs."""
+    api = Mock(
+        return_value=[
+            [{"filename": "src/bridge/secrets/witan/secrets.qa.yaml"}],
+            [{"filename": "src/bridge/secrets/mitxonline/secrets.production.yaml"}],
+        ]
     )
-    from ol_concourse.pipelines.infrastructure.vault.pipeline import (  # noqa: PLC0415
-        vault_pipeline,
+    monkeypatch.setattr(script, "_gh_json", api)
+    assert script._changed_files("mitodl", "ol-infrastructure", 5809) == [
+        "src/bridge/secrets/witan/secrets.qa.yaml",
+        "src/bridge/secrets/mitxonline/secrets.production.yaml",
+    ]
+    api.assert_called_once_with(
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/mitodl/ol-infrastructure/pulls/5809/files",
     )
 
-    path = f"src/bridge/secrets/{family}.{env}.yaml"
-    route, matched_env = script._matching_secrets_route(path)
-    assert matched_env == env
-    pipeline = (
-        concourse_pipeline() if family.startswith("concourse/") else vault_pipeline
-    )
-    jobs = {job.name: job.model_dump(exclude_none=True) for job in pipeline.jobs}
-    deploy = jobs[f"deploy-{route.job_suffix}-{env}"]
-    resource_name = (
-        "ol-infrastructure-pulumi"
-        if family.startswith("concourse/")
-        else "ol-infrastructure-pulumi-substructure"
-    )
-    assert route.resource == resource_name
-    assert resource_name in str(deploy["plan"])
-    resource = next(r for r in pipeline.resources if r.name == resource_name)
-    assert any(
-        path.startswith(prefix)
-        for prefix in resource.model_dump(mode="json")["source"]["paths"]
-    )
-    if env != "ci":
-        assert f"preview-{route.job_suffix}-{env}" in jobs
+
+def test_shared_secret_has_multiple_consumers(script: ModuleType) -> None:
+    """Shared secrets must not be assigned to just one pipeline."""
+    projects = script._secret_projects("src/bridge/secrets/fastly.yaml")
+    assert {
+        "applications/mit_learn/",
+        "applications/xpro/",
+        "infrastructure/vector_log_proxy/",
+    } <= projects
+
+
+def test_new_registry_entry_needs_no_script_route(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new audited project immediately participates in routing."""
+    monkeypatch.setitem(script.PROJECT_SECRETS, "applications/new_app/", ["new_app/"])
+    assert script._secret_projects("src/bridge/secrets/new_app/settings.qa.yaml") == {
+        "applications/new_app/"
+    }
 
 
 @pytest.mark.parametrize(
     "path",
     [
-        "src/bridge/secrets/pulumi/vault.qa.yaml",
-        "src/bridge/secrets/concourse/operations.dev.yaml",
+        "src/bridge/secrets/sops.py",
+        "src/bridge/secrets/__init__.py",
+        "src/bridge/secrets/bin/rotate",
+        "README.md",
         "src/bridge/secrets/concourse/operations.qa.yaml.bak",
-        "src/bridge/secrets/unmapped/secrets.qa.yaml",
-        "src/bridge/secrets/vault/README.md",
     ],
 )
-def test_unmapped_files(script: ModuleType, path: str) -> None:
-    """Do not treat provider credentials or unknown files as Vault deployments."""
-    assert script._matching_secrets_route(path) is None
+def test_non_secret_paths(script: ModuleType, path: str) -> None:
+    """Keep helpers and unrelated files on their existing reporting paths."""
+    assert not script._is_secrets_file(path)
 
 
-@pytest.mark.parametrize("family", ["concourse/operations", "vault/secrets"])
+@pytest.fixture
+def config() -> dict[str, Any]:
+    """Use arbitrary pipeline/job/resource names to rule out naming shortcuts."""
+    return {
+        "resources": [
+            {
+                "name": "infra",
+                "type": "git",
+                "source": {"uri": "git@github.com:mitodl/ol-infrastructure.git"},
+            },
+            {
+                "name": "updater",
+                "type": "pulumi-provisioner",
+                "source": {
+                    "source_dir": (
+                        "checkout/src/ol_infrastructure/applications/mitxonline/"
+                    ),
+                    "action": "update",
+                },
+            },
+        ],
+        "jobs": [
+            {
+                "name": "inspect-qa",
+                "plan": [
+                    {"get": "checkout", "resource": "infra"},
+                    {
+                        "put": "update",
+                        "resource": "updater",
+                        "params": {"stack_name": "QA", "preview": True},
+                    },
+                ],
+            },
+            {
+                "name": "apply-qa",
+                "plan": [
+                    {
+                        "in_parallel": {
+                            "steps": [
+                                {
+                                    "get": "checkout",
+                                    "resource": "infra",
+                                    "passed": ["inspect-qa"],
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "do": [
+                            {
+                                "put": "update",
+                                "resource": "updater",
+                                "params": {"stack_name": "QA"},
+                            }
+                        ]
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def test_routes_come_from_config(script: ModuleType, config: dict[str, Any]) -> None:
+    """Extract source checkout aliases, resource aliases, stack and preview gates."""
+    routes = script._routes_from_config("arbitrary-pipeline", config)
+    assert len(routes) == 1
+    route = routes[0]
+    assert route.project == "applications/mitxonline/"
+    assert route.stack == "QA"
+    assert route.job == "apply-qa"
+    assert route.resource == "infra"
+    assert route.input_name == "checkout"
+    assert route.previews == ("inspect-qa",)
+
+
+@pytest.mark.parametrize("wrapper", ["try", "on_failure", "on_error", "ensure"])
+def test_optional_updates_are_not_deploy_evidence(
+    script: ModuleType,
+    config: dict[str, Any],
+    wrapper: str,
+) -> None:
+    """A successful job does not prove an optional/error-path update succeeded."""
+    config["jobs"][1]["plan"][1] = {wrapper: config["jobs"][1]["plan"][1]}
+    assert script._routes_from_config("pipeline", config) == []
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://github.com/another/repo",
+        "https://github.com/mitodl/ol-infrastructure-fork",
+    ],
+)
+def test_only_ol_infra_inputs_count(
+    script: ModuleType, config: dict[str, Any], uri: str
+) -> None:
+    """Never compare an app-repository commit as if it came from ol-infrastructure."""
+    config["resources"][0]["source"]["uri"] = uri
+    assert script._routes_from_config("pipeline", config) == []
+
+
+@pytest.mark.parametrize("action", ["destroy", "refresh", "preview"])
+def test_non_updates_do_not_count(
+    script: ModuleType, config: dict[str, Any], action: str
+) -> None:
+    """Only update puts, never refresh/destroy/preview, establish deploy evidence."""
+    config["resources"][1]["source"]["action"] = action
+    assert script._routes_from_config("pipeline", config) == []
+
+
+@pytest.mark.parametrize("kind", ["concourse", "vault", "simple"])
+def test_generated_pipeline_contracts(script: ModuleType, kind: str) -> None:
+    """Exercise current dedicated and simple Pulumi generators, not just fake plans."""
+    from ol_concourse.pipelines.infrastructure.concourse.pipeline import (  # noqa: PLC0415
+        concourse_pipeline,
+    )
+    from ol_concourse.pipelines.infrastructure.simple_pulumi.pipeline import (  # noqa: PLC0415
+        build_simple_pulumi_pipeline,
+    )
+    from ol_concourse.pipelines.infrastructure.vault.pipeline import (  # noqa: PLC0415
+        vault_pipeline,
+    )
+
+    pipelines = {
+        "concourse": concourse_pipeline(),
+        "vault": vault_pipeline,
+        "simple": build_simple_pulumi_pipeline("airbyte"),
+    }
+    routes = script._routes_from_config(
+        "any-name", pipelines[kind].model_dump(mode="json", exclude_none=True)
+    )
+    project = {
+        "concourse": "applications/concourse/",
+        "vault": "substructure/vault/secrets/",
+        "simple": "applications/airbyte/",
+    }[kind]
+    selected = [r for r in routes if r.project == project]
+    assert {r.stack.rsplit(".", 1)[-1] for r in selected} == {"CI", "QA", "Production"}
+    assert all(not r.job.startswith("preview-") for r in routes)
+    if kind != "simple":
+        assert all(r.previews for r in selected if not r.stack.endswith("CI"))
+
+
+def test_environment_and_group_selection(script: ModuleType) -> None:
+    """Separate mitx from mitx-staging and QA from CI/production."""
+    routes = [
+        script.SecretsRoute(
+            pipeline="edx",
+            project="applications/edxapp/",
+            stack=f"{group}.{env}",
+            job=f"apply-{group}-{env}",
+            resource="infra",
+            input_name="infra",
+        )
+        for group in ("mitx", "mitx-staging", "mitxonline")
+        for env in ("CI", "QA", "Production")
+    ]
+    matches = script._routes_for_secret(
+        "src/bridge/secrets/edxapp/mitx-staging.qa.yaml", routes
+    )
+    assert [r.stack for r in matches] == ["mitx-staging.QA"]
+    # Shared file without environment/group qualifiers applies to every stack.
+    assert script._routes_for_secret("src/bridge/secrets/fastly.yaml", routes) == routes
+    without_staging_qa = [r for r in routes if r.stack != "mitx-staging.QA"]
+    assert (
+        script._routes_for_secret(
+            "src/bridge/secrets/edxapp/mitx-staging.qa.yaml", without_staging_qa
+        )
+        == []
+    )
+
+
+def test_hyphenated_environment(script: ModuleType) -> None:
+    """edx_notes uses hyphens rather than dots before the environment."""
+    routes = [
+        script.SecretsRoute(
+            pipeline="notes",
+            project="applications/edx_notes/",
+            stack=f"mitx.{env}",
+            job=f"apply-{env}",
+            resource="infra",
+            input_name="infra",
+        )
+        for env in ("CI", "QA", "Production")
+    ]
+    assert [
+        r.stack
+        for r in script._routes_for_secret(
+            "src/bridge/secrets/edx_notes/mitx-qa.yaml", routes
+        )
+    ] == ["mitx.QA"]
+
+
+def test_discovery_and_instance_urls(
+    script: ModuleType,
+    config: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discover arbitrary names and carry instance selectors through API/UI URLs."""
+    api = Mock(
+        side_effect=[
+            [{"name": "new-pipeline", "instance_vars": {"branch": "feature/x"}}],
+            {"config": config},
+        ]
+    )
+    monkeypatch.setattr(script, "_fly_curl", api)
+    routes, failures = script._discover_secret_routes()
+    assert not failures
+    assert len(routes) == 1
+    route = routes[0]
+    assert route.instance_query == "?vars.branch=%22feature%2Fx%22"
+    assert api.call_args.args[0].endswith(
+        "/new-pipeline/config?vars.branch=%22feature%2Fx%22"
+    )
+    assert route.job_url(route.job, "126").endswith(
+        "/jobs/apply-qa/builds/126?vars.branch=%22feature%2Fx%22"
+    )
+
+
+@pytest.mark.parametrize("response", [None, {"error": "unauthorized"}])
+def test_discovery_failures_are_explicit(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    response: Any,
+) -> None:
+    """An unavailable API must not be confused with absence of consumers."""
+    monkeypatch.setattr(script, "_fly_curl", Mock(return_value=response))
+    routes, failures = script._discover_secret_routes()
+    assert not routes
+    assert failures == ["pipeline list unavailable"]
+    routes, failure = script._read_pipeline_routes({"name": "unavailable"})
+    assert not routes
+    assert failure == "unavailable"
+
+
 @pytest.mark.parametrize("reached", [True, False, None])
-def test_report_checks_only_environment_deploy(  # noqa: PLR0913
+def test_report_uses_live_deploy_evidence(  # noqa: PLR0913
     *,
     script: ModuleType,
     pr: object,
+    config: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    family: str,
     reached: bool | None,
 ) -> None:
-    """Successful deploy inputs, not previews or branch tips, supply the status."""
-    path = f"src/bridge/secrets/{family}.qa.yaml"
-    monkeypatch.setattr(script, "_changed_files", Mock(return_value=[path]))
+    """Reuse successful-build ancestry and report a shared deploy just once."""
+    routes = script._routes_from_config("app", config)
+    monkeypatch.setattr(
+        script, "_discover_secret_routes", Mock(return_value=(routes, []))
+    )
     live = Mock(return_value=script.LiveStage(reached, "42", None, "b" * 40))
     monkeypatch.setattr(script, "_live_stage", live)
-    script._report_ol_infrastructure_pr(pr)
-    output = capsys.readouterr().out
-    route, _ = script._matching_secrets_route(path)
-    resource = (
-        "ol-infrastructure-pulumi"
-        if family.startswith("concourse/")
-        else "ol-infrastructure-pulumi-substructure"
-    )
-    live.assert_called_once_with(
+    script._report_sops_secrets(
         pr,
-        route.pipeline,
-        f"deploy-{route.job_suffix}-qa",
-        [resource],
+        [
+            "src/bridge/secrets/mitxonline/secrets.qa.yaml",
+            "src/bridge/secrets/mitxonline/extra.qa.json",
+        ],
     )
-    assert f"Vault {route.vault_mount} (QA)" in output
-    assert "manual deploy after preview" in output
-    assert "preview does not write secrets" in output
-    assert f"/jobs/deploy-{route.job_suffix}-qa/builds/42" in output
-    assert "no known" not in output
-    if reached is None:
-        assert "?  Vault deploy" in output
-    else:
-        assert ("not yet reached" if not reached else "✓  Vault deploy") in output
-
-
-@pytest.mark.parametrize("fly_ready", [True, False])
-def test_missing_evidence_stays_unknown(
-    *,
-    script: ModuleType,
-    pr: object,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    fly_ready: bool,
-) -> None:
-    """Missing login/build evidence must never turn a merge into deploy success."""
-    path = "src/bridge/secrets/concourse/operations.qa.yaml"
-    monkeypatch.setattr(script, "_changed_files", Mock(return_value=[path]))
-    monkeypatch.setattr(script, "_fly_ready", Mock(return_value=fly_ready))
-    live = Mock(return_value=None)
-    monkeypatch.setattr(script, "_live_stage", live)
-    script._report_ol_infrastructure_pr(pr)
+    live.assert_called_once_with(pr, "app", "apply-qa", ["checkout", "infra"], "")
     output = capsys.readouterr().out
-    assert "✓" not in output
-    assert "?" in output
-    assert "packer-pulumi-concourse/jobs/deploy-" in output
-    if fly_ready:
-        assert "Could not verify" in output
-    else:
-        live.assert_not_called()
-        assert "fly -t infrastructure login" in output
+    assert "extra.qa.json" in output
+    assert "SOPS consumer: applications/mitxonline/ QA" in output
+    assert "/jobs/apply-qa/builds/42" in output
+    assert "not proof a key was written to Vault" in output
+    assert (
+        "?  Deploy"
+        if reached is None
+        else "✓  Deploy"
+        if reached
+        else "not yet reached"
+    ) in output
 
 
-def test_mixed_pr_preserves_app_and_unknown_paths(
+def test_credentials_unknown_and_logged_out(
     script: ModuleType,
     pr: object,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Secrets reporting must not suppress existing app or unmatched-file output."""
+    """Explain credential-only and unregistered files even without Concourse access."""
+    monkeypatch.setattr(script, "_fly_ready", Mock(return_value=False))
+    script._report_sops_secrets(
+        pr,
+        [
+            "src/bridge/secrets/pulumi/vault.operations.qa.yaml",
+            "src/bridge/secrets/unknown/secrets.qa.yaml",
+            "src/bridge/secrets/witan/secrets.qa.yaml",
+        ],
+    )
+    output = capsys.readouterr().out
+    assert "Provider credentials only" in output
+    assert "No registered Pulumi consumer" in output
+    assert "applications/witan/" in output
+    assert "fly -t infrastructure login" in output
+    assert "✓" not in output
+
+
+def test_missing_build_and_discovery_are_unknown(
+    script: ModuleType,
+    pr: object,
+    config: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Keep unknown states visible during partial discovery or build API failures."""
+    routes = script._routes_from_config("app", config)
+    monkeypatch.setattr(
+        script,
+        "_discover_secret_routes",
+        Mock(return_value=(routes, ["unavailable-pipeline"])),
+    )
+    monkeypatch.setattr(script, "_live_stage", Mock(return_value=None))
+    script._report_sops_secrets(
+        pr,
+        [
+            "src/bridge/secrets/mitxonline/secrets.qa.yaml",
+            "src/bridge/secrets/witan/secrets.qa.yaml",
+        ],
+    )
+    output = capsys.readouterr().out
+    assert "discovery is incomplete" in output
+    assert "no matching deploy discovered for applications/witan/" in output
+    assert "Could not verify a successful deploy" in output
+    assert "✓" not in output
+
+
+def test_mixed_pr_keeps_existing_reports(
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Retain app-code and unknown-file reporting alongside secret paths."""
     monkeypatch.setattr(
         script,
         "_changed_files",
         Mock(
             return_value=[
-                "src/bridge/secrets/concourse/operations.ci.yaml",
-                "src/bridge/secrets/concourse/operations.production.yaml",
+                "src/bridge/secrets/concourse/operations.qa.yaml",
                 "src/ol_infrastructure/applications/mitxonline/__main__.py",
                 "README.md",
             ]
@@ -191,11 +512,9 @@ def test_mixed_pr_preserves_app_and_unknown_paths(
     app_report = Mock()
     monkeypatch.setattr(script, "_report_ol_infra_app", app_report)
     script._report_ol_infrastructure_pr(pr)
-    output = capsys.readouterr().out
     app_report.assert_called_once_with(pr, "mitxonline")
-    assert "Vault secrets: CI" in output
-    assert "Vault secrets: Production" in output
-    assert "CI deploys automatically" in output
+    output = capsys.readouterr().out
+    assert "applications/concourse/" in output
     assert (
         "Other changed files (no known deployment pipeline mapping):\n    README.md"
         in output
@@ -205,7 +524,7 @@ def test_mixed_pr_preserves_app_and_unknown_paths(
 @pytest.mark.parametrize(
     ("status", "expected"), [("ahead", True), ("behind", False), (None, None)]
 )
-def test_live_stage_compares_deploy_input(
+def test_live_stage_compares_successful_input(
     *,
     script: ModuleType,
     pr: object,
@@ -213,27 +532,28 @@ def test_live_stage_compares_deploy_input(
     status: str | None,
     expected: bool | None,
 ) -> None:
-    """The underlying live check compares the PR SHA with the successful input SHA."""
+    """Compare the PR SHA with the successful build, not the latest failure."""
     curl = Mock(
         side_effect=[
             [
                 {"id": 99, "name": "43", "status": "failed"},
                 {"id": 98, "name": "42", "status": "succeeded"},
             ],
-            {
-                "inputs": [
-                    {"name": "ol-infrastructure-pulumi", "version": {"ref": "b" * 40}}
-                ]
-            },
+            {"inputs": [{"name": "infra", "version": {"ref": "b" * 40}}]},
         ]
     )
     monkeypatch.setattr(script, "_fly_curl", curl)
     compare = Mock(return_value=status)
     monkeypatch.setattr(script, "_compare_status", compare)
     live = script._live_stage(
-        pr, "packer-pulumi-concourse", "deploy-job", ["ol-infrastructure-pulumi"]
+        pr, "pipeline", "apply", ["infra"], "?vars.group=%22test%22"
     )
     assert live.reached is expected
     assert live.build_name == "42"
     compare.assert_called_once_with("mitodl", "ol-infrastructure", "a" * 40, "b" * 40)
+    assert (
+        curl.call_args_list[0]
+        .args[0]
+        .endswith("/builds?vars.group=%22test%22&limit=10")
+    )
     assert curl.call_args.args == ("/api/v1/builds/98/resources",)

--- a/tests/test_where_is_my_pr.py
+++ b/tests/test_where_is_my_pr.py
@@ -1,0 +1,239 @@
+"""Regression tests for the read-only PR deployment tracing script."""
+
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load the extensionless script without invoking its CLI."""
+    path = Path(__file__).resolve().parents[1] / "scripts" / "where-is-my-pr"
+    loader = SourceFileLoader("where_is_my_pr", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, loader.name, module)
+    loader.exec_module(module)
+    # No test may accidentally reach GitHub or Concourse.
+    monkeypatch.setattr(
+        module, "_gh_json", Mock(side_effect=AssertionError("GitHub call"))
+    )
+    monkeypatch.setattr(
+        module, "_fly_curl", Mock(side_effect=AssertionError("fly call"))
+    )
+    monkeypatch.setattr(module, "_fly_ready", Mock(return_value=True))
+    return module
+
+
+@pytest.fixture
+def pr(script: ModuleType) -> object:
+    """Create a merged infrastructure PR like #5809 without secret values."""
+    return script.PullRequest(
+        owner="mitodl",
+        repo="ol-infrastructure",
+        number=5809,
+        title="Replicate the Fastly purge key into QA",
+        state="MERGED",
+        merged=True,
+        commit="a" * 40,
+        merged_at="2026-09-10T14:09:13Z",
+    )
+
+
+@pytest.mark.parametrize("env", ["ci", "qa", "production"])
+@pytest.mark.parametrize("family", ["concourse/operations", "vault/secrets"])
+def test_routes_match_generated_pipeline(
+    script: ModuleType,
+    env: str,
+    family: str,
+) -> None:
+    """Guard explicit mappings against actual pipeline jobs, inputs and watches."""
+    from ol_concourse.pipelines.infrastructure.concourse.pipeline import (  # noqa: PLC0415
+        concourse_pipeline,
+    )
+    from ol_concourse.pipelines.infrastructure.vault.pipeline import (  # noqa: PLC0415
+        vault_pipeline,
+    )
+
+    path = f"src/bridge/secrets/{family}.{env}.yaml"
+    route, matched_env = script._matching_secrets_route(path)
+    assert matched_env == env
+    pipeline = (
+        concourse_pipeline() if family.startswith("concourse/") else vault_pipeline
+    )
+    jobs = {job.name: job.model_dump(exclude_none=True) for job in pipeline.jobs}
+    deploy = jobs[f"deploy-{route.job_suffix}-{env}"]
+    resource_name = (
+        "ol-infrastructure-pulumi"
+        if family.startswith("concourse/")
+        else "ol-infrastructure-pulumi-substructure"
+    )
+    assert route.resource == resource_name
+    assert resource_name in str(deploy["plan"])
+    resource = next(r for r in pipeline.resources if r.name == resource_name)
+    assert any(
+        path.startswith(prefix)
+        for prefix in resource.model_dump(mode="json")["source"]["paths"]
+    )
+    if env != "ci":
+        assert f"preview-{route.job_suffix}-{env}" in jobs
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/bridge/secrets/pulumi/vault.qa.yaml",
+        "src/bridge/secrets/concourse/operations.dev.yaml",
+        "src/bridge/secrets/concourse/operations.qa.yaml.bak",
+        "src/bridge/secrets/unmapped/secrets.qa.yaml",
+        "src/bridge/secrets/vault/README.md",
+    ],
+)
+def test_unmapped_files(script: ModuleType, path: str) -> None:
+    """Do not treat provider credentials or unknown files as Vault deployments."""
+    assert script._matching_secrets_route(path) is None
+
+
+@pytest.mark.parametrize("family", ["concourse/operations", "vault/secrets"])
+@pytest.mark.parametrize("reached", [True, False, None])
+def test_report_checks_only_environment_deploy(  # noqa: PLR0913
+    *,
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    family: str,
+    reached: bool | None,
+) -> None:
+    """Successful deploy inputs, not previews or branch tips, supply the status."""
+    path = f"src/bridge/secrets/{family}.qa.yaml"
+    monkeypatch.setattr(script, "_changed_files", Mock(return_value=[path]))
+    live = Mock(return_value=script.LiveStage(reached, "42", None, "b" * 40))
+    monkeypatch.setattr(script, "_live_stage", live)
+    script._report_ol_infrastructure_pr(pr)
+    output = capsys.readouterr().out
+    route, _ = script._matching_secrets_route(path)
+    resource = (
+        "ol-infrastructure-pulumi"
+        if family.startswith("concourse/")
+        else "ol-infrastructure-pulumi-substructure"
+    )
+    live.assert_called_once_with(
+        pr,
+        route.pipeline,
+        f"deploy-{route.job_suffix}-qa",
+        [resource],
+    )
+    assert f"Vault {route.vault_mount} (QA)" in output
+    assert "manual deploy after preview" in output
+    assert "preview does not write secrets" in output
+    assert f"/jobs/deploy-{route.job_suffix}-qa/builds/42" in output
+    assert "no known" not in output
+    if reached is None:
+        assert "?  Vault deploy" in output
+    else:
+        assert ("not yet reached" if not reached else "✓  Vault deploy") in output
+
+
+@pytest.mark.parametrize("fly_ready", [True, False])
+def test_missing_evidence_stays_unknown(
+    *,
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    fly_ready: bool,
+) -> None:
+    """Missing login/build evidence must never turn a merge into deploy success."""
+    path = "src/bridge/secrets/concourse/operations.qa.yaml"
+    monkeypatch.setattr(script, "_changed_files", Mock(return_value=[path]))
+    monkeypatch.setattr(script, "_fly_ready", Mock(return_value=fly_ready))
+    live = Mock(return_value=None)
+    monkeypatch.setattr(script, "_live_stage", live)
+    script._report_ol_infrastructure_pr(pr)
+    output = capsys.readouterr().out
+    assert "✓" not in output
+    assert "?" in output
+    assert "packer-pulumi-concourse/jobs/deploy-" in output
+    if fly_ready:
+        assert "Could not verify" in output
+    else:
+        live.assert_not_called()
+        assert "fly -t infrastructure login" in output
+
+
+def test_mixed_pr_preserves_app_and_unknown_paths(
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Secrets reporting must not suppress existing app or unmatched-file output."""
+    monkeypatch.setattr(
+        script,
+        "_changed_files",
+        Mock(
+            return_value=[
+                "src/bridge/secrets/concourse/operations.ci.yaml",
+                "src/bridge/secrets/concourse/operations.production.yaml",
+                "src/ol_infrastructure/applications/mitxonline/__main__.py",
+                "README.md",
+            ]
+        ),
+    )
+    monkeypatch.setattr(script, "_fly_ready", Mock(return_value=False))
+    app_report = Mock()
+    monkeypatch.setattr(script, "_report_ol_infra_app", app_report)
+    script._report_ol_infrastructure_pr(pr)
+    output = capsys.readouterr().out
+    app_report.assert_called_once_with(pr, "mitxonline")
+    assert "Vault secrets: CI" in output
+    assert "Vault secrets: Production" in output
+    assert "CI deploys automatically" in output
+    assert (
+        "Other changed files (no known deployment pipeline mapping):\n    README.md"
+        in output
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"), [("ahead", True), ("behind", False), (None, None)]
+)
+def test_live_stage_compares_deploy_input(
+    *,
+    script: ModuleType,
+    pr: object,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str | None,
+    expected: bool | None,
+) -> None:
+    """The underlying live check compares the PR SHA with the successful input SHA."""
+    curl = Mock(
+        side_effect=[
+            [
+                {"id": 99, "name": "43", "status": "failed"},
+                {"id": 98, "name": "42", "status": "succeeded"},
+            ],
+            {
+                "inputs": [
+                    {"name": "ol-infrastructure-pulumi", "version": {"ref": "b" * 40}}
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(script, "_fly_curl", curl)
+    compare = Mock(return_value=status)
+    monkeypatch.setattr(script, "_compare_status", compare)
+    live = script._live_stage(
+        pr, "packer-pulumi-concourse", "deploy-job", ["ol-infrastructure-pulumi"]
+    )
+    assert live.reached is expected
+    assert live.build_name == "42"
+    compare.assert_called_once_with("mitodl", "ol-infrastructure", "a" * 40, "b" * 40)
+    assert curl.call_args.args == ("/api/v1/builds/98/resources",)


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Motivating example: https://github.com/mitodl/ol-infrastructure/pull/5809

### Description (What does it do?)
Trace SOPS secret changes through their candidate Pulumi deployment pipelines, using the existing secrets registry rather than special cases for Concourse and global Vault secrets.

<details>
<summary><b>Implementation details</b></summary>

- Reverse `PROJECT_SECRETS` directory, exact-file and glob entries, including shared consumers and provider-credential exceptions.
- Discover actual Pulumi update jobs, stacks, checkout inputs and preview dependencies from live Concourse configurations. Pipeline names are not hard-coded; instance selectors and input/resource aliases are supported.
- Narrow checks by filename environment and known stack-group tokens; check shared files across matching stacks and deduplicate deployments consuming multiple changed files.
- Compare the PR commit with successful deploy inputs, never previews, refresh/destroy operations, or optional/error-path updates. Explain missing login, incomplete discovery, credential-only files and unknown consumers explicitly.
- Slurp paginated GitHub file responses so large PRs remain valid JSON.

The registry identifies candidate consumers, sometimes at directory granularity. A successful build is pipeline evidence—not proof that a specific key was written to Vault. The script performs no SOPS decryption or Vault read-back; logged-out runs show candidate projects but require login to discover live pipeline links.

</details>

### How can this be tested?
- `uv run pytest tests/test_where_is_my_pr.py tests/ol_concourse/test_secrets_map.py` — 224 passed (52 script tests plus 172 registry tests). The two diagnostic-output regressions failed before the logging changes and pass afterward.
- `uv run pre-commit run --files scripts/where-is-my-pr tests/test_where_is_my_pr.py` — passed.
- `uv run mypy --follow-imports=silent scripts/where-is-my-pr tests/test_where_is_my_pr.py` — passed.
- Ran `uv run python scripts/where-is-my-pr https://github.com/mitodl/ol-infrastructure/pull/5809`. It discovered `packer-pulumi-concourse` and reported QA deploy build #126 using merge commit `b09d1069`: [build evidence](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/packer-pulumi-concourse/jobs/deploy-ol-infrastructure-concourse-application-qa/builds/126).
- Live discovery found an update job for every project with a nonempty registry entry. Routing spot checks covered Witan, MITxOnline, Open edX's `mitx-staging.QA`, global Vault secrets and shared Grafana secrets.

### Additional Context
The existing pre-commit.ci commit reformatted the encrypted Concourse QA secrets file; the generalization commit changes only the script and its tests. CodeQL findings #59 and #60 were addressed in e0d0e09: credential-only diagnostics use fixed text, failure diagnostics omit instance-selector values, and discovery is named for its Pulumi metadata. All PR checks now pass, with no open CodeQL alerts on this PR and no dismissals or suppressions.

