### PR TITLE
feat(clickhouse): daily SQL BACKUP to a dedicated versioned S3 bucket

### DIFF
--- a/docs/clickhouse-llmops-runbook.md
+++ b/docs/clickhouse-llmops-runbook.md
@@ -250,29 +250,51 @@ histogram_quantile(0.99, rate(clickhouse_query_duration_milliseconds_bucket[5m])
 
 ## Backup and Restore
 
-### Cold S3 data (automatic)
+There are two recovery layers. Neither covers the other's case.
 
-Data moved to `cold_s3` disk is stored in S3 (`ol-data-clickhouse-cold-<env>`).
-S3 Intelligent-Tiering provides durability (11 nines). No separate backup needed
-for cold data.
+| Layer | What | Schedule / retention | Use it for |
+|---|---|---|---|
+| AWS Backup | EBS snapshot of every CH and Keeper PVC (`<cluster>-eks-backup-plan`, `infrastructure/aws/eks/aws_backup.py`) | Daily 05:00 UTC, 14 days | A lost or corrupted PVC. Crash-consistent and per volume, not coordinated across replicas. |
+| SQL `BACKUP` | `clickhouse-backup` CronJob: every database except `system` / `INFORMATION_SCHEMA`, to `s3://ol-data-clickhouse-backup-<env>/backups/<UTC timestamp>/` | Daily 03:30 UTC, 14 days (`clickhouse:backup_retention_days`); overwritten or deleted objects kept 7 more days as noncurrent versions | Restoring tables or whole databases, into this cluster or another one at the same or a newer server version. |
 
-### Hot data snapshot
+The SQL backup runs on replica 0 (`chi-clickhouse-default-0-0`) because Opik's
+Liquibase ledger (`default.DATABASECHANGELOG*`) exists only there. The target is
+the `backups` disk (`s3_plain`), the only disk `backups.allowed_disk` permits.
+The cold-tier bucket is not a backup: once tiering is active it holds live
+parts.
 
-ClickHouse's built-in `BACKUP` command can snapshot hot data to the cold S3 bucket:
+### Check the latest backup
 
-```sql
-BACKUP DATABASE tensorzero_db
-TO S3('https://ol-data-clickhouse-cold-production.s3.amazonaws.com/backups/tensorzero_db/', '<irsa-credentials-auto-provided>')
-SETTINGS compression_method='lz4';
+```bash
+kubectl -n clickhouse get jobs -l app.kubernetes.io/name=clickhouse-backup
+kubectl -n clickhouse logs job/<job-name>
+aws s3 ls s3://ol-data-clickhouse-backup-<env>/backups/
 ```
 
-### Restore from backup
+`system.backups` only lists runs since that server last restarted, and only on
+the server that ran them.
+
+### Restore
+
+Restore a single table next to the live one, then compare or swap:
 
 ```sql
-RESTORE DATABASE tensorzero_db
-FROM S3('https://ol-data-clickhouse-cold-production.s3.amazonaws.com/backups/tensorzero_db/')
-SETTINGS allow_non_empty_tables=true;
+RESTORE TABLE opik_db.spans AS opik_db.spans_restored
+FROM Disk('backups', '<UTC timestamp>');
 ```
+
+Restore a whole database into a cluster where it does not exist yet:
+
+```sql
+RESTORE DATABASE opik_db FROM Disk('backups', '<UTC timestamp>');
+RESTORE TABLE default.DATABASECHANGELOG, TABLE default.DATABASECHANGELOGLOCK
+FROM Disk('backups', '<UTC timestamp>');
+```
+
+Run the restore on replica 0. Replicated tables are recreated under their
+original ZooKeeper paths, so restore a whole database only into a cluster that
+does not already have those tables; for the live cluster, restore under a new
+table name as above.
 
 ---
 

--- a/docs/clickhouse-llmops-runbook.md
+++ b/docs/clickhouse-llmops-runbook.md
@@ -276,14 +276,19 @@ the server that ran them.
 
 ### Restore
 
-Restore a single table next to the live one, then compare or swap:
+**Never restore into the cluster the backup came from while its tables still
+exist, not even under a new table name.** Opik's replicated tables hardcode
+their Keeper path in the engine definition, e.g.
+`ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/opik_db/spans',
+'{replica}', ...)`. `RESTORE ... AS opik_db.spans_restored` keeps that
+definition, so the restored table registers under the live table's Keeper path
+and replica name instead of becoming an independent copy.
 
-```sql
-RESTORE TABLE opik_db.spans AS opik_db.spans_restored
-FROM Disk('backups', '<UTC timestamp>');
-```
-
-Restore a whole database into a cluster where it does not exist yet:
+Restore into a cluster with its own Keeper ensemble instead: a scratch
+ClickHouseInstallation and ClickHouseKeeperInstallation, or a rebuilt cluster
+after a total loss. Its IRSA role needs read access to the source environment's
+backup bucket, and its `backups` disk must point at that bucket. Run the
+restore on replica 0 of the target:
 
 ```sql
 RESTORE DATABASE opik_db FROM Disk('backups', '<UTC timestamp>');
@@ -291,10 +296,9 @@ RESTORE TABLE default.DATABASECHANGELOG, TABLE default.DATABASECHANGELOGLOCK
 FROM Disk('backups', '<UTC timestamp>');
 ```
 
-Run the restore on replica 0. Replicated tables are recreated under their
-original ZooKeeper paths, so restore a whole database only into a cluster that
-does not already have those tables; for the live cluster, restore under a new
-table name as above.
+To recover individual rows into the live cluster, restore into the scratch
+cluster first, then copy across with `INSERT INTO opik_db.<table> SELECT ...
+FROM remote('<scratch host>', opik_db.<table>, ...)`.
 
 ---
 

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -346,6 +346,7 @@ def _create_clickhouse_installation(  # noqa: PLR0913
     storage_class: str,
     hot_storage_size: str,
     cold_bucket_name: "Output[str]",
+    backup_bucket_name: "Output[str]",
     users_secret_name: str,
     irsa_role_arn: "Output[str]",
     keeper_installation: "Output[kubernetes.apiextensions.CustomResource]",
@@ -355,7 +356,8 @@ def _create_clickhouse_installation(  # noqa: PLR0913
     """Build the ClickHouseInstallation CRD and return it wrapped in an Output.
 
     Uses ``Output.all().apply()`` because the storage configuration XML must be
-    resolved from the cold-storage bucket name, which is an ``Output[str]``.
+    resolved from the cold-storage and backup bucket names, which are
+    ``Output[str]``.
     """
     ch_tolerations = (
         [
@@ -428,8 +430,8 @@ def _create_clickhouse_installation(  # noqa: PLR0913
         )
     )
 
-    storage_config_xml = cold_bucket_name.apply(
-        lambda bucket: dedent(f"""\
+    storage_config_xml = Output.all(cold_bucket_name, backup_bucket_name).apply(
+        lambda buckets: dedent(f"""\
             <clickhouse>
               <storage_configuration>
                 <disks>
@@ -440,10 +442,23 @@ def _create_clickhouse_installation(  # noqa: PLR0913
                        UNKNOWN_ELEMENT_IN_CONFIG ("cannot be equal to <path>"). -->
                   <cold_s3>
                     <type>s3</type>
-                    <endpoint>https://{bucket}.s3.amazonaws.com/data/</endpoint>
+                    <endpoint>https://{buckets[0]}.s3.amazonaws.com/data/</endpoint>
                     <use_environment_credentials>true</use_environment_credentials>
                     <metadata_path>/var/lib/clickhouse/disks/cold_s3/</metadata_path>
                   </cold_s3>
+                  <!-- Destination for BACKUP ... TO Disk('backups', ...).
+                       s3_plain rather than s3: an s3 disk keeps its object
+                       metadata on the local PVC, so a backup written through
+                       one could only be read back from the replica that wrote
+                       it. s3_plain stores files under their real names, which
+                       is what lets a different cluster or a rebuilt replica
+                       read the backup. Not referenced by any storage policy,
+                       so no table data lands here. -->
+                  <backups>
+                    <type>s3_plain</type>
+                    <endpoint>https://{buckets[1]}.s3.amazonaws.com/backups/</endpoint>
+                    <use_environment_credentials>true</use_environment_credentials>
+                  </backups>
                 </disks>
                 <policies>
                   <tiered>
@@ -459,6 +474,12 @@ def _create_clickhouse_installation(  # noqa: PLR0913
                   </tiered>
                 </policies>
               </storage_configuration>
+              <!-- Without this, Disk() is refused outright as a BACKUP target
+                   (Code 318, "'backups.allowed_disk' configuration parameter is
+                   not set"). -->
+              <backups>
+                <allowed_disk>backups</allowed_disk>
+              </backups>
             </clickhouse>
         """)
     )
@@ -688,12 +709,59 @@ export("cold_bucket_name", cold_bucket.bucket_v2.bucket)
 export("cold_bucket_arn", cold_bucket.bucket_v2.arn)
 
 ############################################################
+# S3 Backup Bucket
+#
+# Destination of the daily SQL BACKUP (see the CronJob below). Kept apart from
+# the cold-tier bucket: once tiering is activated that bucket holds live parts,
+# and a backup sharing a bucket with the data it protects shares its failure
+# modes (a bad lifecycle rule, a mistaken delete) too.
+#
+# ClickHouse's own IRSA role writes here, so it can also delete. Versioning is
+# what makes a backup deleted or overwritten through that role recoverable for
+# a week afterwards. Each run is a full backup (no base_backup chain), so
+# expiring by object age never strands a backup that a newer one depends on.
+############################################################
+backup_retention_days = int(clickhouse_config.get("backup_retention_days") or "14")
+backup_bucket_name = f"ol-data-clickhouse-backup-{stack_info.env_suffix}"
+
+backup_bucket = OLBucket(
+    f"clickhouse-backup-{stack_info.env_suffix}",
+    S3BucketConfig(
+        bucket_name=backup_bucket_name,
+        tags=aws_config.tags,
+        versioning_enabled=True,
+        server_side_encryption_enabled=True,
+        sse_algorithm="AES256",
+        # Objects live two weeks; Intelligent-Tiering's 30-day monitoring
+        # window never pays back on them.
+        intelligent_tiering_enabled=False,
+        noncurrent_version_expiration_days=7,
+        lifecycle_rules=[
+            aws.s3.BucketLifecycleConfigurationRuleArgs(
+                id="expire-backups",
+                status="Enabled",
+                filter=aws.s3.BucketLifecycleConfigurationRuleFilterArgs(
+                    prefix="backups/"
+                ),
+                expiration=aws.s3.BucketLifecycleConfigurationRuleExpirationArgs(
+                    days=backup_retention_days
+                ),
+            )
+        ],
+    ),
+)
+
+export("backup_bucket_name", backup_bucket.bucket_v2.bucket)
+export("backup_bucket_arn", backup_bucket.bucket_v2.arn)
+
+############################################################
 # IRSA + Vault Auth Binding for ClickHouse
 ############################################################
 
 # Build the IAM policy JSON as an Output to resolve bucket ARN values
 clickhouse_s3_policy_json: Output[str] = Output.all(
     bucket_arn=cold_bucket.bucket_v2.arn,
+    backup_bucket_arn=backup_bucket.bucket_v2.arn,
 ).apply(
     lambda args: json.dumps(
         {
@@ -713,6 +781,8 @@ clickhouse_s3_policy_json: Output[str] = Output.all(
                     "Resource": [
                         args["bucket_arn"],
                         f"{args['bucket_arn']}/*",
+                        args["backup_bucket_arn"],
+                        f"{args['backup_bucket_arn']}/*",
                     ],
                 },
             ],
@@ -852,6 +922,7 @@ clickhouse_installation = _create_clickhouse_installation(
     storage_class=storage_class,
     hot_storage_size=hot_storage_size,
     cold_bucket_name=cold_bucket.bucket_v2.bucket,
+    backup_bucket_name=backup_bucket.bucket_v2.bucket,
     users_secret_name=users_secret_name,
     irsa_role_arn=clickhouse_app.irsa_role.arn,
     keeper_installation=keeper_installation,
@@ -871,6 +942,147 @@ clickhouse_installation = _create_clickhouse_installation(
 #
 # Required databases: opik_db
 ############################################################
+
+############################################################
+# Daily SQL backup
+#
+# Two recovery layers exist, and this is the second:
+#   1. AWS Backup (infrastructure/aws/eks/aws_backup.py) snapshots every CH and
+#      Keeper EBS volume daily at 05:00 UTC, kept 14 days. Crash-consistent and
+#      per volume, uncoordinated across replicas: good for "a PVC died", not
+#      for restoring into another cluster or across a server version.
+#   2. This job: BACKUP of every non-system database to the backup bucket via
+#      the s3_plain ``backups`` disk. Application-consistent per table and
+#      readable by any ClickHouse at the same or a newer version.
+#
+# Runs against replica 0 by name, not the load-balanced service. With one
+# shard every replica holds the same replicated data, but Opik's Liquibase
+# ledger (default.DATABASECHANGELOG*) has rows only on replica 0, where
+# migrations are pinned (CLICKHOUSE_MIGRATIONS_HOST in applications/opik).
+# Replicas 1 and 2 carry empty tables of the same name. A restore without the
+# ledger would replay every migration against existing tables.
+#
+# ASYNC plus polling rather than a synchronous BACKUP: the statement's outcome
+# lives in system.backups on the server, so the job exits non-zero on
+# BACKUP_FAILED instead of depending on how long the client connection survives
+# a multi-minute query. system.backups is in-memory per server, which is why
+# every query here targets the same host.
+############################################################
+BACKUP_HOST = f"chi-clickhouse-default-0-0.{CLICKHOUSE_NAMESPACE}.svc.cluster.local"
+BACKUP_SCRIPT = """\
+set -eu
+ch() {
+    clickhouse-client --host "${CLICKHOUSE_HOST}" --user admin \\
+        --password "${CLICKHOUSE_PASSWORD}" "$@"
+}
+name="$(date -u +%Y%m%dT%H%M%SZ)"
+id="$(ch --query "BACKUP ALL EXCEPT DATABASES system, INFORMATION_SCHEMA, information_schema TO Disk('backups', '${name}') ASYNC" | cut -f1)"
+echo "backup ${name} started as ${id}"
+while :; do
+    status="$(ch --param_id="${id}" --query "SELECT status FROM system.backups WHERE id = {id:String}")"
+    case "${status}" in
+        BACKUP_CREATED) break ;;
+        CREATING_BACKUP) sleep 30 ;;
+        *)
+            ch --param_id="${id}" --query "SELECT status, error FROM system.backups WHERE id = {id:String} FORMAT Vertical" >&2
+            exit 1
+            ;;
+    esac
+done
+ch --param_id="${id}" --query "SELECT name, num_files, formatReadableSize(total_size) AS size, end_time - start_time AS seconds FROM system.backups WHERE id = {id:String} FORMAT Vertical"
+"""
+
+backup_credentials_secret_name = (
+    "clickhouse-backup-credentials"  # pragma: allowlist secret  # noqa: S105
+)
+backup_credentials_secret = OLVaultK8SSecret(
+    f"clickhouse-backup-credentials-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        name="clickhouse-backup-credentials",
+        namespace=CLICKHOUSE_NAMESPACE,
+        labels=k8s_global_labels,
+        dest_secret_labels=k8s_global_labels,
+        dest_secret_name=backup_credentials_secret_name,
+        dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
+        mount=clickhouse_vault_kv_path,
+        mount_type="kv-v2",
+        path="credentials",
+        templates={"CLICKHOUSE_PASSWORD": '{{- get .Secrets "admin" -}}'},
+        refresh_after="1h",
+        vaultauth=clickhouse_app.vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=clickhouse_app.vault_k8s_resources,
+    ),
+)
+
+clickhouse_backup_cron_job = kubernetes.batch.v1.CronJob(
+    f"clickhouse-backup-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="clickhouse-backup",
+        namespace=CLICKHOUSE_NAMESPACE,
+        labels=k8s_global_labels,
+    ),
+    spec=kubernetes.batch.v1.CronJobSpecArgs(
+        # 90 minutes ahead of the 05:00 UTC AWS Backup snapshot, so a bad night
+        # for one layer is not also the same moment for the other.
+        schedule=clickhouse_config.get("backup_schedule") or "30 3 * * *",
+        concurrency_policy="Forbid",
+        starting_deadline_seconds=3600,
+        successful_jobs_history_limit=3,
+        failed_jobs_history_limit=3,
+        job_template=kubernetes.batch.v1.JobTemplateSpecArgs(
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+            spec=kubernetes.batch.v1.JobSpecArgs(
+                # No retry: the server keeps running an ASYNC backup after the
+                # client pod dies, so a retry could start a second one beside
+                # it. The next night is the retry, and a failed Job alerts now.
+                backoff_limit=0,
+                active_deadline_seconds=7200,
+                template=kubernetes.core.v1.PodTemplateSpecArgs(
+                    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                        labels={
+                            **k8s_global_labels,
+                            "app.kubernetes.io/name": "clickhouse-backup",
+                        },
+                    ),
+                    spec=kubernetes.core.v1.PodSpecArgs(
+                        restart_policy="Never",
+                        containers=[
+                            kubernetes.core.v1.ContainerArgs(
+                                name="backup",
+                                # Same image as the server, for a client that
+                                # speaks exactly the server's protocol version.
+                                image=ch_image,
+                                command=["/bin/sh", "-c", BACKUP_SCRIPT],
+                                env=[
+                                    kubernetes.core.v1.EnvVarArgs(
+                                        name="CLICKHOUSE_HOST", value=BACKUP_HOST
+                                    ),
+                                ],
+                                env_from=[
+                                    kubernetes.core.v1.EnvFromSourceArgs(
+                                        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                                            name=backup_credentials_secret_name
+                                        )
+                                    )
+                                ],
+                                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                    requests={"cpu": "50m", "memory": "64Mi"},
+                                    limits={"cpu": "200m", "memory": "256Mi"},
+                                ),
+                            )
+                        ],
+                    ),
+                ),
+            ),
+        ),
+    ),
+    opts=ResourceOptions(
+        depends_on=[clickhouse_installation, backup_credentials_secret],
+    ),
+)
 
 ############################################################
 # Networking — ClusterIP Service + NetworkPolicy

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -1033,7 +1033,15 @@ clickhouse_backup_cron_job = kubernetes.batch.v1.CronJob(
         successful_jobs_history_limit=3,
         failed_jobs_history_limit=3,
         job_template=kubernetes.batch.v1.JobTemplateSpecArgs(
-            metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+            # On the Job as well as its pods, so `kubectl get jobs -l
+            # app.kubernetes.io/name=clickhouse-backup` (the runbook's check)
+            # finds the runs.
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                labels={
+                    **k8s_global_labels,
+                    "app.kubernetes.io/name": "clickhouse-backup",
+                },
+            ),
             spec=kubernetes.batch.v1.JobSpecArgs(
                 # No retry: the server keeps running an ASYNC backup after the
                 # client pod dies, so a retry could start a second one beside


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Step 1 of the ClickHouse production-readiness work for shared Opik.

### Description (What does it do?)
Adds an application-level backup for the ClickHouse cluster behind Opik. After this there are two recovery layers:

| Layer | Covers | Doesn't cover |
|---|---|---|
| AWS Backup (existing): daily 05:00 UTC EBS snapshots of all six prod CH/Keeper volumes, 14 days | A lost or corrupted PVC | Restoring into another cluster or across a server version. Snapshots are crash-consistent per volume and not coordinated across replicas. |
| SQL `BACKUP` (this PR): daily 03:30 UTC, every database except `system`/`INFORMATION_SCHEMA` | Table or database restore into this or another cluster | Nothing below the table level |

- New bucket `ol-data-clickhouse-backup-<env>`, kept separate from the cold tier because that bucket will hold live parts once tiering is activated. Versioned, 14-day expiry on `backups/` (`clickhouse:backup_retention_days`), 7-day noncurrent retention, so a backup deleted through ClickHouse's own role can still be recovered.
- `backups` disk of type `s3_plain` plus `backups.allowed_disk`. `s3_plain` because a regular `s3` disk keeps its metadata on the local PVC, which would make a backup readable only from the replica that wrote it.
- `clickhouse-backup` CronJob. It runs `BACKUP ... ASYNC` on replica 0 and polls `system.backups`, so `BACKUP_FAILED` fails the Job. It runs on replica 0 because Opik's Liquibase ledger has rows only there: 154 changesets on replica 0, empty tables on replicas 1 and 2 (checked in prod).
- The runbook's backup section pointed `BACKUP` at the cold bucket and at `tensorzero_db`, which no longer exists. Replaced it with the two layers and restore syntax.

### How can this be tested?
- `pulumi preview` for CI and Production: 11 creates, 3 updates (IAM policy, CHI spec, provider kubeconfig), no other drift.
- The `BACKUP ALL EXCEPT DATABASES system, INFORMATION_SCHEMA, information_schema ... ASYNC` statement parses on 24.8. On data-ci it failed at execution with Code 318 (`backups.allowed_disk` not set), which is why this PR sets it. That run wrote nothing (`num_files 0`).
- `sh -n` and shellcheck pass on the embedded script.
- After deploy: `kubectl -n clickhouse create job --from=cronjob/clickhouse-backup backup-manual`, then check the job log and `aws s3 ls s3://ol-data-clickhouse-backup-<env>/backups/`.

### Additional Context
- **The CHI change rolls every replica.** The operator's default `configurationRestartPolicy` has `files/config.d/*.xml: "yes"`, so each ClickHouse pod restarts in turn when this reaches an environment.
- **Restore drill:** not done yet. It needs a deployed backup first. Open question: restoring prod into QA means giving QA's role read access to prod backups. A scratch CHI in data-production avoids that.
- A failed run already alerts through the existing `WorkloadJobFailed*` rules. A 26h staleness rule for `clickhouse-backup` comes with the observability PR.
- The job authenticates as `admin` through a VSO secret. A dedicated user with only `BACKUP` would be narrower. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVAx8W2aXR7CCYUkeFij9u
