### PR TITLE
feat(witan): thread WITAN_OIDC_RESOURCE_URL to the serving tier

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -908,6 +908,7 @@ witan_serving_tier = create_serving_tier(
     council_graph_id=council_graph_id,
     oidc_issuer=KEYCLOAK_ISSUER,
     oidc_audience=WITAN_OIDC_AUDIENCE,
+    oidc_resource_url=f"https://{WITAN_DOMAIN}",
     actor_tokens_secret_name=ACTOR_TOKENS_SECRET_NAME,
     actor_tokens_secret=actor_tokens_secret,
     witan_ci_token_secret_name=WITAN_CI_TOKEN_SECRET_NAME,

--- a/src/ol_infrastructure/applications/witan/deployment.py
+++ b/src/ol_infrastructure/applications/witan/deployment.py
@@ -495,6 +495,7 @@ def create_serving_tier(  # noqa: PLR0913
     council_graph_id: str | Output[str],
     oidc_issuer: str,
     oidc_audience: str,
+    oidc_resource_url: str,
     actor_tokens_secret_name: str,
     actor_tokens_secret: Resource,
     witan_ci_token_secret_name: str,
@@ -686,6 +687,18 @@ def create_serving_tier(  # noqa: PLR0913
                                 ),
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="WITAN_OIDC_AUDIENCE", value=oidc_audience
+                                ),
+                                # witan's own public base URL (no path), so the
+                                # RemoteAuthProvider it builds from these can
+                                # advertise RFC 9728 protected-resource
+                                # metadata and a WWW-Authenticate header
+                                # pointing an MCP client at oidc_issuer's real
+                                # authorization endpoint, instead of the
+                                # client guessing one on witan's own origin
+                                # (agent-kit ADR-0004, 2026-09-10 addendum).
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="WITAN_OIDC_RESOURCE_URL",
+                                    value=oidc_resource_url,
                                 ),
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="WITAN_ACTOR_TOKENS_FILE",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- witan is moving from a bare `JWTVerifier` to fastmcp's `RemoteAuthProvider` (companion agent-kit PR mitodl/agent-kit#336), which serves RFC 9728 protected-resource metadata so an MCP client can discover Keycloak's real authorization endpoint instead of guessing one on witan's own origin and 404ing.
- `RemoteAuthProvider` needs witan's own public base URL to advertise. This threads it through as `WITAN_OIDC_RESOURCE_URL`, set to `https://<WITAN_DOMAIN>` per environment.

### How can this be tested?
- `ruff check` and `mypy` clean on the two changed files.
- `pulumi preview --stack CI` confirms the env var lands on the Deployment: `WITAN_OIDC_RESOURCE_URL=https://witan.ci.ol.mit.edu`.

### Additional Context
- Companion PR: mitodl/agent-kit#336 (the actual `RemoteAuthProvider` code change this env var supports).
- This env var is inert against the currently-deployed witan image; it takes effect once mitodl/agent-kit#336 merges and `pulumi-witan` rebuilds the image this stack picks up via `WITAN_DOCKER_SHA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUWMMQEie9uZdzCTSPo2s5