### PR TITLE
test(canaries): add MIT Learn HubSpot tracking script canary

### DIFF
--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/README.md
@@ -9,6 +9,7 @@
 | Spec | Journey | Status |
 |---|---|---|
 | `homepage.spec.ts` | Homepage renders in a real browser, anonymously | Active |
+| `hubspot-tracking.spec.ts` | HubSpot tracking script loads on the homepage, anonymously | Active |
 | `login-and-search.spec.ts` | Log in, reach the dashboard, then search for courses | Active |
 
 ## Helpers

--- a/src/ol_concourse/pipelines/canaries/specs/mit-learn/hubspot-tracking.spec.ts
+++ b/src/ol_concourse/pipelines/canaries/specs/mit-learn/hubspot-tracking.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test"
+
+// Presence, not the portal ID: the ID differs per environment (RC/QA vs
+// production), so asserting a specific number would be keying the canary on the
+// environment. Any js.hs-scripts.com loader means tracking is wired up, which is
+// the regression this guards — the script silently vanished when its portal ID
+// stopped being set in the deployed env (mitodl/hq#13258).
+const HUBSPOT_SCRIPT = 'script[src^="https://js.hs-scripts.com/"]'
+
+test.describe("MIT Learn HubSpot tracking", () => {
+  test("loads the HubSpot tracking script for an anonymous visitor", async ({ page }) => {
+    await page.goto("/")
+
+    // Next renders this <Script strategy="afterInteractive"> as a preload +
+    // flight descriptor server-side and injects the executable tag only after
+    // hydration, so the tag is not in the initial HTML. toHaveCount auto-retries
+    // until it appears rather than reading a count once and racing hydration.
+    await expect(page.locator(HUBSPOT_SCRIPT)).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/13300

### Description (What does it do?)

Adds a Concourse Playwright **canary** asserting the HubSpot tracking script loads on `learn.mit.edu`, so the missing-tracking-script regression (#13258) can't recur silently.

- New anonymous spec [`hubspot-tracking.spec.ts`](https://github.com/mitodl/ol-infrastructure/blob/910ce615b/src/ol_concourse/pipelines/canaries/specs/mit-learn/hubspot-tracking.spec.ts) under `specs/mit-learn/`, asserting a `script[src^="https://js.hs-scripts.com/"]` is present on the homepage.
- **Real browser on purpose:** the tag is injected [after hydration](https://github.com/mitodl/mit-learn/blob/c4a317e3435217eeeb1d3f5672b5e55d1ce97ed8/frontends/main/src/app/%28site%29/layout.tsx#L93), so a raw-HTML check misses it. Asserts the script's presence, not the portal ID (which differs per environment), so it holds true of every environment.
- No `pipeline.py` / `meta.py` change — `spec_paths` defaults to the whole property directory, so a new spec just runs.

### Screenshots (if appropriate):

N/A — canary/infra change, no UI. See **How can this be tested?**

### How can this be tested?

**1. Manual (local) — passes when the script is present**

With mit-learn running and `frontends/main/.env.local` containing `NEXT_PUBLIC_HUBSPOT_PORTAL_ID=23128026` (`yarn workspace main dev`, default `http://open.odl.local:8062`), confirm it serves the script:

```bash
curl -s http://open.odl.local:8062/ | grep -o 'js.hs-scripts.com/[0-9]*\.js'
# -> js.hs-scripts.com/23128026.js
```

Then run the spec (Node 24):

```bash
cd src/ol_concourse/pipelines/canaries
npm ci
npx playwright install chromium
CANARY_BASE_URL=http://open.odl.local:8062 npx playwright test specs/mit-learn/hubspot-tracking.spec.ts --project=chromium
# -> 1 passed
```

**2. Manual — goes red for the actual regression**

Point it at RC, where the fix (#5808) isn't deployed yet, so the script is absent:

```bash
CANARY_BASE_URL=https://rc.learn.mit.edu npx playwright test specs/mit-learn/hubspot-tracking.spec.ts --project=chromium
# -> 1 failed: expect(locator).toHaveCount — Expected: 1, Received: 0
```

It will pass on RC once #5808 is deployed to the QA stack.

**3. Automated (typecheck)**

```bash
cd src/ol_concourse/pipelines/canaries
npm run typecheck
# -> tsc --noEmit, no errors
```

### Additional Context

Related ticket and PRs:

- Origin issue this guards against: https://github.com/mitodl/hq/issues/13258
- Ask to catch this regression class (pdpinch): https://github.com/mitodl/hq/issues/13258#issuecomment-5619179218
- The fix this canary guards: https://github.com/mitodl/ol-infrastructure/pull/5808
- Moved env reads to runtime (the mechanism behind the regression): https://github.com/mitodl/mit-learn/pull/3364

**Merge/deploy order matters.** This canary asserts the script *is present*, so it will page until the portal-ID fix is live on the environment it runs against (RC = the **QA** stack, `origin: https://rc.learn.mit.edu` in `Pulumi.QA.yaml`). Land and deploy #5808 first, then this.