### PR TITLE
feat(starrocks): provision a b2b_learner_records database

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -558,21 +558,23 @@ CREATE DATABASE IF NOT EXISTS b2b_analytics;
 GRANT CREATE TABLE ON DATABASE b2b_analytics TO ROLE app;
 GRANT CREATE MATERIALIZED VIEW ON DATABASE b2b_analytics TO ROLE app;"""
 
-_b2b_analytics_db_drop_sql = "DROP DATABASE IF EXISTS b2b_analytics;"
-
+# No delete step and no delete_before_replace. The database is persistent
+# infrastructure holding every b2b_analytics MV, and `triggers` replaces this
+# command whenever the SQL changes -- so with a DROP DATABASE delete, adding a
+# grant would destroy the tables and MVs before recreating an empty database,
+# and a stack teardown would do the same. CREATE DATABASE IF NOT EXISTS is
+# idempotent, so a replacement simply re-runs it. Same reasoning as
+# roles_setup_cmd above: dropping the database is a deliberate manual act.
 command.local.Command(
     f"starrocks-{stack_info.env_suffix}-b2b-analytics-database-setup",
     create=_exec_sql,
     update=_exec_sql,
-    delete=_exec_delete_sql,
     environment={
         **_mysql_env,
         "STARROCKS_SQL": _b2b_analytics_db_sql,
-        "STARROCKS_DELETE_SQL": _b2b_analytics_db_drop_sql,
     },
     triggers=[hashlib.sha256(_b2b_analytics_db_sql.encode()).hexdigest()],
     opts=ResourceOptions(
-        delete_before_replace=True,
         depends_on=[roles_setup_cmd],
     ),
 )
@@ -589,21 +591,18 @@ CREATE DATABASE IF NOT EXISTS b2b_learner_records;
 GRANT CREATE TABLE ON DATABASE b2b_learner_records TO ROLE app;
 GRANT CREATE MATERIALIZED VIEW ON DATABASE b2b_learner_records TO ROLE app;"""
 
-_b2b_learner_records_db_drop_sql = "DROP DATABASE IF EXISTS b2b_learner_records;"
-
+# No delete step, for the same reason as b2b_analytics above -- more so here,
+# since this database holds individually identifying learner records.
 command.local.Command(
     f"starrocks-{stack_info.env_suffix}-b2b-learner-records-database-setup",
     create=_exec_sql,
     update=_exec_sql,
-    delete=_exec_delete_sql,
     environment={
         **_mysql_env,
         "STARROCKS_SQL": _b2b_learner_records_db_sql,
-        "STARROCKS_DELETE_SQL": _b2b_learner_records_db_drop_sql,
     },
     triggers=[hashlib.sha256(_b2b_learner_records_db_sql.encode()).hexdigest()],
     opts=ResourceOptions(
-        delete_before_replace=True,
         depends_on=[roles_setup_cmd],
     ),
 )

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -577,6 +577,37 @@ command.local.Command(
     ),
 )
 
+# --- b2b_learner_records database -------------------------------------------
+# Individually identifying learner records for ol-analytics-api's
+# b2b_learner_records tenant (ol-data-platform models/b2b_learner_records).
+# Kept out of b2b_analytics so these PII-bearing MVs can be granted to that
+# tenant's role on their own once per-tenant StarRocks users with
+# schema-scoped grants land; until then the catalog-wide SELECT grants above
+# still reach them. Same privilege shape as b2b_analytics (see there).
+_b2b_learner_records_db_sql = """\
+CREATE DATABASE IF NOT EXISTS b2b_learner_records;
+GRANT CREATE TABLE ON DATABASE b2b_learner_records TO ROLE app;
+GRANT CREATE MATERIALIZED VIEW ON DATABASE b2b_learner_records TO ROLE app;"""
+
+_b2b_learner_records_db_drop_sql = "DROP DATABASE IF EXISTS b2b_learner_records;"
+
+command.local.Command(
+    f"starrocks-{stack_info.env_suffix}-b2b-learner-records-database-setup",
+    create=_exec_sql,
+    update=_exec_sql,
+    delete=_exec_delete_sql,
+    environment={
+        **_mysql_env,
+        "STARROCKS_SQL": _b2b_learner_records_db_sql,
+        "STARROCKS_DELETE_SQL": _b2b_learner_records_db_drop_sql,
+    },
+    triggers=[hashlib.sha256(_b2b_learner_records_db_sql.encode()).hexdigest()],
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=[roles_setup_cmd],
+    ),
+)
+
 # --- OIDC / OAuth2 authentication via Keycloak ------------------------------
 # StarRocks v3.5+ uses a "security integration" (SQL object) to hold OAuth2
 # provider settings rather than fe.conf env vars.  The integration name goes


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Needed by https://github.com/mitodl/ol-data-platform/pull/2669.

### Description (What does it do?)
Two things:

1. **Adds a `b2b_learner_records` StarRocks database**, with the same grants `b2b_analytics` has: CREATE TABLE and CREATE MATERIALIZED VIEW on the database to role `app`. ol-data-platform #2669 adds individually identifying learner-record MVs for ol-analytics-api's learner-records tenant. Review there asked that they not share `b2b_analytics` with the k-anonymized aggregate views, so a per-tenant, schema-scoped grant can later reach one set without the other. Until that isolation work lands, the existing catalog-wide `SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES` grants still cover the new database.

2. **Stops both b2b database commands dropping their database** (from review on this PR). Each carried `delete=DROP DATABASE` with `delete_before_replace=True`, and `triggers` replaces the command whenever its SQL changes — so adding a grant would have destroyed every table and MV in the database before recreating it empty, and a stack teardown would have done the same. `CREATE DATABASE IF NOT EXISTS` is idempotent, so a replacement can simply re-run it. This touches the **pre-existing `b2b_analytics` block** as well as the new one, since it had the identical hazard. Dropping either database is now a deliberate manual act, matching how `roles_setup_cmd` already treats persistent objects.

### How can this be tested?
- Pre-commit passes (ruff, mypy).
- `pulumi preview -s lakehouse.QA`: 1 to create, 2 to update, 15 unchanged.
  - `starrocks-qa-b2b-learner-records-database-setup`: create.
  - `starrocks-qa-b2b-analytics-database-setup`: update **in place** (`diff: -delete ~environment`) — the delete command and its `STARROCKS_DELETE_SQL` env var are removed. No replace and no delete are planned against the deployed database.
  - `starrocks-qa-keycloak-group-sync`: update. That is the usual local-checkout artifact — its command string embeds the script's path, which differs between my worktree and the CI build directory. This PR does not touch it.
- After deploy: `SHOW DATABASES LIKE 'b2b_learner_records'` and `SHOW GRANTS FOR ROLE app` on each cluster.

### Additional Context
Deploy this before #2669 merges, so the database and its `app` grants exist when Dagster first builds the MVs into it. That's the same arrangement as `b2b_analytics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FmjwANjfgtuKAtsRPf6Ly
