### PR TITLE
feat(release-bot): add /doof hotfix, cut from what production runs

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -39,7 +39,7 @@ from ol_concourse.lib.resources import (
     registry_image,
     release_resource,
 )
-from ol_concourse.lib.tasks import bump_version_task
+from ol_concourse.lib.tasks import TASK_IMAGE, bump_version_task
 from pydantic import BaseModel, model_validator
 
 from bridge.settings.apps import github_repo as app_github_repo
@@ -1087,6 +1087,39 @@ def _build_image_job(
     return Job(name=Identifier(job_name), build_log_retention={"builds": 10}, plan=plan)
 
 
+def _checkout_release_task(main_repo: Resource, output: Identifier) -> TaskStep:
+    """Check the cut `releases/<version>` branch out into *output*.
+
+    Also records the commit the version tag points at in
+    ``<output>/.git/release_ref``, which is what the image is stamped with.
+    The app repositories are public, as is ``main_repo``'s unauthenticated
+    https URI, so the fetch needs no credentials.
+    """
+    script = "\n".join(
+        [
+            f'cp -a "$REPO/." {output}/',
+            f"cd {output}",
+            "git fetch --quiet origin"
+            ' "+refs/heads/releases/$VERSION:refs/remotes/origin/releases/$VERSION"'
+            ' "+refs/tags/$VERSION:refs/tags/$VERSION"',
+            'git checkout --quiet --force --detach "origin/releases/$VERSION"',
+            "git clean --quiet -fdx",
+            'git rev-list -n1 "$VERSION" > .git/release_ref',
+        ]
+    )
+    return TaskStep(
+        task=Identifier("checkout-release"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=TASK_IMAGE,
+            inputs=[Input(name=main_repo.name)],
+            outputs=[Output(name=output)],
+            params={"REPO": str(main_repo.name), "VERSION": "((.:release_version))"},
+            run=Command(path="sh", args=["-euc", script]),
+        ),
+    )
+
+
 def _build_release_image_job(
     app_name: str,
     dockerfile_path: str,
@@ -1124,6 +1157,7 @@ def _build_release_image_job(
         "additional_tags": f"{release_res.name}/version",
     }
 
+    release_source = Identifier("release-source")
     plan = [
         GetStep(get=release_res.name, trigger=True),
         GetStep(get=main_repo.name, trigger=False),
@@ -1132,17 +1166,13 @@ def _build_release_image_job(
             file=f"{release_res.name}/version",
             reveal=True,
         ),
-        # The release resource's "create" out-action tags the pre-bumpver HEAD SHA
-        # as the release (see ol-concourse resources/release/README.md): it records
-        # main_repo's current HEAD *before* running bump_version_task, then commits
-        # the version bump separately. Capture git_ref from main_repo here -- before
-        # bump_version_task mutates the checkout -- so the built image is stamped
-        # with the exact commit the release tag points to. The release resource
-        # itself never writes a .git/ref file (only version/commits.json/
-        # checklist.md/changelog_entry.md), so loading it from there would fail.
+        # The commit a hotfix cherry-picks onto production, or empty for a
+        # normal release. The release resource's check sets it while a
+        # `hotfix/<sha>` request tag is pending, which is how `/doof hotfix`
+        # gets a SHA to a job whose trigger carries no parameters.
         LoadVarStep(
-            load_var="git_ref",
-            file=f"{main_repo.name}/.git/ref",
+            load_var="hotfix",
+            file=f"{release_res.name}/hotfix",
             reveal=True,
         ),
         bump_version_task(
@@ -1155,13 +1185,29 @@ def _build_release_image_job(
                 "action": "create",
                 "repo_dir": str(main_repo.name),
                 "version_file": f"{release_res.name}/version",
+                "commit_hash": "((.:hotfix))",
             },
         ),
+        # Build from the cut release, not from main_repo. A hotfix is
+        # production plus one commit, which main_repo does not hold, and
+        # Concourse does not document a put writing back to its inputs, so the
+        # put's checkout is not something later steps can rely on. For a normal
+        # release, releases/<version> is the tree main_repo holds after
+        # bump_version_task, unless main moved between the get and the put, in
+        # which case the branch is what was actually tagged.
+        _checkout_release_task(main_repo, release_source),
+        # The commit the version tag points at: the pre-bump HEAD for a normal
+        # release, the cherry-picked commit for a hotfix.
+        LoadVarStep(
+            load_var="git_ref",
+            file=f"{release_source}/.git/release_ref",
+            reveal=True,
+        ),
         container_build_task(
-            inputs=[Input(name=main_repo.name)],
+            inputs=[Input(name=release_source)],
             build_parameters={
-                "CONTEXT": main_repo.name,
-                "DOCKERFILE": f"{main_repo.name}/{dockerfile_path}",
+                "CONTEXT": str(release_source),
+                "DOCKERFILE": f"{release_source}/{dockerfile_path}",
                 "BUILD_ARG_GIT_REF": "((.:git_ref))",
                 # Some Dockerfiles (e.g. ol-analytics-api) declare ARG GIT_SHA
                 # instead of the GIT_REF convention above; pass both so either

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from functools import partial
@@ -37,6 +38,7 @@ _release_requesters: dict[str, str] = {}
 _USAGE = (
     "Usage:\n"
     "• `/doof release <app>` — cut a release\n"
+    "• `/doof hotfix <app> <sha>` — cut what production runs plus one commit\n"
     "• `/doof preview <app>` — show what the next release would contain "
     "(changes nothing)\n"
     "• `/doof release-notes <app>` — show unreleased commits\n"
@@ -91,6 +93,26 @@ async def _cmd_release(repos, ack, respond, command, context):
     cfg, error = _resolve_app(repos, app_name)
     if cfg is None:
         await respond(error)
+        return
+
+    # While a hotfix request is pending the release resource offers that
+    # hotfix, not the tracked branch, so this build would cut it instead.
+    try:
+        pending = await github.pending_hotfix_requests(cfg.repo)
+    except Exception:
+        log.exception("Failed to check pending hotfixes for %s", app_name)
+        await respond(
+            f"❌ Could not check `{app_name}` for a pending hotfix. Refusing to "
+            "trigger — a pending one would be cut instead of this release."
+        )
+        return
+    if pending:
+        short = pending[0][:7]
+        await respond(
+            f"A hotfix of `{short}` is pending for `{app_name}`, so a release "
+            f"now would cut that hotfix instead. `/doof hotfix {app_name} {short}` "
+            f"continues it; `/doof abandon {app_name}` cancels it."
+        )
         return
 
     # Report a release that was cut but never finished. Cutting a new one
@@ -322,6 +344,23 @@ async def _cmd_abandon(repos, ack, respond, command, _context):
         await respond(error)
         return
     try:
+        cancelled = await github.cancel_hotfix_requests(cfg.repo)
+        in_flight = await github.in_flight_release(cfg.repo)
+    except Exception:
+        log.exception("Failed to check release state for %s", app_name)
+        await respond(
+            f"❌ Could not check `{app_name}`'s release state. Nothing abandoned."
+        )
+        return
+    lines = [f"Cancelled the pending hotfix of `{sha[:7]}`." for sha in cancelled]
+    if not in_flight:
+        # The abandon job deletes the branch and tag of whatever version the
+        # release resource last reported. With nothing in flight that is the
+        # release production is running, and its tag is the only record of it.
+        lines.append(f"No release is in flight for `{app_name}`; nothing to abandon.")
+        await respond("\n".join(lines))
+        return
+    try:
         build_url = await concourse.trigger_job(
             cfg.pipeline, f"abandon-{app_name}-release"
         )
@@ -330,7 +369,12 @@ async def _cmd_abandon(repos, ack, respond, command, _context):
         await respond(f"❌ Failed to trigger release abandon for `{app_name}`.")
         return
     _release_requesters.pop(app_name, None)
-    await respond(f"🗑️ Release abandon triggered for `{app_name}`. Build: {build_url}")
+    lines.insert(
+        0,
+        f"🗑️ Abandoning {_describe_in_flight(in_flight)} for `{app_name}`. "
+        f"Build: {build_url}",
+    )
+    await respond("\n".join(lines))
 
 
 async def _handle_promote_button(repos, ack, body, say):
@@ -530,8 +574,103 @@ async def _cmd_wait_for_checkboxes(repos, ack, respond, command, _context):
     )
 
 
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+async def _request_hotfix(cfg, app_name, ref):
+    """Request a hotfix of *ref*; return (full sha, None) or (None, error).
+
+    The release resource refuses an in-flight release too, but only once the
+    build is running, so it is checked here first. A request already pending
+    for the same commit is reused, which is what makes `/doof hotfix` safe to
+    re-run after a failed trigger.
+    """
+    try:
+        sha = await github.resolve_commit(cfg.repo, ref)
+    except Exception:
+        log.exception("Failed to resolve %s in %s", ref, cfg.repo)
+        return None, f"❌ Could not find commit `{ref}` in `{cfg.repo}`."
+    try:
+        in_flight = await github.in_flight_release(cfg.repo)
+        pending = await github.pending_hotfix_requests(cfg.repo)
+    except Exception:
+        log.exception("Failed to check release state for %s", app_name)
+        return None, (
+            f"❌ Could not check `{app_name}`'s release state. Not requesting a hotfix."
+        )
+    if in_flight:
+        return None, (
+            f"Release {_describe_in_flight(in_flight)} is in flight for "
+            f"`{app_name}`. Promote it or `/doof abandon {app_name}` before "
+            "cutting a hotfix."
+        )
+    others = [p for p in pending if p != sha]
+    if others:
+        return None, (
+            f"A hotfix of `{others[0][:7]}` is already pending for `{app_name}`. "
+            f"`/doof abandon {app_name}` cancels it."
+        )
+    if sha not in pending:
+        try:
+            await github.request_hotfix(cfg.repo, sha)
+        except Exception:
+            log.exception("Failed to request hotfix of %s for %s", sha, app_name)
+            return None, f"❌ Failed to request a hotfix of `{sha[:7]}`."
+    return sha, None
+
+
+async def _cmd_hotfix(repos, ack, respond, command, context):
+    """Cut a hotfix: what production runs plus one commit.
+
+    The SHA reaches the release job through a `hotfix/<sha>` tag, because
+    triggering a Concourse job carries no parameters. The release resource's
+    check sees the tag and hands the job a hotfix version; cutting it deletes
+    the tag, whether or not the cut succeeds.
+    """
+    await ack()
+    app_name, _, ref = command["text"].strip().partition(" ")
+    ref = ref.strip().lower()
+    if not app_name or not _COMMIT_SHA_RE.match(ref):
+        await respond("Usage: `/doof hotfix <app> <commit sha>`")
+        return
+    cfg, error = _resolve_app(repos, app_name)
+    if cfg is None:
+        await respond(error)
+        return
+
+    sha, error = await _request_hotfix(cfg, app_name, ref)
+    if sha is None:
+        await respond(error)
+        return
+
+    retry = (
+        f"The hotfix is requested but not started: `/doof hotfix {app_name} "
+        f"{sha[:7]}` retries, `/doof abandon {app_name}` cancels."
+    )
+    try:
+        # Same reason as /doof release: without a check, the job binds the
+        # version Concourse last recorded, which knows nothing of the request.
+        await concourse.check_resource(cfg.pipeline, f"{app_name}-release")
+        build_url = await concourse.trigger_job(
+            cfg.pipeline, f"build-{app_name}-release-image"
+        )
+    except Exception:
+        log.exception("Failed to trigger hotfix for %s", app_name)
+        await respond(f"❌ Failed to trigger the hotfix build. {retry}")
+        return
+
+    requester = (context or {}).get("user_id")
+    if requester:
+        _release_requesters[app_name] = requester
+    await respond(
+        f"🚑 Hotfix of `{sha[:7]}` triggered for `{app_name}`: what production "
+        f"runs plus that commit. Build: {build_url}"
+    )
+
+
 _SUBCOMMANDS = {
     "release": _cmd_release,
+    "hotfix": _cmd_hotfix,
     "preview": _cmd_preview,
     "release-notes": _cmd_release_notes,
     "release-status": _cmd_release_status,

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -35,6 +35,18 @@ _slack_app: AsyncApp | None = None
 _release_requesters: dict[str, str] = {}
 
 
+# app name -> lock held across a command's check-then-act sequence. Slack
+# handlers run concurrently on one event loop, so without it two commands can
+# each read "nothing pending" before either writes: two hotfix requests for
+# one app, or a release triggered while a hotfix is being requested.
+# Process-local is enough because the bot runs one replica (see _slack_app).
+_app_locks: dict[str, asyncio.Lock] = {}
+
+
+def _app_lock(app_name: str) -> asyncio.Lock:
+    return _app_locks.setdefault(app_name, asyncio.Lock())
+
+
 _USAGE = (
     "Usage:\n"
     "• `/doof release <app>` — cut a release\n"
@@ -94,7 +106,11 @@ async def _cmd_release(repos, ack, respond, command, context):
     if cfg is None:
         await respond(error)
         return
+    async with _app_lock(app_name):
+        await _release(respond, app_name, cfg, context)
 
+
+async def _release(respond, app_name, cfg, context):
     # While a hotfix request is pending the release resource offers that
     # hotfix, not the tracked branch, so this build would cut it instead.
     try:
@@ -343,13 +359,29 @@ async def _cmd_abandon(repos, ack, respond, command, _context):
     if cfg is None:
         await respond(error)
         return
+    async with _app_lock(app_name):
+        await _abandon(respond, app_name, cfg)
+
+
+async def _abandon(respond, app_name, cfg):
+    # Read before mutating: a lookup that failed after the cancel would report
+    # "nothing abandoned" with the requests already deleted.
     try:
-        cancelled = await github.cancel_hotfix_requests(cfg.repo)
         in_flight = await github.in_flight_release(cfg.repo)
     except Exception:
         log.exception("Failed to check release state for %s", app_name)
         await respond(
-            f"❌ Could not check `{app_name}`'s release state. Nothing abandoned."
+            f"❌ Could not check `{app_name}`'s release state. Nothing abandoned "
+            "or cancelled."
+        )
+        return
+    try:
+        cancelled = await github.cancel_hotfix_requests(cfg.repo)
+    except Exception:
+        log.exception("Failed to cancel hotfix requests for %s", app_name)
+        await respond(
+            f"❌ Failed while cancelling `{app_name}`'s pending hotfix requests; "
+            "some may already be gone. Nothing abandoned."
         )
         return
     lines = [f"Cancelled the pending hotfix of `{sha[:7]}`." for sha in cancelled]
@@ -638,7 +670,11 @@ async def _cmd_hotfix(repos, ack, respond, command, context):
     if cfg is None:
         await respond(error)
         return
+    async with _app_lock(app_name):
+        await _hotfix(respond, app_name, cfg, ref, context)
 
+
+async def _hotfix(respond, app_name, cfg, ref, context):
     sha, error = await _request_hotfix(cfg, app_name, ref)
     if sha is None:
         await respond(error)

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -355,8 +355,9 @@ async def _cmd_abandon(repos, ack, respond, command, _context):
     lines = [f"Cancelled the pending hotfix of `{sha[:7]}`." for sha in cancelled]
     if not in_flight:
         # The abandon job deletes the branch and tag of whatever version the
-        # release resource last reported. With nothing in flight that is the
-        # release production is running, and its tag is the only record of it.
+        # release resource last reported. With nothing in flight and no new
+        # commits, that is the release production is running, and its tag is
+        # the only record of what it runs.
         lines.append(f"No release is in flight for `{app_name}`; nothing to abandon.")
         await respond("\n".join(lines))
         return

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -419,7 +419,12 @@ async def _abandon(respond, app_name, cfg):
         )
     except Exception:
         log.exception("Failed to trigger abandon for %s", app_name)
-        await respond(f"❌ Failed to trigger release abandon for `{app_name}`.")
+        # Any cancelled-hotfix lines already collected are a real state
+        # change that happened before this failure; dropping them would tell
+        # the user nothing was abandoned when their hotfix requests are
+        # already gone.
+        lines.append(f"❌ Failed to trigger release abandon for `{app_name}`.")
+        await respond("\n".join(lines))
         return
     _release_requesters.pop(app_name, None)
     # The job deletes whatever version the release resource's last `check`

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -193,6 +193,26 @@ async def _cmd_preview(repos, ack, respond, command, _context):
     if cfg is None:
         await respond(error)
         return
+    # While a hotfix request is pending the release resource offers that
+    # hotfix, not the tracked branch's calver-next version -- same check
+    # `_release` uses, so the preview doesn't contradict what `/doof release`
+    # would actually cut.
+    try:
+        pending = await github.pending_hotfix_requests(cfg.repo)
+    except Exception:
+        log.exception("Failed to check pending hotfixes for %s", app_name)
+        await respond(f"❌ Could not check `{app_name}` for a pending hotfix.")
+        return
+    if pending:
+        short = pending[0][:7]
+        await respond(
+            f"*Release preview for `{app_name}`* — a hotfix of `{short}` is "
+            "pending, so the next cut would be that hotfix (what production "
+            "runs plus that commit), not a normal release.\n"
+            f"`/doof hotfix {app_name} {short}` continues it; "
+            f"`/doof abandon {app_name}` cancels it."
+        )
+        return
     try:
         preview = await github.release_preview(cfg.repo)
     except Exception:
@@ -402,10 +422,15 @@ async def _abandon(respond, app_name, cfg):
         await respond(f"❌ Failed to trigger release abandon for `{app_name}`.")
         return
     _release_requesters.pop(app_name, None)
+    # The job deletes whatever version the release resource's last `check`
+    # recorded, which can diverge from `in_flight` (read fresh from GitHub
+    # branches here) if a `check` ran without a cut in between. Report the
+    # trigger, not a specific deletion, and let the build's own output say
+    # what it removed.
     lines.insert(
         0,
-        f"🗑️ Abandoning {_describe_in_flight(in_flight)} for `{app_name}`. "
-        f"Build: {build_url}",
+        f"🗑️ Release abandon triggered for `{app_name}` (last seen in flight: "
+        f"{_describe_in_flight(in_flight)}). Build: {build_url}",
     )
     await respond("\n".join(lines))
 

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -441,8 +441,18 @@ async def resolve_commit(repo_slug: str, ref: str) -> str:
     return await asyncio.to_thread(_resolve_commit_sync, repo_slug, ref)
 
 
+# Only a tag named for a full SHA is a request. The release resource offers no
+# other and deletes a request by that exact name, so anything else under the
+# prefix would block releases here while never being cut or consumed there.
+_HOTFIX_REQUEST_RE = re.compile(r"^refs/tags/hotfix/[0-9a-f]{40}$")
+
+
 def _hotfix_refs(repo: Any) -> list[Any]:
-    return list(repo.get_git_matching_refs(f"tags/{HOTFIX_TAG_PREFIX}"))
+    return [
+        ref
+        for ref in repo.get_git_matching_refs(f"tags/{HOTFIX_TAG_PREFIX}")
+        if _HOTFIX_REQUEST_RE.match(ref.ref)
+    ]
 
 
 def _hotfix_sha(ref: Any) -> str:

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -424,3 +424,60 @@ async def release_issue_for_version(
 ) -> dict[str, Any] | None:
     """Return the release issue whose checklist header names *version*, or None."""
     return await asyncio.to_thread(_release_issue_for_version_sync, repo_slug, version)
+
+
+# A hotfix is requested with a `hotfix/<full sha>` tag. The release resource's
+# check offers it as the next version, and its create deletes the tag by that
+# exact name, so anything else under this prefix would never be consumed.
+HOTFIX_TAG_PREFIX = "hotfix/"
+
+
+def _resolve_commit_sync(repo_slug: str, ref: str) -> str:
+    return _get_client().get_repo(repo_slug).get_commit(ref).sha
+
+
+async def resolve_commit(repo_slug: str, ref: str) -> str:
+    """Return the full SHA of *ref*, a short or full commit SHA, in *repo_slug*."""
+    return await asyncio.to_thread(_resolve_commit_sync, repo_slug, ref)
+
+
+def _hotfix_refs(repo: Any) -> list[Any]:
+    return list(repo.get_git_matching_refs(f"tags/{HOTFIX_TAG_PREFIX}"))
+
+
+def _hotfix_sha(ref: Any) -> str:
+    return ref.ref.removeprefix(f"refs/tags/{HOTFIX_TAG_PREFIX}")
+
+
+def _pending_hotfix_requests_sync(repo_slug: str) -> list[str]:
+    repo = _get_client().get_repo(repo_slug)
+    return [_hotfix_sha(ref) for ref in _hotfix_refs(repo)]
+
+
+async def pending_hotfix_requests(repo_slug: str) -> list[str]:
+    """Return the commit SHAs of hotfixes requested but not yet cut."""
+    return await asyncio.to_thread(_pending_hotfix_requests_sync, repo_slug)
+
+
+def _request_hotfix_sync(repo_slug: str, sha: str) -> None:
+    repo = _get_client().get_repo(repo_slug)
+    repo.create_git_ref(f"refs/tags/{HOTFIX_TAG_PREFIX}{sha}", sha)
+
+
+async def request_hotfix(repo_slug: str, sha: str) -> None:
+    """Request a hotfix of the full commit *sha* for the release resource to cut."""
+    await asyncio.to_thread(_request_hotfix_sync, repo_slug, sha)
+
+
+def _cancel_hotfix_requests_sync(repo_slug: str) -> list[str]:
+    repo = _get_client().get_repo(repo_slug)
+    cancelled = []
+    for ref in _hotfix_refs(repo):
+        ref.delete()
+        cancelled.append(_hotfix_sha(ref))
+    return cancelled
+
+
+async def cancel_hotfix_requests(repo_slug: str) -> list[str]:
+    """Delete every pending hotfix request and return the SHAs cancelled."""
+    return await asyncio.to_thread(_cancel_hotfix_requests_sync, repo_slug)

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -280,6 +280,47 @@ async def test_preview_flags_an_in_flight_release(repos, slack, monkeypatch):
     assert "supersedes it" in slack.said
 
 
+async def test_preview_reports_a_pending_hotfix_instead_of_the_normal_next_version(
+    repos, slack, monkeypatch
+):
+    """A pending hotfix is what the resource would actually offer next.
+
+    Without this, preview reports the calver-next version and every commit
+    on the default branch -- contradicting what `/doof release` would cut
+    (and refuse to), since the release resource offers the hotfix instead.
+    """
+    release_preview = AsyncMock()
+    monkeypatch.setattr(bot.github, "release_preview", release_preview)
+    monkeypatch.setattr(
+        bot.github, "pending_hotfix_requests", AsyncMock(return_value=[_SHA])
+    )
+
+    await bot._cmd_preview(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    release_preview.assert_not_awaited()
+    said = slack.said
+    assert "a hotfix of `aaaaaaa` is pending" in said
+    assert "not a normal release" in said
+    assert "/doof hotfix my-app aaaaaaa" in said
+
+
+async def test_preview_fails_closed_when_the_pending_hotfix_check_errors(
+    repos, slack, monkeypatch
+):
+    release_preview = AsyncMock()
+    monkeypatch.setattr(bot.github, "release_preview", release_preview)
+    monkeypatch.setattr(
+        bot.github,
+        "pending_hotfix_requests",
+        AsyncMock(side_effect=RuntimeError("github down")),
+    )
+
+    await bot._cmd_preview(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    release_preview.assert_not_awaited()
+    assert "Could not check" in slack.said
+
+
 # ---------------------------------------------------------------------------
 # /doof release-status
 # ---------------------------------------------------------------------------
@@ -1548,7 +1589,13 @@ async def test_abandon_triggers_the_job_for_an_in_flight_release(
     await bot._cmd_abandon(repos, slack.ack, slack.respond, _command("my-app"), {})
 
     assert calls == [("trigger", "my-app-pipeline", "abandon-my-app-release")]
-    assert "Abandoning" in slack.said
+    said = slack.said
+    # Not "Abandoning <version>": the job deletes whatever version the
+    # release resource's last `check` recorded, which can diverge from what
+    # in_flight_release reads fresh from GitHub branches.
+    assert "abandon triggered" in said
+    assert "last seen in flight" in said
+    assert "2026.9.9.1" in said
 
 
 async def test_abandon_cancels_nothing_when_it_cannot_read_release_state(

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -1598,6 +1598,29 @@ async def test_abandon_triggers_the_job_for_an_in_flight_release(
     assert "2026.9.9.1" in said
 
 
+async def test_abandon_reports_cancelled_hotfixes_when_the_trigger_fails(
+    repos, slack, monkeypatch
+):
+    """A failed trigger must not hide that hotfix requests were already cancelled."""
+    monkeypatch.setattr(
+        bot.github, "cancel_hotfix_requests", AsyncMock(return_value=[_SHA])
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.9.1", timedelta(days=1))),
+    )
+    monkeypatch.setattr(
+        bot.concourse, "trigger_job", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    await bot._cmd_abandon(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    said = slack.said
+    assert "Cancelled the pending hotfix of `aaaaaaa`" in said
+    assert "Failed to trigger release abandon" in said
+
+
 async def test_abandon_cancels_nothing_when_it_cannot_read_release_state(
     repos, slack, monkeypatch
 ):

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -379,11 +379,13 @@ def _clear_watchers(monkeypatch):
     monkeypatch.setattr(bot, "_slack_app", app)
     bot._checkbox_watchers.clear()
     bot._release_requesters.clear()
+    bot._app_locks.clear()
     slack_users._cache.clear()
     slack_users._lookups_disabled = False
     yield
     bot._checkbox_watchers.clear()
     bot._release_requesters.clear()
+    bot._app_locks.clear()
     slack_users._cache.clear()
     slack_users._lookups_disabled = False
 
@@ -1547,3 +1549,48 @@ async def test_abandon_triggers_the_job_for_an_in_flight_release(
 
     assert calls == [("trigger", "my-app-pipeline", "abandon-my-app-release")]
     assert "Abandoning" in slack.said
+
+
+async def test_abandon_cancels_nothing_when_it_cannot_read_release_state(
+    repos, slack, monkeypatch
+):
+    """Deleting requests and then reporting "nothing abandoned" would hide it."""
+    cancel = AsyncMock()
+    monkeypatch.setattr(bot.github, "cancel_hotfix_requests", cancel)
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(side_effect=RuntimeError("github down")),
+    )
+
+    await bot._cmd_abandon(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    cancel.assert_not_awaited()
+    assert "Nothing abandoned" in slack.said
+
+
+async def test_concurrent_hotfixes_for_one_app_cannot_both_be_requested(
+    repos, slack, hotfix_api
+):
+    """Without the per-app lock both read "nothing pending" before either writes."""
+    pending: list[str] = []
+
+    async def _request(_repo, sha):
+        await asyncio.sleep(0)  # where a racing command could slip in
+        pending.append(sha)
+
+    hotfix_api.resolve_commit.side_effect = lambda _repo, ref: ref[0] * 40
+    hotfix_api.pending_hotfix_requests.side_effect = lambda _repo: list(pending)
+    hotfix_api.request_hotfix.side_effect = _request
+
+    await asyncio.gather(
+        bot._cmd_hotfix(
+            repos, slack.ack, slack.respond, _command("my-app aaaaaaa"), {}
+        ),
+        bot._cmd_hotfix(
+            repos, slack.ack, slack.respond, _command("my-app bbbbbbb"), {}
+        ),
+    )
+
+    assert pending == ["a" * 40]
+    assert "`aaaaaaa` is already pending" in slack.said

--- a/tests/ol_infrastructure/applications/release_bot/test_bot.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_bot.py
@@ -76,6 +76,14 @@ def _record_trigger(calls: list[tuple[str, str, str]]):
     return _trigger
 
 
+@pytest.fixture(autouse=True)
+def _no_pending_hotfix(monkeypatch):
+    """Default to no pending hotfix, since one changes what /doof release does."""
+    monkeypatch.setattr(
+        bot.github, "pending_hotfix_requests", AsyncMock(return_value=[])
+    )
+
+
 # ---------------------------------------------------------------------------
 # /doof release
 # ---------------------------------------------------------------------------
@@ -1372,3 +1380,170 @@ async def test_startup_channel_check_still_covers_legacy_apps(mixed_repos, monke
 
     checked.assert_awaited_once()
     assert list(checked.await_args_list[0].args[1]) == ["my-app", "legacy-app"]
+
+
+# ---------------------------------------------------------------------------
+# /doof hotfix, and what a pending request does to release and abandon
+# ---------------------------------------------------------------------------
+
+_SHA = "a" * 40
+_OTHER_SHA = "b" * 40
+
+
+@pytest.fixture
+def hotfix_api(monkeypatch):
+    """Stub every GitHub and Concourse call /doof hotfix makes, in call order."""
+    api = MagicMock()
+    api.calls = []
+    api.resolve_commit = AsyncMock(return_value=_SHA)
+    api.in_flight_release = AsyncMock(return_value=None)
+    api.pending_hotfix_requests = AsyncMock(return_value=[])
+    api.request_hotfix = AsyncMock(
+        side_effect=lambda repo, sha: api.calls.append(("request", repo, sha))
+    )
+    api.check_resource = AsyncMock(
+        side_effect=lambda p, r: api.calls.append(("check", p, r))
+    )
+    api.trigger_job = AsyncMock(side_effect=_record_trigger(api.calls))
+    for name in (
+        "resolve_commit",
+        "in_flight_release",
+        "pending_hotfix_requests",
+        "request_hotfix",
+    ):
+        monkeypatch.setattr(bot.github, name, getattr(api, name))
+    for name in ("check_resource", "trigger_job"):
+        monkeypatch.setattr(bot.concourse, name, getattr(api, name))
+    return api
+
+
+async def test_hotfix_requests_then_checks_then_triggers(repos, slack, hotfix_api):
+    """The request has to exist before the check, or check offers a release."""
+    await bot._cmd_hotfix(
+        repos,
+        slack.ack,
+        slack.respond,
+        _command("my-app aaaaaaa"),
+        {"user_id": "UDANA"},
+    )
+
+    hotfix_api.resolve_commit.assert_awaited_once_with("mitodl/my-app", "aaaaaaa")
+    assert hotfix_api.calls == [
+        ("request", "mitodl/my-app", _SHA),
+        ("check", "my-app-pipeline", "my-app-release"),
+        ("trigger", "my-app-pipeline", "build-my-app-release-image"),
+    ]
+    assert "Hotfix of `aaaaaaa` triggered" in slack.said
+    assert bot._release_requesters["my-app"] == "UDANA"
+
+
+async def test_hotfix_rejects_something_that_is_not_a_sha(repos, slack, hotfix_api):
+    await bot._cmd_hotfix(repos, slack.ack, slack.respond, _command("my-app main"), {})
+
+    assert slack.said.startswith("Usage:")
+    assert hotfix_api.calls == []
+
+
+async def test_hotfix_refuses_while_a_release_is_in_flight(repos, slack, hotfix_api):
+    """The release resource refuses too, but only once a build is running."""
+    hotfix_api.in_flight_release.return_value = _in_flight(
+        "2026.9.9.1", timedelta(days=1)
+    )
+
+    await bot._cmd_hotfix(
+        repos, slack.ack, slack.respond, _command(f"my-app {_SHA}"), {}
+    )
+
+    assert "is in flight" in slack.said
+    assert hotfix_api.calls == []
+
+
+async def test_hotfix_refuses_while_another_hotfix_is_pending(repos, slack, hotfix_api):
+    hotfix_api.pending_hotfix_requests.return_value = [_OTHER_SHA]
+
+    await bot._cmd_hotfix(
+        repos, slack.ack, slack.respond, _command(f"my-app {_SHA}"), {}
+    )
+
+    assert "`bbbbbbb` is already pending" in slack.said
+    assert hotfix_api.calls == []
+
+
+async def test_hotfix_reuses_its_own_pending_request(repos, slack, hotfix_api):
+    """Re-running after a failed trigger must not trip over its own tag."""
+    hotfix_api.pending_hotfix_requests.return_value = [_SHA]
+
+    await bot._cmd_hotfix(
+        repos, slack.ack, slack.respond, _command(f"my-app {_SHA}"), {}
+    )
+
+    assert hotfix_api.calls == [
+        ("check", "my-app-pipeline", "my-app-release"),
+        ("trigger", "my-app-pipeline", "build-my-app-release-image"),
+    ]
+
+
+async def test_hotfix_says_how_to_retry_when_the_trigger_fails(
+    repos, slack, hotfix_api
+):
+    hotfix_api.trigger_job.side_effect = RuntimeError("boom")
+
+    await bot._cmd_hotfix(
+        repos, slack.ack, slack.respond, _command(f"my-app {_SHA}"), {}
+    )
+
+    assert "requested but not started" in slack.said
+
+
+async def test_release_refuses_while_a_hotfix_is_pending(repos, slack, monkeypatch):
+    """The build would cut the pending hotfix, not the release asked for."""
+    trigger = AsyncMock()
+    monkeypatch.setattr(
+        bot.github, "pending_hotfix_requests", AsyncMock(return_value=[_SHA])
+    )
+    monkeypatch.setattr(bot.concourse, "trigger_job", trigger)
+
+    await bot._cmd_release(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    trigger.assert_not_called()
+    assert "would cut that hotfix instead" in slack.said
+
+
+async def test_abandon_with_nothing_in_flight_only_cancels_requests(
+    repos, slack, monkeypatch
+):
+    """With nothing in flight, the abandon job can delete production's tag."""
+    trigger = AsyncMock()
+    monkeypatch.setattr(
+        bot.github, "cancel_hotfix_requests", AsyncMock(return_value=[_SHA])
+    )
+    monkeypatch.setattr(bot.github, "in_flight_release", AsyncMock(return_value=None))
+    monkeypatch.setattr(bot.concourse, "trigger_job", trigger)
+
+    await bot._cmd_abandon(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    trigger.assert_not_called()
+    assert "Cancelled the pending hotfix of `aaaaaaa`" in slack.said
+    assert "nothing to abandon" in slack.said
+
+
+async def test_abandon_triggers_the_job_for_an_in_flight_release(
+    repos, slack, monkeypatch
+):
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        bot.github, "cancel_hotfix_requests", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        bot.github,
+        "in_flight_release",
+        AsyncMock(return_value=_in_flight("2026.9.9.1", timedelta(days=1))),
+    )
+    monkeypatch.setattr(
+        bot.concourse, "trigger_job", AsyncMock(side_effect=_record_trigger(calls))
+    )
+
+    await bot._cmd_abandon(repos, slack.ack, slack.respond, _command("my-app"), {})
+
+    assert calls == [("trigger", "my-app-pipeline", "abandon-my-app-release")]
+    assert "Abandoning" in slack.said

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -548,6 +548,57 @@ def test_commits_since_last_tag_keeps_lookalike_subjects(fake_repo):
 
 
 # ---------------------------------------------------------------------------
+# Hotfix requests
+# ---------------------------------------------------------------------------
+
+
+class _FakeRef:
+    def __init__(self, repo, ref):
+        self._repo = repo
+        self.ref = ref
+
+    def delete(self):
+        self._repo.refs.remove(self)
+
+
+class _RefsRepo:
+    """Just the git-refs slice of the API that hotfix requests use."""
+
+    def __init__(self, *names):
+        self.refs = [_FakeRef(self, name) for name in names]
+
+    def get_git_matching_refs(self, ref):
+        return [r for r in self.refs if r.ref.startswith(f"refs/{ref}")]
+
+    def create_git_ref(self, ref, sha):
+        assert ref == f"refs/tags/hotfix/{sha}"
+        self.refs.append(_FakeRef(self, ref))
+
+
+_HOTFIX_SHA = "a" * 40
+
+
+def test_pending_hotfix_requests_lists_the_requested_shas(fake_repo):
+    fake_repo(_RefsRepo(f"refs/tags/hotfix/{_HOTFIX_SHA}", "refs/tags/2026.9.1.1"))
+    assert github._pending_hotfix_requests_sync("mitodl/thing") == [_HOTFIX_SHA]
+
+
+def test_request_hotfix_names_the_tag_after_the_full_sha(fake_repo):
+    """The release resource deletes a request by exactly this name."""
+    repo = fake_repo(_RefsRepo())
+    github._request_hotfix_sync("mitodl/thing", _HOTFIX_SHA)
+    assert [r.ref for r in repo.refs] == [f"refs/tags/hotfix/{_HOTFIX_SHA}"]
+
+
+def test_cancel_hotfix_requests_deletes_only_requests(fake_repo):
+    repo = fake_repo(
+        _RefsRepo(f"refs/tags/hotfix/{_HOTFIX_SHA}", "refs/tags/2026.9.1.1")
+    )
+    assert github._cancel_hotfix_requests_sync("mitodl/thing") == [_HOTFIX_SHA]
+    assert [r.ref for r in repo.refs] == ["refs/tags/2026.9.1.1"]
+
+
+# ---------------------------------------------------------------------------
 # In-flight release detection
 # ---------------------------------------------------------------------------
 

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -598,6 +598,16 @@ def test_cancel_hotfix_requests_deletes_only_requests(fake_repo):
     assert [r.ref for r in repo.refs] == ["refs/tags/2026.9.1.1"]
 
 
+def test_hotfix_tags_not_named_for_a_full_sha_are_not_requests(fake_repo):
+    """The release resource ignores these, so they must not block releases here."""
+    repo = fake_repo(
+        _RefsRepo("refs/tags/hotfix/test", f"refs/tags/hotfix/{_HOTFIX_SHA[:7]}")
+    )
+    assert github._pending_hotfix_requests_sync("mitodl/thing") == []
+    assert github._cancel_hotfix_requests_sync("mitodl/thing") == []
+    assert len(repo.refs) == 2
+
+
 # ---------------------------------------------------------------------------
 # In-flight release detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/7185. Depends on https://github.com/mitodl/ol-concourse/pull/102.

### Description (What does it do?)
Doof had `hotfix <sha>`; the new bot never did. This adds `/doof hotfix <app> <sha>`, which cuts what production runs plus that one commit, through the existing release job.

**How the SHA gets to the job.** Triggering a Concourse job carries no parameters, so the bot pushes a `hotfix/<full sha>` tag. The release resource's `check` then offers the next version as a hotfix (ol-concourse#102), and the job cuts it.

**Bot**
- `/doof hotfix <app> <sha>`:
  - resolves the SHA through the GitHub API
  - refuses while a release is in flight or a different hotfix is pending
  - creates the request tag, reusing it if the same SHA is already pending so a failed trigger can simply be re-run
  - checks the release resource and triggers `build-<app>-release-image`
- `/doof release` refuses while a hotfix request is pending, since the build would cut the hotfix instead.
- `/doof abandon` cancels pending hotfix requests, and now **refuses when nothing is in flight**. The abandon job deletes the branch and tag of whatever version the release resource last reported. With nothing in flight and no new commits, `check` reports the latest release tag: the release production is running, whose tag is the only record of what it runs. The bot previously triggered the job in that state anyway.

**Pipeline** (`_build_release_image_job`, release-resource apps only)
- `load_var`s the release resource's new `hotfix` file and passes it as `commit_hash`. It is empty for a normal release.
- Builds the image from a new `checkout-release` task that fetches `releases/<version>`, instead of from `main_repo`. A hotfix's code is not in `main_repo`. Concourse does not document a `put` writing back to its inputs, so the build cannot rely on the put's checkout either.
  - For a normal release, the branch holds the same tree the bumped `main_repo` does. The exception is when main moves between the job's `get` and the `put`; the branch is then what was actually tagged, which is also what the image should be.
- `git_ref` is now the commit the version tag points at, read from that checkout: the same commit as before for a normal release, the cherry-picked commit for a hotfix.

### How can this be tested?
Generated pipelines, compared with main's generator:
- `ol-analytics-api` (the only release-resource app): the diff is only the release job. The `hotfix` `load_var`, `commit_hash: ((.:hotfix))`, the `checkout-release` task, `git_ref` from `release-source`, and build inputs switched to `release-source`.
- `mitxonline` (legacy pipeline): byte-identical.

`tests/ol_infrastructure/applications/release_bot` passes (150 tests). New ones cover:
- `/doof hotfix`: request, check, trigger order; refusal while a release is in flight or another hotfix is pending; reuse of its own pending request; the retry hint when the trigger fails
- `/doof release` refusing while a hotfix is pending
- both `/doof abandon` paths
- the `github_client` request helpers

An autouse fixture stubs the pending-hotfix lookup. The four existing `/doof release` tests needed it once `release` started checking for a pending request.

`pre-commit` (ruff, mypy) passes on all three files.

Not verified:
- Whether org rulesets allow the ol-release-bot App to create `hotfix/*` tags. It already pushes `releases/*` branches and calver tags with the same credentials.
- No end-to-end run in Concourse yet. The first real hotfix on ol-analytics-api is the proof.

### Checklist:
- [x] ol-concourse#102 merged and `mitodl/concourse-release-resource` rebuilt. Done 2026-09-10: `build-and-publish-release-image` build 30 pushed `latest` = `7a7d126` (`sha256:f6cfee68…`), and the image's `/opt/resource/concourse.py` is byte-identical to the merged source. Merging this first breaks ol-analytics-api releases: the job's new `load_var` would read a `hotfix` file the current resource image does not write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAC3Cb2tbKe5bUrp8zRcgR

