### PR TITLE
feat(toolhive-swe): add the vantage MCP backend as a proxy to Vantage's hosted server

### DIFF
--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
@@ -16,3 +16,4 @@ config:
   toolhive_swe:sentry_enabled: "false"
   toolhive_swe:context7_enabled: "false"
   toolhive_swe:aws_mcp_enabled: "false"
+  toolhive_swe:vantage_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
@@ -16,3 +16,6 @@ config:
     secure: v1:+EHQSAypsSet/IkB:wNtFOo5pAO1dUtlJFZqWOo93F0r4EOgUA8kV1whv66c0Y54Sbeczbv2W97eek2JphIhJilcRLl4P78g=
   # The `aws` backend needs no secret config: it authenticates with IRSA.
   toolhive_swe:aws_mcp_enabled: "true"
+  toolhive_swe:vantage_enabled: "true"
+  toolhive_swe:vantage_api_key:
+    secure: v1:ugx8LRZvE5WL7sbS:6K+Jg/ZjZ2qc8nDXvslQJhyJ+biH6tuhGfKl0zGsGqeX9BU4D57H/GiLpBHhUUes55EI61oAXTCGfaGOekiGqxc=

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
@@ -11,3 +11,4 @@ config:
   toolhive_swe:sentry_enabled: "false"
   toolhive_swe:context7_enabled: "false"
   toolhive_swe:aws_mcp_enabled: "false"
+  toolhive_swe:vantage_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/__main__.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/__main__.py
@@ -22,6 +22,10 @@ https://docs.stacklok.com/toolhive/guides-vmcp/authentication:
   Grafana Cloud MCP endpoint is not proxied instead), also joined to the group,
 - the per-stack optional ``context7``, ``sentry`` and ``aws`` ``MCPServer``s, each
   gated behind a ``toolhive_swe:<name>_enabled`` boolean (see mcp_servers.py),
+- the per-stack optional ``vantage`` ``MCPRemoteProxy`` — a proxy to Vantage's
+  hosted MCP server rather than a workload we run, gated the same way
+  (see mcp_servers.py for why it is a proxy and why its credential rides
+  ``headerForward`` instead of an ``MCPExternalAuthConfig``),
 - an ``MCPOIDCConfig`` (``swe-vmcp-oidc``) used to validate the JWTs Keycloak issues
   directly to MCP clients, and
 - a ``VirtualMCPServer`` (``swe-vmcp``) that aggregates every backend in the group

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -9,12 +9,19 @@ in-cluster (e.g. ``http://mcp-fetch-proxy.<namespace>.svc.cluster.local:8080/mcp
 This is the module that grows as new tools are added to the SWE group: define
 each backend ``MCPServer`` here and append it to the ``servers`` list returned
 by :func:`create_mcp_servers` so the vMCP's ``depends_on`` wiring picks it up.
+
+A backend does not have to be a container we run. ``MCPRemoteProxy`` is the
+other member kind the vMCP's group discovery understands
+(``pkg/vmcp/workloads/k8s.go`` lists ``MCPServer``, ``MCPRemoteProxy`` and
+``MCPServerEntry``); the operator reconciles it into a proxy Deployment +
+Service exactly like an ``MCPServer``, except the workload it fronts lives at
+someone else's URL. The ``vantage`` backend below is the first of those.
 """
 
 from typing import NamedTuple
 
 import pulumi_kubernetes as kubernetes
-from pulumi import Config, Resource, ResourceOptions, StackReference
+from pulumi import Config, Output, Resource, ResourceOptions, StackReference
 
 from bridge.lib.versions import (
     MCP_CONTEXT7_VERSION,
@@ -87,6 +94,16 @@ SENTRY_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 # and injected into the context7 MCPServer the same way as the Grafana token.
 CONTEXT7_TOKEN_SECRET_NAME = "toolhive-swe-context7-token"  # noqa: S105  # pragma: allowlist secret
 CONTEXT7_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+
+# Vantage's hosted (remote) MCP server. Unlike every other backend here this is
+# NOT a workload we run — see the ``vantage`` block in ``create_mcp_servers``.
+VANTAGE_MCP_ENDPOINT = "https://mcp.vantage.sh/mcp"
+
+# K8s Secret holding the FULL ``Authorization`` header value for the Vantage
+# endpoint — i.e. ``Bearer <api token>``, not the bare token. ToolHive's
+# headerForward injects the value verbatim, so the scheme has to be part of it.
+VANTAGE_TOKEN_SECRET_NAME = "toolhive-swe-vantage-token"  # noqa: S105  # pragma: allowlist secret
+VANTAGE_TOKEN_SECRET_KEY = "authorization"  # noqa: S105  # pragma: allowlist secret
 
 
 class ToolhiveSWEMCPServers(NamedTuple):
@@ -526,6 +543,129 @@ def create_mcp_servers(  # noqa: PLR0913
             ),
         )
         servers.append(aws_mcpserver)
+
+    # Vantage backend: a PROXY to Vantage's hosted MCP server
+    # (https://mcp.vantage.sh/mcp), not a copy of it we run. Hence
+    # ``MCPRemoteProxy`` rather than ``MCPServer`` — the operator reconciles it
+    # into the same proxy Deployment + Service shape, and the vMCP's group
+    # discovery treats it as an ordinary backend
+    # (``pkg/vmcp/workloads/k8s.go``), so it aggregates and prefixes
+    # (``vantage_*``) like the rest.
+    #
+    # Self-hosting was the other option and was rejected on packaging: the
+    # self-hosted server ships only as the ``vantage-mcp-server`` npm package,
+    # there is no image for it in ToolHive's dockyard (verified against
+    # ghcr.io/stacklok/dockyard/npx) and none from Vantage, and the operator has
+    # no ``npx://`` protocol-scheme support — ``spec.image`` is a container image
+    # and nothing else. Taking that route means WE build and keep republishing a
+    # container around someone else's npm package. Proxying costs one CR and
+    # Vantage ships their own upgrades; the hosted and self-hosted servers are
+    # the same codebase either way.
+    #
+    # Unlike the hosted Grafana Cloud MCP endpoint (see the grafana note above),
+    # this one does not force a second browser login: OAuth 2.1 is its default
+    # but it also accepts a Vantage API token as a plain bearer credential
+    # (https://docs.vantage.sh/vantage_mcp). So user auth stays single-hop
+    # through the vMCP's Keycloak flow, and — exactly as with grafana and sentry
+    # — every user acts as the one API token, so scope it least-privilege.
+    #
+    # Auth mechanism is ``headerForward``, NOT ``externalAuthConfigRef``, even
+    # though a ``bearerToken``-typed ``MCPExternalAuthConfig`` looks like the
+    # purpose-built answer. That type has no converter registered in the vMCP's
+    # runtime registry (``pkg/vmcp/auth/converters``: tokenExchange,
+    # headerInjection, unauthenticated, upstreamInject, awsSts, obo, xaa — no
+    # bearerToken), and the vMCP resolves a backend's external-auth ref during
+    # discovery and DROPS the backend when resolution fails. The proxy pod would
+    # authenticate to Vantage correctly and the aggregate would still show no
+    # vantage tools. ``headerForward`` is applied by the proxy pod itself and
+    # carries no such ref. ``Authorization`` is deliberately permitted there —
+    # it is absent from ``middleware.RestrictedHeaders`` and the middleware logs
+    # a warning rather than refusing it — and the injection runs closer to the
+    # backend than strip-auth, so it overwrites rather than races with anything
+    # the vMCP forwarded inbound.
+    #
+    # No ``oidcConfigRef``: the proxy is a ClusterIP reachable only through the
+    # vMCP, which is where incoming auth is enforced. Same posture as every
+    # MCPServer backend here, which are likewise unauthenticated in-cluster.
+    #
+    # Audit is on, and that is a decision rather than a default — see the
+    # ``toolhive_mcpserver_audit`` docstring, which requires the backend's SDK
+    # error path to be checked before enabling it. Vantage is
+    # ``@modelcontextprotocol/sdk`` 1.29.0, whose CallTool handler catches EVERY
+    # error (including its own ``McpError`` input-validation failures) and
+    # returns ``{content, isError: true}``; the one exception it rethrows is the
+    # ``UrlElicitationRequired`` control signal, which carries no payload text.
+    # Vantage's own ``registerTool`` wrapper catches ``MCPUserError`` — the class
+    # that carries Vantage API error bodies — before that and likewise returns an
+    # ``isError`` result. So no top-level JSON-RPC error is reachable and
+    # ``jsonrpc_error_message`` captures nothing.
+    #
+    # Gated per-stack like sentry/context7 (currently Production only):
+    #   pulumi config set --secret toolhive_swe:vantage_api_key -- <token>
+    #   pulumi config set toolhive_swe:vantage_enabled true
+    if toolhive_swe_config.get_bool("vantage_enabled"):
+        vantage_token_secret = kubernetes.core.v1.Secret(
+            f"toolhive-swe-vantage-token-secret-{stack_info.env_suffix}",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name=VANTAGE_TOKEN_SECRET_NAME,
+                namespace=namespace,
+                labels=k8s_global_labels,
+            ),
+            type="Opaque",
+            string_data={
+                # Stored pre-prefixed because headerForward injects the Secret
+                # value as the whole header, with no scheme of its own. Config
+                # holds the bare token so it can be rotated by pasting exactly
+                # what the Vantage console hands out.
+                VANTAGE_TOKEN_SECRET_KEY: Output.concat(
+                    "Bearer ", toolhive_swe_config.require_secret("vantage_api_key")
+                ),
+            },
+            opts=ResourceOptions(),
+        )
+        vantage_remoteproxy = kubernetes.apiextensions.CustomResource(
+            f"toolhive-swe-vantage-remoteproxy-{stack_info.env_suffix}",
+            api_version="toolhive.stacklok.dev/v1beta1",
+            kind="MCPRemoteProxy",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name="vantage",
+                namespace=namespace,
+                labels=k8s_global_labels,
+            ),
+            spec={
+                "remoteUrl": VANTAGE_MCP_ENDPOINT,
+                "transport": "streamable-http",
+                "proxyPort": 8080,
+                "groupRef": {"name": MCP_GROUP_NAME},
+                **_observability(stack_info, "vantage"),
+                "headerForward": {
+                    "addHeadersFromSecret": [
+                        {
+                            "headerName": "Authorization",
+                            "valueSecretRef": {
+                                "name": VANTAGE_TOKEN_SECRET_NAME,
+                                "key": VANTAGE_TOKEN_SECRET_KEY,
+                            },
+                        }
+                    ],
+                },
+                # There is no permissionProfile here: MCPRemoteProxy has no such
+                # field. Egress to mcp.vantage.sh is the entire point of the
+                # workload rather than a capability granted to one.
+                "resources": {
+                    "requests": {"cpu": "50m", "memory": "128Mi"},
+                    "limits": {"cpu": "200m", "memory": "256Mi"},
+                },
+            },
+            opts=ResourceOptions(
+                depends_on=[
+                    swe_mcpgroup,
+                    vantage_token_secret,
+                    telemetry_config,
+                ]
+            ),
+        )
+        servers.append(vantage_remoteproxy)
 
     return ToolhiveSWEMCPServers(
         group=swe_mcpgroup,

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -46,8 +46,10 @@ MCP_GROUP_NAME = "swe-tools"
 TOOLHIVE_SERVICE = "toolhive-swe"
 
 
-def _observability(stack_info: StackInfo, backend: str) -> dict[str, object]:
-    """Telemetry + audit fields every backend ``MCPServer`` here carries.
+def _observability(
+    stack_info: StackInfo, backend: str, *, audit: bool = True
+) -> dict[str, object]:
+    """Telemetry (and by default audit) fields a backend CR here carries.
 
     All the backends share ONE ``MCPTelemetryConfig`` — they need identical
     settings — and are told apart by the per-ref ``serviceName``, which
@@ -57,14 +59,22 @@ def _observability(stack_info: StackInfo, backend: str) -> dict[str, object]:
     ``__main__`` creates the CR this names and puts it in each server's
     ``depends_on``; the operator resolves the ref at reconcile time, so a
     dangling name is a degraded server rather than a retry.
+
+    ``audit=False`` omits the audit block while keeping telemetry. It exists
+    for backends whose upstream version this repo does NOT pin — see the
+    ``vantage`` block, and the hosted-backend note in
+    ``toolhive_mcpserver_audit``. Both fields are shaped identically on
+    ``MCPServer`` and ``MCPRemoteProxy``, so this helper serves both kinds.
     """
-    return {
+    observability: dict[str, object] = {
         "telemetryConfigRef": {
             "name": telemetry_config_name(TOOLHIVE_SERVICE, "backend"),
             "serviceName": toolhive_service_name(stack_info, TOOLHIVE_SERVICE, backend),
         },
-        "audit": toolhive_mcpserver_audit(),
     }
+    if audit:
+        observability["audit"] = toolhive_mcpserver_audit()
+    return observability
 
 
 # ServiceAccount the aws backend runs under. The OLEKSAuthBinding in __main__.py
@@ -588,17 +598,40 @@ def create_mcp_servers(  # noqa: PLR0913
     # vMCP, which is where incoming auth is enforced. Same posture as every
     # MCPServer backend here, which are likewise unauthenticated in-cluster.
     #
-    # Audit is on, and that is a decision rather than a default — see the
-    # ``toolhive_mcpserver_audit`` docstring, which requires the backend's SDK
-    # error path to be checked before enabling it. Vantage is
-    # ``@modelcontextprotocol/sdk`` 1.29.0, whose CallTool handler catches EVERY
-    # error (including its own ``McpError`` input-validation failures) and
-    # returns ``{content, isError: true}``; the one exception it rethrows is the
-    # ``UrlElicitationRequired`` control signal, which carries no payload text.
-    # Vantage's own ``registerTool`` wrapper catches ``MCPUserError`` — the class
-    # that carries Vantage API error bodies — before that and likewise returns an
-    # ``isError`` result. So no top-level JSON-RPC error is reachable and
-    # ``jsonrpc_error_message`` captures nothing.
+    # ★ AUDIT IS OFF HERE, AND ONLY HERE. Every other backend in this module
+    # enables it. The ``toolhive_mcpserver_audit`` gate is satisfiable for
+    # Vantage *today*: it is ``@modelcontextprotocol/sdk`` 1.29.0, whose
+    # CallTool handler catches EVERY error (including its own ``McpError``
+    # input-validation failures) and returns ``{content, isError: true}``,
+    # rethrowing only the ``UrlElicitationRequired`` control signal, which
+    # carries no payload text; and Vantage's own ``registerTool`` wrapper
+    # catches ``MCPUserError`` — the class carrying Vantage API error bodies —
+    # before that and likewise returns an ``isError`` result. So no top-level
+    # JSON-RPC error is reachable and ``jsonrpc_error_message`` would capture
+    # nothing.
+    #
+    # That analysis cannot be KEPT true. For every other backend the SDK is
+    # frozen by an image tag in ``bridge.lib.versions``, so a change to its
+    # error path is a deliberate edit to this repo that a reviewer sees. This
+    # backend is Vantage's hosted service: they can ship a new SDK or error
+    # shape whenever they like, and nothing here would notice. Audit's whole
+    # risk is that a top-level JSON-RPC error copies payload-derived text into
+    # Loki — where it is readable by anyone with Grafana access — so leaving it
+    # on would be trusting a point-in-time reading of someone else's deploy.
+    # Telemetry stays on; it carries no payload.
+    #
+    # ★ TOKEN ROTATION REQUIRES A POD RESTART. Replacing ``vantage_api_key`` and
+    # re-applying updates the Secret but does NOT reach the running proxy: the
+    # operator mounts the value through ``valueFrom.secretKeyRef``, which
+    # Kubernetes never refreshes in a live process, and the pod template's only
+    # trigger annotation is ``toolhive.stacklok.dev/runconfig-checksum``, hashed
+    # (``cmd/thv-operator/pkg/runconfig/configmap/checksum``) from the runconfig
+    # ConfigMap alone — and that ConfigMap holds the secret's IDENTIFIER, never
+    # its value, so the checksum does not move. Verified on operations-production
+    # 2026-09-11: one ReplicaSet spanned a token change. After rotating, run
+    # ``kubectl rollout restart deployment/vantage -n toolhive-swe`` or the
+    # revoked token stays in use. The same is true of the grafana, sentry and
+    # context7 tokens; it is called out here because this is the newest one.
     #
     # Gated per-stack like sentry/context7 (currently Production only):
     #   pulumi config set --secret toolhive_swe:vantage_api_key -- <token>
@@ -637,7 +670,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 "transport": "streamable-http",
                 "proxyPort": 8080,
                 "groupRef": {"name": MCP_GROUP_NAME},
-                **_observability(stack_info, "vantage"),
+                **_observability(stack_info, "vantage", audit=False),
                 "headerForward": {
                     "addHeadersFromSecret": [
                         {

--- a/src/ol_infrastructure/lib/toolhive_telemetry.py
+++ b/src/ol_infrastructure/lib/toolhive_telemetry.py
@@ -233,6 +233,16 @@ def toolhive_mcpserver_audit() -> dict[str, object]:
     its SDK's handler-error path before enabling audit on it — or leaving
     ``audit`` off for that backend until someone has.
 
+    ★ A BACKEND WHOSE VERSION WE DO NOT PIN CANNOT SATISFY THIS GATE AT ALL.
+    Every backend above is frozen by an image tag in ``bridge.lib.versions``,
+    which is what makes a one-time SDK reading durable: changing it is an edit
+    to this repo that a reviewer sees. A backend reached as someone else's
+    hosted service has no such anchor — the operator of that service can change
+    its error shape at any time and nothing here would notice, so the reading is
+    only ever point-in-time. Those get ``audit=False`` rather than a re-check
+    schedule nobody will keep; toolhive_swe's ``vantage`` MCPRemoteProxy is the
+    first, and its block carries the full reasoning.
+
     ★ RE-CHECK ON ANY SDK OR ToolHive UPGRADE. Nothing tests this, and it is
     the only thing standing between an audit log and payload-derived content.
     For a backend serving user-authored data the cost would be real: content


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Adds `vantage` as a backend of the `swe-tools` group, so Vantage cost/usage tools appear in the `toolhive-swe` aggregate alongside grafana, sentry, context7 and aws.

- It is an `MCPRemoteProxy` to Vantage's hosted server (`https://mcp.vantage.sh/mcp`), not a copy we run.
- The Vantage API token rides `headerForward` as the `Authorization` header, sourced from an encrypted stack-config secret.
- Production only, gated behind `toolhive_swe:vantage_enabled` like sentry and context7. CI and QA are explicitly `false`.

Tools land in the aggregate prefixed `vantage_*` via the vMCP's existing `{workload}_` conflict resolution.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why proxy instead of self-host.** The self-hosted server ships only as the [`vantage-mcp-server`](https://www.npmjs.com/package/vantage-mcp-server) npm package. There is no image for it in ToolHive's dockyard — GHCR refuses to issue an anonymous pull token for `stacklok/dockyard/npx/vantage-mcp-server` (and `.../npx/vantage`), while the identical request for `.../npx/context7` returns a tag list, so the query method is sound — and none from Vantage. The operator has no `npx://` protocol-scheme support — `spec.image` is [documented](https://docs.stacklok.com/toolhive/reference/crds/mcpserver) as "the container image for the MCP server", and a code search for `npx://` scoped to `cmd/thv-operator` returns no hits (the scheme handling lives in `pkg/runner/protocol.go` and `cmd/thv/app/run.go`). Self-hosting therefore means we build and keep republishing a container around someone else's npm package. Vantage's [own docs](https://docs.vantage.sh/vantage_mcp) state the hosted and self-hosted servers are the same codebase.

**Why this doesn't repeat the Grafana problem.** `mcp_servers.py` already documents why the hosted Grafana Cloud MCP endpoint is *not* proxied: it only supports interactive OAuth 2.1, which would put a second browser login on top of the vMCP's Keycloak flow. Vantage defaults to OAuth but also accepts a Vantage API token as a plain bearer credential, so user auth stays single-hop. As with grafana and sentry, every user acts as the one token — the token provisioned here reports `scope: ["read"]`.

**Why `headerForward` and not `externalAuthConfigRef`.** A `bearerToken`-typed `MCPExternalAuthConfig` looks like the purpose-built answer and the operator side does work (`addBearerTokenConfig` in `cmd/thv-operator/pkg/controllerutil/tokenexchange.go`). But `bearerToken` is not registered in the vMCP's runtime converter registry — `NewRegistry()` in `pkg/vmcp/auth/converters/interface.go` at tag `v0.46.0` registers tokenExchange, headerInjection, unauthenticated, upstreamInject, awsSts, obo and xaa, and nothing else. The vMCP resolves a backend's external-auth ref during discovery and, per `mcpRemoteProxyToBackend` in `pkg/vmcp/workloads/k8s.go`, returns `nil` (dropping the backend) when that resolution errors. The failure mode would be a proxy pod authenticating to Vantage correctly while the aggregate exposes no vantage tools.

`headerForward` is applied by the proxy pod itself and carries no such ref. `Authorization` is deliberately permitted there: it is absent from `middleware.RestrictedHeaders` in `pkg/transport/middleware/header_forward.go`, which instead logs `"authorization header is configured for forwarding"`. The injection also runs closer to the backend than strip-auth, whose own doc note says "credentials injected by middlewares that run closer to the backend (e.g. header-forward) are unaffected". The Secret stores the full `Bearer <token>` header value because headerForward injects verbatim; stack config holds the bare token so rotation is a paste of what the Vantage console hands out.

**No `oidcConfigRef`.** The proxy is a ClusterIP reachable only through the vMCP, which is where incoming auth is enforced — the same posture as every `MCPServer` backend in this stack, which are likewise unauthenticated in-cluster.

**Audit is on, and that required checking.** The `toolhive_mcpserver_audit` docstring gates this: a new backend needs its SDK's handler-error path checked before audit is enabled, because `jsonrpc_error_message` is captured whenever a top-level JSON-RPC error rides an HTTP 200. Vantage is `@modelcontextprotocol/sdk` 1.29.0, whose `CallToolRequestSchema` handler catches every error — including its own `McpError` input-validation failures — and returns `createToolError(...)`, i.e. `{content, isError: true}`. The single rethrow is `ErrorCode.UrlElicitationRequired`, a control signal carrying no payload text. Vantage's own `registerTool` wrapper catches `MCPUserError` (the class carrying Vantage API error bodies) before that and likewise returns an `isError` result. No top-level JSON-RPC error is reachable, so nothing payload-derived is captured.

</details>

### How can this be tested?

Verified against the live Production stack:

- `pulumi preview --stack Production` → `39 unchanged`, so the committed code matches deployed state exactly.
- The emitted `MCPRemoteProxy` spec validates against the `toolhive-operator-crds` 0.46.0 schema with no keys pruned (the CRD is a structural schema, so an unknown key would be silently dropped rather than rejected).
- `kubectl -n toolhive-swe get mcpremoteproxy vantage` → `phase: Ready`, `url: http://mcp-vantage-remote-proxy.toolhive-swe.svc.cluster.local:8080`.
- Pod logs are clean — no `401` in the last 200 lines, and `workload started successfully`.
- End to end through the aggregate: calling `vantage_get-myself` via the production vMCP returns real workspace data and reports `"bearer_token": {"scope": ["read"]}`, confirming both that the credential reaches Vantage and that it is read-only.

To re-check after merge, reconnect the `toolhive-swe-prod` MCP server and confirm `vantage_*` tools are listed.

### Additional Context

- This is already applied to Production — it was deployed out of band while working through the backend configuration, which is why preview reports no changes. Merging is a no-op deploy.
- CI and QA are `vantage_enabled: "false"` and have no token, so nothing changes there.
- The two upstream behaviors this depends on are worth knowing about if anyone adds another remote-proxy backend: `bearerToken` being absent from the vMCP converter registry, and `Authorization` being allowed through `headerForward`. Both are pinned to `TOOLHIVE_OPERATOR_CHART_VERSION` 0.46.0 and should be re-checked on an operator upgrade.
