### PR TITLE
fix(concourse): re-run github-repositories when the app registry changes

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -400,6 +400,11 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-saas-github-repositories",
         stages=["default"],
         topology="preview-gated",
+        # rulesets.py grants the release bot its required-checks bypass from
+        # bridge.settings.apps, so flipping an app's release_resource_workflow
+        # has to re-run this stack. The registry is outside PULUMI_WATCHED_PATHS
+        # and this project's path.
+        additional_watched_paths=["src/bridge/settings/apps.py"],
     ),
     "grafana-alerting": SimplePulumiParams(
         app_name="grafana-alerting",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -400,10 +400,10 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-saas-github-repositories",
         stages=["default"],
         topology="preview-gated",
-        # rulesets.py grants the release bot its required-checks bypass from
-        # bridge.settings.apps, so flipping an app's release_resource_workflow
-        # has to re-run this stack. The registry is outside PULUMI_WATCHED_PATHS
-        # and this project's path.
+        # rulesets.py grants the release bot its required-checks bypass on every
+        # repo registered in bridge.settings.apps, so adding or removing an app
+        # there has to re-run this stack. The registry is outside
+        # PULUMI_WATCHED_PATHS and this project's path.
         additional_watched_paths=["src/bridge/settings/apps.py"],
     ),
     "grafana-alerting": SimplePulumiParams(


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7185 (release workflow rollout)

### Description (What does it do?)
- [`rulesets.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/github/repositories/rulesets.py#L157) grants the ol-release-bot App a required-checks bypass on every repo returned by [`release_workflow_repos()`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/apps.py#L128), which is every app registered in `bridge.settings.apps.APPS` (a deliberate over-grant, not only apps with `release_resource_workflow` set).
- The `github-repositories` stack's git resource did not watch `apps.py`. Adding an app to `APPS` put the bypass in code without applying it, until an unrelated commit touched a watched path.
- Adds `src/bridge/settings/apps.py` to that stack's `additional_watched_paths`. #5759 already did this for the release-bot stack and `k8s_apps/meta.py`.

The stack is `preview-gated`, so a registry edit now opens a preview. Applying it to the org rulesets still needs a human.

### How can this be tested?
Build the pipeline and read the resource paths, not the literal:

```python
from ol_concourse.pipelines.infrastructure.simple_pulumi.pipeline import build_simple_pulumi_pipeline
build_simple_pulumi_pipeline("github-repositories")
```

`ol-infrastructure-pulumi-github-repositories`'s `source.paths` now ends with `src/bridge/settings/apps.py`. The stack has no docker build, so no other resource changes. `pre-commit` (ruff, mypy) passes on the file.

After merge, `fly get-pipeline` on the github-repositories pipeline should show the new path.

### Additional Context
- `org_rulesets.py` also imports from `bridge.settings.apps`, but only the `RELEASE_BOT_APP_ID` constant. I left it without a trigger. It has the same gap, but the value doesn't change in practice.
- Once the bypass is narrowed to opted-in apps (planned after the rollout), flipping `release_resource_workflow` will also change the bypass set. This trigger covers that case with no further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAC3Cb2tbKe5bUrp8zRcgR