### PR TITLE
fix(starrocks): stop roles-setup from dropping roles on replacement

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -410,8 +410,7 @@ if enable_data_lake:
 # LIMITATION: these GRANTs are additive.  If enable_data_lake_integration is
 # later set to false the Iceberg catalog grants already on the roles are NOT
 # automatically revoked.  A manual REVOKE USAGE ON CATALOG + REVOKE on tables
-# is required to remove them (or DROP + recreate the roles via pulumi destroy
-# followed by pulumi up).
+# is required to remove them.
 _base_roles_sql = """\
 -- Machine-access roles assigned to Vault-issued ephemeral service accounts.
 -- These are referenced by the vault.database.SecretBackendRole resources above.
@@ -499,13 +498,6 @@ GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE ol_business_anal
 _roles_sql = _base_roles_sql + _iceberg_roles_sql
 _role_deps: list[pulumi.Resource] = [starrocks_db_connection, *catalog_setups]
 
-_roles_drop_sql = (
-    "DROP ROLE IF EXISTS readonly; DROP ROLE IF EXISTS app; DROP ROLE IF EXISTS admin;"
-    " DROP ROLE IF EXISTS ol_platform_admin; DROP ROLE IF EXISTS ol_data_engineer;"
-    " DROP ROLE IF EXISTS ol_data_analyst; DROP ROLE IF EXISTS ol_researcher;"
-    " DROP ROLE IF EXISTS ol_instructor; DROP ROLE IF EXISTS ol_business_analyst;"
-)
-
 # Valid Keycloak ol-starrocks-client role names.  These match StarRocks role
 # names 1:1 so no translation is needed when creating OIDC user accounts.
 _GOVERNANCE_ROLES: frozenset[str] = frozenset(
@@ -526,18 +518,23 @@ _GOVERNANCE_ROLES: frozenset[str] = frozenset(
 # generated CREATE USER / GRANT statements.
 _OIDC_USERNAME_RE = re.compile(r"^[A-Za-z0-9._%+@-]+$")
 
+# No delete step. Dropping a StarRocks role revokes it from every user that
+# holds it, and nothing re-grants roles to Vault-issued users that already
+# exist. This resource is replaced whenever _roles_sql changes (Production
+# recorded replacements on 2026-08-12 and 2026-09-03); each replacement ran a
+# DROP ROLE delete step and left the Superset and MIT Learn credentials with
+# no role at all. The roles therefore outlive this resource and must be
+# dropped by hand if that is ever wanted.
 roles_setup_cmd = command.local.Command(
     f"starrocks-{stack_info.env_suffix}-roles-setup",
     create=_exec_sql,
     update=_exec_sql,
-    delete=_exec_delete_sql,
     environment={
         **_mysql_env,
         "STARROCKS_SQL": _roles_sql,
-        "STARROCKS_DELETE_SQL": _roles_drop_sql,
     },
     triggers=[hashlib.sha256(_roles_sql.encode()).hexdigest()],
-    opts=ResourceOptions(delete_before_replace=True, depends_on=_role_deps),
+    opts=ResourceOptions(depends_on=_role_deps),
 )
 
 # --- b2b_analytics database ---------------------------------------------


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Follow-up to #5812. Sentry: https://mit-office-of-digital-learning.sentry.io/issues/MIT-LEARN-4C1

### Description (What does it do?)
Removes the `DROP ROLE` delete step from the StarRocks `roles-setup` Command ([substructure/starrocks/__main__.py#L521-L537](https://github.com/mitodl/ol-infrastructure/blob/1c55da4f78f3b33fd62e577e5bb6624c5d77b476/src/ol_infrastructure/substructure/starrocks/__main__.py#L521-L537)).

- `roles-setup` is replaced when the roles SQL changes. With `delete_before_replace=True`, the replacement ran `DROP ROLE IF EXISTS readonly; DROP ROLE IF EXISTS app; ...` and then recreated the roles empty.
- Vault only grants a role when it mints a user, so users minted before a replacement are left with none:
  ```
  Access denied; you need (at least one of) the SELECT privilege(s) on TABLE integrations__learn__program_certificates ... Current role(s): NONE. Inactivated role(s): NONE.
  ```
- Production state shows `roles-setup` recreated at 2026-09-03 18:14:05Z (`created` == `modified`, in an update that recorded `replace: 1`). mit-learn's StarRocks credential was minted at 14:50Z that day. The first `SyncProgramCertificatesTask` run to get past the network (17:54Z today, after #5812) failed with the error above; VSO issued a new credential at 17:59:50Z and the next run succeeded (10945 rows).
- Superset (`database-starrocks/creds/readonly`) logged `Current role(s): NONE` 3,748 times in the last 7 days, most recently at 17:48Z today. Daily counts begin in the bucket covering 2026-08-12, the date of an earlier Production update that also recorded `replace: 1`.
- `delete_before_replace` is removed too; it only existed to order the delete step. The roles now outlive the resource and would need dropping by hand.

### How can this be tested?
- `pulumi preview` on `substructure/starrocks` `lakehouse.Production`, `lakehouse.QA`, and `lakehouse.CI`: `roles-setup` is an in-place update in all three (`[diff: -delete~environment]`), not a replace, so the old delete step does not run one last time. The update re-applies the existing roles SQL (`CREATE ROLE IF NOT EXISTS` + `GRANT`).
- Production and QA also show a second update. In Production it is the keycloak group sync Command: a kubeconfig key reorder plus a script-path diff from running the preview locally. QA's second update was not inspected.
- pre-commit (ruff, mypy) passes.

### Additional Context
- This does not repair users who already lost their role. Superset's StarRocks credential has not been re-issued: VSO events today show only renewals of its existing lease, and Superset was still logging the error at 17:48Z.

### Checklist:
- [ ] Re-issue Superset's StarRocks credential (e.g. delete the `superset-starrocks-creds` Secret in the `superset` namespace on data-production so VSO mints a new user), then confirm `Current role(s): NONE` stops appearing in Superset logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJdaHqaGXb1ibmWA4HxYu4
