### PR TITLE
fix(starrocks): let mit-learn reach the FE MySQL NLB

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -80,6 +80,9 @@ vault_stack = make_stack_reference(
 )
 mit_learn_stack = make_stack_reference(projects.MIT_LEARN, stack_info.name)
 concourse_stack = make_stack_reference(projects.CONCOURSE, stack_info.name)
+applications_cluster_stack = make_stack_reference(
+    projects.EKS, f"applications.{stack_info.name}"
+)
 
 starrocks_env = f"data-{stack_info.env_suffix}"
 aws_config = AWSBase(tags={"OU": "data", "Environment": starrocks_env})
@@ -1059,11 +1062,20 @@ starrocks_apisix_httproute = OLApisixHTTPRoute(
 # Internal NLB exposing the StarRocks FE MySQL port (9030) to the data VPC so that
 # Vault — running on EC2 in the operations VPC, which is peered with the data VPC —
 # can reach StarRocks to manage dynamic database credentials. Also admits MIT
-# Learn's application pods (applications VPC) and Concourse workers (operations
-# VPC, which run the Vault DB-role SQL setup Command resources in
-# substructure/starrocks) as explicit sources — supplying this SG via the LBC
-# annotation below means it becomes the sole authority on the NLB's ingress, so
-# every legitimate caller must be listed here.
+# Learn (applications VPC) and Concourse workers (operations VPC, which run the
+# Vault DB-role SQL setup Command resources in substructure/starrocks) as
+# explicit sources — supplying this SG via the LBC annotation below means it
+# becomes the sole authority on the NLB's ingress, so every legitimate caller
+# must be listed here.
+#
+# MIT Learn's pod SG alone does not match its traffic. The applications cluster
+# runs security groups for pods in "standard" enforcing mode with in-node SNAT,
+# so a pod's connection to a peered VPC leaves from its node's primary ENI and
+# carries the node group SG instead. With only the pod SG listed, the NLB's
+# SecurityGroupBlockedFlowCount_Inbound_TCP metric recorded a burst of dropped
+# flows at every failed MIT Learn warehouse sync. Listing the node group SG
+# means any pod on those nodes can reach this port; StarRocks authentication is
+# what gates access.
 FE_MYSQL_PORT = 9030
 
 # Stable name for the FE MySQL endpoint, published by external-dns from the
@@ -1088,14 +1100,17 @@ fe_mysql_nlb_security_group = ec2.SecurityGroup(
             security_groups=[
                 vault_stack.require_output("vault_server")["security_group"],
                 mit_learn_stack.require_output("mit_learn")["app_security_group_id"],
+                applications_cluster_stack.require_output(
+                    "node_group_security_group_id"
+                ),
                 concourse_stack.require_output("worker_security_group"),
             ],
             protocol="tcp",
             from_port=FE_MYSQL_PORT,
             to_port=FE_MYSQL_PORT,
             description=(
-                "Allow Vault, MIT Learn application pods, and Concourse workers "
-                "to reach the StarRocks FE MySQL protocol port."
+                "Allow Vault, MIT Learn, applications cluster nodes, and "
+                "Concourse workers to reach the StarRocks FE MySQL protocol port."
             ),
         ),
     ],


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Sentry: https://mit-office-of-digital-learning.sentry.io/issues/MIT-LEARN-4A5

### Description (What does it do?)
mit-learn's `SyncProgramCertificatesTask` has timed out in production every day since #5719 wired StarRocks credentials (8 events, 2026-09-04 through 2026-09-10):

```
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'mysql.lakehouse.starrocks.ol.mit.edu' (timed out)")
```

- The FE MySQL NLB security group (added in #5556) admits mit-learn by its pod SG, `mitlearn-app-sg-<env>`.
- The applications clusters run the VPC CNI with `POD_SECURITY_GROUP_ENFORCING_MODE=standard` and `AWS_VPC_K8S_CNI_EXTERNALSNAT=false` ([eks/__main__.py#L400](https://github.com/mitodl/ol-infrastructure/blob/7fbd2a23110d21e0e51ffdd632dd2389e13f3e72/src/ol_infrastructure/infrastructure/aws/eks/__main__.py#L400)). The data VPC is outside the applications VPC CIDR, so pod traffic to the NLB is SNATed to the node's primary ENI and carries the node group SG, not the pod SG.
- This adds the applications cluster's `node_group_security_group_id` to the NLB ingress ([starrocks/__main__.py#L1071-L1116](https://github.com/mitodl/ol-infrastructure/blob/387876490d3f6009b15d671e93f9c46575fc5454/src/ol_infrastructure/applications/starrocks/__main__.py#L1071-L1116)). Any pod on those nodes can now reach 9030 at the network layer; StarRocks auth still gates access.

Evidence:
- The production NLB's `SecurityGroupBlockedFlowCount_Inbound_TCP` recorded 28 blocked flows within 10 minutes of each of the 8 Sentry events, and none at other times in the 7-day window queried.
- AWS Reachability Analyzer from a mit-learn pod branch ENI to the NLB on 9030 reports reachable. Peering routes, NACLs, the DNS alias, and target health (3/3 healthy) are all correct. The analyzer does not model in-node SNAT.
- The SNAT step is inferred from the CNI config and the above; it was not observed from inside a pod.

### How can this be tested?
- `pulumi preview` on `lakehouse.Production`, `lakehouse.QA`, and `lakehouse.CI`: each shows the NLB SG ingress update (masked as `[secret]` by Pulumi) plus a k8s provider kubeconfig update that parses to an identical config in all three (key order only). Nothing else changes.
- pre-commit (ruff, mypy) passes.
- Not yet validated live. After deploy, the next 09:00 UTC `SyncProgramCertificatesTask` run in production should succeed with no new MIT-LEARN-4A5 events, and the NLB's `SecurityGroupBlockedFlowCount_Inbound_TCP` should stay at 0 during the run.

### Additional Context
- The GPU node group has its own SG and is not included. It is tainted `ol.mit.edu/gpu_node: NoSchedule`, so celery workers don't schedule there.
- Alternative considered: `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` for the data VPC CIDR. It keeps pod-SG scoping, but it's a cluster-wide CNI change that alters the source identity of every applications pod talking to the data VPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJdaHqaGXb1ibmWA4HxYu4
