### PR TITLE
docs(rootly): correct the rule enabled-flag note from #5819

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -49,15 +49,15 @@ def rootly_imported_route_opts(route_id: str) -> ResourceOptions:
     Diff the preview before applying; the rule bodies were generated from
     `GET /v1/alert_routes` precisely so the declared state starts out matching.
 
-    Any change to a route's `rules` disables every rule on it. The provider
-    resends the whole list, Rootly destroys the existing rules and creates new
-    ones with `enabled=false`, and neither this SDK nor the upstream provider
-    (checked through v5.21.0) has a per-rule `enabled` field -- so Pulumi can
-    neither set it nor see the drift. That is how #5494's apply on 2026-08-18
-    turned off all ten rules on the Grafana Production Service Route. After an
-    apply that touches `rules`, re-enable them in Rootly and confirm with
-    `GET /v1/alert_routes` -> `.rules[].enabled`. Deleting a whole route does
-    not trigger this.
+    Any change to a route's `rules` resends the whole list, and Rootly destroys
+    the existing rules and creates new ones. The new rules read `enabled=false`
+    in `GET /v1/alert_routes`; neither this SDK nor the upstream provider
+    (checked at v5.21.0) has a per-rule `enabled` field. That flag does not stop
+    a rule matching under Advanced Alert Routing, and the Rootly UI has no
+    per-rule toggle. After #5494's apply recreated the Grafana Production
+    Service Route's rules on 2026-08-18, alerts from `mitxonline-openedx` that
+    day and `mitlearn` the next were still attributed to the services those
+    rules target. Don't read `enabled=false` on these routes as a dead rule.
 
     Safe to drop back to `rootly_opts` once every stack has applied this.
     """
@@ -3776,8 +3776,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
         # and they emit exactly the `service`/`ol_component` pair these two
         # match on. Before the move they matched nothing and MIT Learn - API
         # and MIT Learn - NextJS were among the Rootly services no rule
-        # targeted. The apply that added them also left every rule on this
-        # route disabled; see `rootly_imported_route_opts`.
+        # targeted.
         #
         # These sit ahead of the `namespace`-keyed rules below because
         # conditions are `contains` and the first match wins: a narrow rule


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Follow-up to #5819.

### Description (What does it do?)

#5819's note on `rootly_imported_route_opts` says a Pulumi `rules` change disables every rule on the route and that the rules need re-enabling in Rootly afterwards. The second half is wrong. The recreated rules read `enabled=false` in `GET /v1/alert_routes`, but that doesn't stop them matching. After #5494's apply recreated the Grafana Production Service Route's rules (2026-08-18 11:12 PT), a `mitxonline-openedx` alert at 11:58 PT that day and a `mitlearn` alert on 8/19 were both attributed to services that, for the alertmanager source, only that route targets. The Rootly UI has no per-rule toggle either.

This rewrites the note to say the flag isn't a gate, and drops the matching sentence from the Grafana Production Service Route's comment. Comments only, no resource changes.

### How can this be tested?

No infra effect. pre-commit (ruff, mypy) passed on this diff when it was first committed. The evidence is in Rootly alerts `geyc5Z` and `Lgn4Cc`, both created after the rules' `created_at`, and in the audit log entries for route `e7b002f8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaG3BbJchKyxygXaqpJj3L
