### PR TITLE
feat(dagster): wire the ml code location into Opik

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -130,6 +130,14 @@ mitxonline_stack = (
     if stack_info.env_suffix in ("ci", "qa", "production")
     else None
 )
+# Opik is also deployed to CI/QA/Production only. The ml code location traces its
+# LLM calls there; on the Dev stack OPIK_URL_OVERRIDE stays unset and the ml
+# code's tracing is a no-op.
+opik_stack = (
+    make_stack_reference(projects.OPIK, stack_info.name)
+    if stack_info.env_suffix in ("ci", "qa", "production")
+    else None
+)
 
 # VPC and network configuration
 mitodl_zone_id = dns_stack.require_output("odl_zone_id")
@@ -2627,6 +2635,25 @@ for location in code_locations:
                 "name": "MITXONLINE_APP_DB_HOST",
                 "value": mitxonline_stack.require_output("mitxonline")["rds_host"],
             }
+        )
+
+    # ml's Opik tracing and Prompt Library. Only the non-secret settings live
+    # here: the code reads the Keycloak client-credentials from Vault at
+    # secret-operations/sso/opik itself (dagster_server_policy.hcl), the same
+    # secret learn_ai syncs. No OPIK_API_KEY -- the Keycloak auth hook owns the
+    # Authorization header (see the opik stack's OPIK_SDK_KEYCLOAK_AUTH.md).
+    if name == "ml" and opik_stack is not None:
+        deployment["env"].extend(
+            [
+                {
+                    "name": "OPIK_URL_OVERRIDE",
+                    "value": opik_stack.require_output("opik_url").apply(
+                        lambda url: f"{url}/api/"
+                    ),
+                },
+                {"name": "OPIK_WORKSPACE", "value": "default"},
+                {"name": "OPIK_PROJECT_NAME", "value": "dagster-ml"},
+            ]
         )
 
     # Add higher resources for lakehouse deployment (runs dbt)

--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -8,6 +8,10 @@ path "secret-global/*" {
 path "secret-operations/sso/dagster" {
   capabilities = ["read"]
 }
+# Keycloak client-credentials for Opik, read by the ml code location
+path "secret-operations/sso/opik" {
+  capabilities = ["read"]
+}
 path "mariadb-xpro/creds/readonly/*" {
   capabilities = ["read"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
Supports https://github.com/mitodl/ol-data-platform/pull/2662

### Description (What does it do?)
Wires the Dagster `ml` code location into Opik, so the LLM tracing and Prompt Library added in mitodl/ol-data-platform#2662 work outside local dev.

- **Env vars on the `ml` deployment only:** `OPIK_URL_OVERRIDE` (derived from the opik stack's `opik_url`, the same way learn_ai does it), `OPIK_WORKSPACE`, and `OPIK_PROJECT_NAME=dagster-ml`.
- **Environments:** CI, QA and Production only. Opik has no Dev stack, so the reference uses the same guard as the Keycloak and MITx Online stack references, and Dev stays untraced.
- **Vault:** read access to `secret-operations/sso/opik` for the `dagster` Vault role. The ml code reads the Keycloak client-credentials from there itself; learn_ai syncs the same secret.

### How can this be tested?
I ran `pulumi preview --stack QA --diff`:
- The Vault policy gains the `sso/opik` path.
- Deployment 9 (`ml`) gains three env entries; no other deployment gains any.
- The remaining diffs (image tags → `latest`, OTEL `service.version`) come from running preview without the Concourse `DAGSTER_*_IMAGE_TAG` vars, not from this change.

pre-commit (ruff, mypy) passes.

After deploying to QA: materialize an LLM-calling feedback asset and check the `dagster-ml` project in Opik for its traces.

### Additional Context
Safe to merge before mitodl/ol-data-platform#2662. The `ml` code on `main` doesn't read any `OPIK_*` variable, so these stay inert until the Opik code ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJV252XExQ39SmC2NVfxMC
