### PR TITLE
feat(keycloak): add a QA-only throwaway partner org for the state handover rehearsal

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -23,7 +23,7 @@ from ol_infrastructure.substructure.keycloak.org_sso_helpers import (
 )
 
 
-def create_olapps_realm(  # noqa: PLR0913, PLR0915
+def create_olapps_realm(  # noqa: C901, PLR0913, PLR0915
     keycloak_provider: keycloak.Provider,
     keycloak_url: str,
     env_name: str,
@@ -974,6 +974,31 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             resource_options=resource_options,
         )
     )
+
+    # A fake partner with the same Organization -> SAML IdP -> mappers shape as
+    # the production onboardings below, so the move of per-org resources out of
+    # Pulumi state can be rehearsed somewhere other than production partner SSO.
+    # Delete once the rehearsal runbook is written up.
+    if stack_info.env_suffix == "qa":
+        onboard_saml_org(
+            SamlIdpConfig(
+                idp_alias="handover-rehearsal",
+                idp_display_name="Handover Rehearsal (QA only)",
+                org_saml_metadata_url="https://sso.ol.mit.edu/realms/olapps/protocol/saml/descriptor",
+                keycloak_url=keycloak_url,
+                realm_id=ol_apps_realm.id,
+                first_login_flow=ol_first_login_flow,
+                resource_options=resource_options,
+            ),
+            org=OrgConfig(
+                org_domains=["handover-rehearsal.mit.edu"],
+                org_name="Handover Rehearsal",
+                org_alias="handover-rehearsal",
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                resource_options=resource_options,
+            ),
+        )
 
     if stack_info.env_suffix == "production":
         onboard_saml_org(


### PR DESCRIPTION
### What are the relevant tickets?

Prerequisite for moving per-org Keycloak resources out of Pulumi state, part of the B2B onboarding design in https://github.com/mitodl/hq/discussions/12784.

### Description (What does it do?)

Adds one fake partner, `handover-rehearsal`, to the `olapps` realm on the QA stack only. It goes through the same `onboard_saml_org` path as a real partner: an Organization with a verified domain (`handover-rehearsal.mit.edu`), a SAML IdP linked to it, and the IdP's attribute mappers.

Every real partner onboarding in `olapps.py` sits inside the `env_suffix == "production"` block. CI and QA get only `moira` and `company-x`, and neither has an IdP. So the retain_on_delete handover has nowhere to be tried except the Production stack. Today that stack holds 113 organization, IdP and IdP-mapper resources: 25 Organizations, 15 SAML IdPs, 11 OIDC IdPs, and 62 mappers. With this change, QA has a cluster of the same shape to practice on.

Metadata comes from the production `olapps` realm's SAML descriptor. The rehearsal only needs the resources to exist, not a working login through them.

`create_olapps_realm` gets a `C901` noqa. The extra `if` takes its complexity to 11, and the noqa comes back out with the block.

### How can this be tested?

Checked before opening:
- A local `pulumi preview --stack QA` on this branch shows **32 to create, 265 unchanged**, and nothing updated or deleted. The 32 are 1 Organization, 1 `saml/IdentityProvider`, and 30 `AttributeImporterIdentityProviderMapper`. The descriptor publishes no attributes, so all 30 mapper names come from the `SAML_FRIENDLY_NAMES` fallback. No other QA drift rides along.
- QA Keycloak fetches and parses the descriptor itself: `identity-provider/import-config` with `fromUrl` returns the SSO URL, entity ID and a signing cert.
- The live QA realm has orgs `company-x`, `mit`, `moira` and `Proton`, and no partner IdP. `identity-provider/instances/handover-rehearsal` returns 404, so neither the alias nor the domain is taken.

After merge, QA needs a manual trigger, because only CI auto-deploys. Then:
- `pulumi stack export --stack QA | jq '[.deployment.resources[] | select(.urn|test("handover-rehearsal"))] | length'` should return 32.
- The admin API should show the org and the IdP, with 30 mappers on the IdP.

### Additional context

This is stage 1 of 4. Each later stage is its own PR plus a QA deploy:
1. Land the cluster (this PR).
2. Pass `retain_on_delete=True` for this org's resources only. Check that all 32 entries carry `retainOnDelete: true` in `pulumi stack export`. The field is `omitempty`, so a missing key means the flag is not live.
3. Remove the block. Afterwards the 32 URNs are gone from state, and the realm still has the org, the IdP and 30 mappers.
4. Rehearse the failure mode on purpose: remove the block without the flag live, and record what the realm loses.

After that, the org is deleted from QA by hand, and the runbook goes into the migration task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrFRmSw9CSWr8eHkzyYjGg
