### PR TITLE
fix(rootly): stop Dagster alerts paging on-call

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -90,6 +90,22 @@ CLOUDWATCH_NON_PROD_URGENCY_RULES = [
     },
 ]
 
+# Dagster's metadata database. Its alarms are worth seeing but not worth waking
+# anyone for: Dagster retries and backfills, so a degraded control plane costs
+# pipeline latency, not user-facing availability. DiskQueueDepth in particular
+# is expected to breach and self-clear about weekly (see the RDS comment in
+# applications/dagster/__main__.py), and paged on-call at High on 2026-09-11.
+# Medium routes to #devops-warnings only; see the Medium urgency paths below.
+CLOUDWATCH_DAGSTER_DB_URGENCY_RULES = [
+    {
+        "alertUrgencyId": "fce5c971-6660-4ad9-90eb-e75122055f50",
+        "jsonPath": "$.Message.AlarmName",
+        "kind": "payload",
+        "operator": "contains",
+        "value": "ol-etl-db-production",
+    },
+]
+
 # Deliberately no CUSTOM deduplication-key or resolution-rule config on the two
 # CloudWatch sources below -- deduplicate_alerts_by_key is switched off so that
 # Rootly's native cloud_watch behaviour handles both, keyed on something better
@@ -2957,7 +2973,10 @@ alerts_source_cloudwatch_critical = rootly.AlertsSource(
         {"alertFieldId": "4a3add3c-5611-4dd9-ba65-4fb60b7f4fc6"},
         {"alertFieldId": "45a09cf3-b0f2-43cf-b596-34aaab9279dc"},
     ],
-    alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
+    alert_source_urgency_rules_attributes=[
+        *CLOUDWATCH_NON_PROD_URGENCY_RULES,
+        *CLOUDWATCH_DAGSTER_DB_URGENCY_RULES,
+    ],
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplicate_alerts_by_key=False,
     deduplication_key_kind="payload",
@@ -2977,7 +2996,10 @@ alerts_source_cloudwatch_warning = rootly.AlertsSource(
         {"alertFieldId": "4a3add3c-5611-4dd9-ba65-4fb60b7f4fc6"},
         {"alertFieldId": "45a09cf3-b0f2-43cf-b596-34aaab9279dc"},
     ],
-    alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
+    alert_source_urgency_rules_attributes=[
+        *CLOUDWATCH_NON_PROD_URGENCY_RULES,
+        *CLOUDWATCH_DAGSTER_DB_URGENCY_RULES,
+    ],
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplicate_alerts_by_key=False,
     deduplication_key_kind="payload",
@@ -3112,6 +3134,20 @@ alerts_source_grafana_prometheus_production = rootly.AlertsSource(
                 "HPAAtMaxReplicasCritical",
             ]
         ],
+        # Every Dagster rule (metric_rules/dagster_*.py, log_rules/dagster_*.py).
+        # Their production *Critical twins arrived at High and paged:
+        # DagsterQueuedRunStuckCritical and DagsterRunFailureRateCritical on
+        # 2026-09-10 around 20:45 ET. A stalled or failing Dagster delays data
+        # pipelines by hours; nothing user-facing is down, so it can wait for
+        # business hours. `contains` rather than an alertname list so a new or
+        # renamed Dagster rule cannot bypass this and page.
+        {
+            "alertUrgencyId": "fce5c971-6660-4ad9-90eb-e75122055f50",
+            "jsonPath": "$.commonLabels.alertname",
+            "kind": "payload",
+            "operator": "contains",
+            "value": "Dagster",
+        },
     ],
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplication_key_kind="payload",
@@ -3298,7 +3334,16 @@ alerts_source_pingdom = rootly.AlertsSource(
             "kind": "payload",
             "operator": "is",
             "value": "LOW",
-        }
+        },
+        # Same reasoning as the Dagster rule on the Grafana Production source.
+        # Matches the "Dagster Checks to Dagster Webapp" route's condition.
+        {
+            "alertUrgencyId": "fce5c971-6660-4ad9-90eb-e75122055f50",
+            "jsonPath": "$.check_name",
+            "kind": "payload",
+            "operator": "contains",
+            "value": "Dagster",
+        },
     ],
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplication_key_kind="payload",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Production Dagster alerts reach Rootly at High urgency, the only tier that pages. They're useful signal, but a degraded Dagster delays pipelines rather than taking anything user-facing down, so they shouldn't wake anyone. Recent ones, all High and all notifying the on-call engineer:

- `DagsterQueuedRunStuckCritical`, 2026-09-10: Rootly `sR94WK` at 16:45 ET, then `IJMabp` at 20:46 ET for the same stuck queue.
- `DagsterRunFailureRateCritical` (`i8kCWC`), 20:42 ET the same evening.
- `simple-rds-ol-etl-db-production-DiskQueueDepth` (`psrsl2`), 2026-09-11 16:21 ET. The dagster stack's own comment expects this alarm to breach and self-clear about weekly.

This demotes them to Medium, which today routes to #devops-warnings only (held off-hours by the deferral path, Slack-only in business hours). For comparison, `KnIn6x`, a Medium `PodCrashLoopingCritical` created at 02:41 ET on 2026-09-11, notified nobody. Three urgency rules in `src/ol_infrastructure/saas/rootly/__main__.py`:

- **Grafana Prometheus - Production:** `$.commonLabels.alertname` contains `Dagster`. Covers every rule in `metric_rules/dagster_control_plane.py`, `metric_rules/dagster_pgbouncer.py` and `log_rules/dagster_database.py`. `contains` rather than an alertname list, so a new or renamed Dagster rule can't bypass it.
- **Cloudwatch - Critical / Warning:** `$.Message.AlarmName` contains `ol-etl-db-production`, the Dagster metadata DB.
- **Pingdom:** `$.check_name` contains `Dagster`, the same condition as the existing "Dagster Checks to Dagster Webapp" route.

Generic rules that happen to fire in the `dagster` namespace (e.g. `DeploymentUnavailableCritical`) are unchanged. The noisy ones there (`PodCrashLoopingCritical`, `PodOOMKilledCritical`, `WorkloadJobFailedCritical`) were already demoted.

### How can this be tested?

From `src/ol_infrastructure/saas/rootly/`:

```
PULUMI_TERRAFORM_VERSION=1.5.0 pulumi preview --diff --stack default
```

Expect `~ 4 to update, 154 unchanged`: in-place appends to `alertSourceUrgencyRulesAttributes` on `grafana-prometheus-production`, `cloudwatch-critical`, `cloudwatch-warning` and `pingdom`. That's what I got locally. pre-commit (ruff, mypy) passes.

**Not verified:**

- A `contains` rule on `$.commonLabels.alertname` hasn't been exercised on the alertmanager source before. The operator is already in use on the CloudWatch payload rules. After deploy, the next production Dagster alert should show Medium in Rootly.
- I didn't confirm which Pingdom checks have "Dagster" in their name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WehVYPgQPRmHdePuDHhPro
