### PR TITLE
feat(dagster): grant IRx read on the IRx delivery bucket

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -517,15 +517,11 @@ irx_export_bucket = OLBucket(
 
 # IRx reads with the static key of an IAM user created by hand in 2022, which is
 # what Simeon is configured with. Its read policy and attachment were made in the
-# console too and are imported here so the grant lives in code. An import only
-# succeeds when the declared resource matches the live one, so this document is
-# the live one verbatim (Sids included); the IRx bucket is added once the import
-# has been applied.
+# console too and were adopted into this stack by import (#5822). The user itself
+# stays unmanaged. The mitx-etl-* grants cover the legacy_openedx drop, which is
+# the only delivery path to IRx until the facade's parallel run passes.
 if stack_info.env_suffix == "production":
     irx_user_name = "institutional-research-edx-data-exports-access"
-    irx_read_policy_arn = (
-        f"arn:aws:iam::{aws_account.account_id}:policy/edx-data-extracts-read-only"
-    )
     irx_read_policy = iam.Policy(
         "irx-edx-data-extracts-read-only",
         name="edx-data-extracts-read-only",
@@ -548,6 +544,7 @@ if stack_info.env_suffix == "production":
                         "Resource": [
                             "arn:aws:s3:::mitx-etl-*/*",
                             "arn:aws:s3:::*production-edxapp-tracking/*",
+                            f"arn:aws:s3:::{irx_export_bucket_name}/*",
                         ],
                     },
                     {
@@ -557,20 +554,19 @@ if stack_info.env_suffix == "production":
                         "Resource": [
                             "arn:aws:s3:::mitx-etl-*",
                             "arn:aws:s3:::*production-edxapp-tracking",
+                            f"arn:aws:s3:::{irx_export_bucket_name}",
                         ],
                     },
                 ],
             }
         ),
-        opts=ResourceOptions(import_=irx_read_policy_arn, protect=True),
+        opts=ResourceOptions(protect=True),
     )
     iam.UserPolicyAttachment(
         "irx-edx-data-extracts-read-only-attachment",
         user=irx_user_name,
         policy_arn=irx_read_policy.arn,
-        opts=ResourceOptions(
-            import_=f"{irx_user_name}/{irx_read_policy_arn}", protect=True
-        ),
+        opts=ResourceOptions(protect=True),
     )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2359 (retire `legacy_openedx`). Second apply of #5822.

### Description (What does it do?)

#5822 imported IRx's console-made policy `edx-data-extracts-read-only` and its attachment to `institutional-research-edx-data-exports-access`, with the document held identical to the live v2 so the import would succeed. That has applied to Production: both resources are in the stack state with `protect=True`.

This PR:

- drops `import_` from both resources and keeps `protect=True`;
- adds `ol-irx-partners-storage-production` to the ListBucket statement and `ol-irx-partners-storage-production/*` to the GetObject statement.

The `mitx-etl-*` and `*production-edxapp-tracking` grants stay. The legacy drop is the only delivery path to IRx until the facade's parallel run passes, and removing them belongs to the decommission step.

### How can this be tested?

From `src/ol_infrastructure/applications/dagster/`:

```
pulumi preview --stack Production --diff
pulumi preview --stack QA --diff
```

What I got:

- Production: `~ 3 to update`. The policy gains the two ARNs above and nothing else in its document changes. No step for the user attachment. The other two are the Helm releases: `dagster-helm-release-production` moves its image tag `ef407b82` to `latest` because `__main__.py` falls back to `latest` outside CI (as on #5822). `dagster-user-code-release-production` masks its values as `[secret]`, but the changed fields are each deployment's `image.tag` and the same two env entries.
- QA: `~ 2 to update`, the same two Helm releases. The IRx resources are production-only.
- pre-commit (ruff, mypy) passes.

After apply, `aws iam get-policy-version` on the new default version should list the bucket in both statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsLfWeogyWUMMzieEeUGx
