### PR TITLE
fix(tika): raise the APISIX read timeout to match Tika's 300s budget

### DIFF
--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -218,6 +218,10 @@ tika_apisix_route = OLApisixRoute(
             priority=10,
             shared_plugin_config_name=tika_shared_plugins.resource_name,
             timeout_send="300s",  # Tika can take a while to process large files
+            # A slow parse hits the read timeout, not the send timeout. Left at
+            # the 60s default, the gateway answers 504 long before the client's
+            # own 300s timeout.
+            timeout_read="300s",
             plugins=[
                 # Use serverless-pre-function to validate X-Access-Token header
                 # This is simpler than request-validation and more flexible


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Sentry: https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-5G

### Description (What does it do?)
Sets `timeout_read="300s"` on the `tika-all` APISIX route ([tika/__main__.py](https://github.com/mitodl/ol-infrastructure/blob/bfbeacc07/src/ol_infrastructure/applications/tika/__main__.py#L216-L224)).

- The route raised `timeout_send` to 300s but left `timeout_read` at the `OLApisixRouteConfig` default of 60s ([apisix.py#L305](https://github.com/mitodl/ol-infrastructure/blob/a19172556/src/ol_infrastructure/components/services/apisix.py#L305)). Two other limits sit at 300s:
  - the ol-data-platform Tika client ([tika.py#L141-L147](https://github.com/mitodl/ol-data-platform/blob/ad395fde8/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py#L141-L147))
  - Tika's own `taskTimeoutMillis` of 300000 ([tika-config.xml#L14](https://github.com/mitodl/ol-infrastructure/blob/a19172556/src/bilder/components/tika/templates/tika-config.xml#L14))
- As a result, any document that takes Tika more than 60s to parse gets a 504 from the gateway. In Dagster, the Open edX document-text asset treated that 504 as Tika being down and failed the whole course partition. DAGSTER-5G logged 22,716 production events between 2026-09-03 and 2026-09-10. The event I sampled:

```
TikaUnavailableError: Tika is unavailable (failed on static/SustainabilityLectureSlides.pdf): Server error '504 Gateway Time-out' for url 'https://tika-production.ol.mit.edu/tika'
```

The ol-data-platform side, which counts a 504 against the one document instead of the whole course, is https://github.com/mitodl/ol-data-platform/pull/2664. This change is what lets those slow documents actually finish.

### How can this be tested?
- `pre-commit run --files src/ol_infrastructure/applications/tika/__main__.py`: passed (ruff, mypy).
- `pulumi preview` has not been run; this session has no Pulumi credentials. The route config maps `timeout_read` into the route's upstream `timeout.read`, so the preview should show only that value changing from 60s to 300s on the Tika route.
- After deploy: rerun one of the failing partitions of `openedx__processed_data__course_document_text`, for example `course-v1:MITxT+14.740x+3T2026`, and confirm the run logs show no 504s from `tika-production.ol.mit.edu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaS2hez2aw3LBTtmZAmwzX
