### PR TITLE
feat(concourse): derive the ocw/fastly_learn purge credential

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -1,3 +1,10 @@
+"""Deploy the Concourse application across CI, QA, and Production.
+
+This stack takes a StackReference on applications/mit_learn for the Fastly service
+ID behind the ocw/fastly_learn credential, so that project must have deployed in an
+environment before this one can provision the credential there.
+"""
+
 import sys
 
 from ol_concourse.lib.models.fragment import PipelineFragment

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -352,14 +352,26 @@ vault.generic.Secret(
         ]
     ).apply(json.dumps),
 )
-for pipeline_var_path, secret_data in read_yaml_secrets(
+pipeline_secrets = read_yaml_secrets(
     Path(f"concourse/operations.{stack_info.env_suffix}.yaml")
-)["pipelines"].items():
+)["pipelines"]
+# The OCW publish pipelines purge the MIT Learn Fastly service by surrogate key,
+# which needs that service's ID alongside a purge token. Both halves are derived
+# rather than transcribed: the token is the shared purge key that already covers
+# every service in the account, and the ID is read from the stack that owns the
+# service, so no opaque service ID is ever hand-entered.
+if "shared/fastly" in pipeline_secrets:
+    mitlearn_stack = make_stack_reference(projects.MIT_LEARN, stack_info.name)
+    pipeline_secrets["ocw/fastly_learn"] = {
+        "api_token": pipeline_secrets["shared/fastly"]["api_token"],
+        "service_id": mitlearn_stack.require_output("mit_learn")["fastly_service_id"],
+    }
+for pipeline_var_path, secret_data in pipeline_secrets.items():
     secret_path = partial("{1}/{0}".format, pipeline_var_path)
     vault.generic.Secret(
         f"concourse-pipeline-credentials-{pipeline_var_path}",
         path=concourse_secrets_mount.path.apply(secret_path),
-        data_json=json.dumps(secret_data),
+        data_json=Output.json_dumps(secret_data),
     )
 
 # Vault policy definition

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -2248,5 +2248,6 @@ export(
             mitlearn_vault_iam_role.backend, mitlearn_vault_iam_role.name
         ).apply(lambda role: f"{role[0]}/roles/{role[1]}"),
         "app_security_group_id": mitlearn_app_security_group.id,
+        "fastly_service_id": mitlearn_fastly_service.id,
     },
 )


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/13254 — part of https://github.com/mitodl/hq/issues/13251. Pairs with https://github.com/mitodl/ocw-studio/pull/3199, which renders `((fastly_learn.api_token))` and `((fastly_learn.service_id))` into the live cache-clear step.

### Description (What does it do?)

Provisions the `fastly_learn` Concourse credential for the `ocw` team without storing a Fastly service ID anywhere.

- `applications/mit_learn` exports `fastly_service_id` off the `fastly.ServiceVcl` it already manages.
- `applications/concourse` builds `secret-concourse/ocw/fastly_learn` from two values that already exist: the service ID read from the stack that owns the service, and the shared Fastly purge token added in #5809.
- No SOPS file changes. Nothing hand-entered, and the token is not duplicated — rotating `shared/fastly` rotates this credential too.

<details>
<summary><b>Implementation details</b></summary>
<br>

The issue's plan was to add a `fastly_learn` entry with a literal `service_id`, matching `ocw/fastly_draft` and `ocw/fastly_live`. This derives both halves instead, so there is no second copy of the token to rotate and no opaque ID to go stale.

**Service ID.** `learn_service_id_{ci,qa,production}` were hand-entered under `pipelines.infrastructure/fastly` in the production SOPS file by 5a55db413 and are read by nothing in the repo. Rather than adding a fourth copy, the concourse stack takes a `StackReference` to `applications.mit_learn.<env>` and reads the new output. The repo already treats domain-or-stack resolution as the norm over stored IDs — [`k8s_apps/pipeline.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py#L256-L294) purges this same service via `mitodl/concourse-fastly-resource` with `domain`, documented as "no opaque service IDs need to be stored in Vault", and [`ocw_site`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/ocw_site/__main__.py#L1290-L1291) exports its own Fastly IDs the same way this change does.

**Token.** `pipelines.shared/fastly.api_token` exists at the same path and key name in both `operations.qa.yaml` and `operations.production.yaml`; #5809 ("replicate the Fastly purge key into QA", filed against #13251) and #5811 put it there for this work. Copying the value into `ocw/fastly_learn` would mean two ciphertexts to rotate, so the stack reads it in place. Note that Concourse already exposes it to every team via the `shared/` fallback, so this is not a privilege change — it only binds it to the `fastly_learn` var name that ocw-studio expects.

**Serialization.** The loop moves from `json.dumps` to `Output.json_dumps` because `service_id` is an `Output`. For the plain dicts of every other entry the two are byte-identical, confirmed by asserting equality on a sample dict, so no existing credential resource is rewritten.

</details>

### How can this be tested?

`applications/mit_learn` QA preview — output-only, no resource changes, and the ID resolves off the live service:

```
Outputs:
  ~ mit_learn: {
      + fastly_service_id : "05crh..."
    }
Resources:
    155 unchanged
```

`applications/concourse` QA preview cannot complete until the above is deployed, because the output it reads does not exist yet. It reaches `KeyError: 'fastly_service_id'` during serialization, having reported `117 unchanged` and `1 to update` for the resources it did evaluate. That one pending update is inherited from `main`: a refresh of the `ol-infrastructure-consul/operations.QA` StackReference whose outputs changed when e3852df2e removed the `salt_minion` and `ssh` security groups. No pipeline-credential resource is modified.

End-to-end verification after deploy, per https://github.com/mitodl/ocw-studio/pull/3199:

1. Warm two courses until both report `x-cache: HIT` — `curl -sI https://rc.learn.mit.edu/courses/o/<course-slug>/ | grep -i x-cache`
2. Republish one in ocw-studio.
3. The republished course must come back `x-cache: MISS`; the other must stay `HIT`.

### Additional Context

- **Deploy order matters.** `applications/mit_learn` must be deployed before `applications/concourse` in each of QA and Production, or the concourse stack raises `KeyError` on the unpublished output. The failure is loud rather than silently writing a null `service_id`, which is why it is not guarded. The mit_learn side is output-only, so deploying it first is a no-op for running infrastructure.
- **Token scope is not independently verified.** I could not decrypt the secrets to inspect the token's Fastly scopes, so the claim that `shared/fastly.api_token` can purge the MIT Learn services rests on #5809 having added it as the purge key for this work, plus `infrastructure/fastly.fastly_api_token` being used to purge `{ci,rc,}learn.mit.edu` from `k8s_apps` today. Worth a reviewer confirming it carries `purge_select` before the first live publish.
- **`learn_service_id_{ci,qa,production}` are left in place** under `pipelines.infrastructure/fastly` in the production SOPS file. They now have no reader in this repo and contradict this approach, but a manually configured pipeline outside the repo could still reference them, and the values are not recoverable once deleted. Suggest removing them in a follow-up once that is ruled out.
- The CI concourse stack is unaffected: `operations.ci.yaml` has no `shared/fastly` entry, so the block is skipped and no StackReference to `applications.mit_learn.CI` is created.

### Checklist:
- [ ] Deploy `applications/mit_learn` (QA, then Production) before `applications/concourse`
- [ ] Confirm the `shared/fastly` token carries Fastly `purge_select` for the MIT Learn services
- [ ] Re-upsert the ocw-studio pipelines after https://github.com/mitodl/ocw-studio/pull/3199 merges — purge args are baked in at render time
