### PR TITLE
feat(release): move learn-ai to the release-resource workflow

### DIFF
--- a/src/bridge/settings/apps.py
+++ b/src/bridge/settings/apps.py
@@ -54,7 +54,9 @@ class AppRegistration:
 
 
 APPS: dict[str, AppRegistration] = {
-    "learn-ai": AppRegistration(slack_channel="product-learn-ai"),
+    "learn-ai": AppRegistration(
+        slack_channel="product-learn-ai", release_resource_workflow=True
+    ),
     "micromasters": AppRegistration(
         repo_main_branch="master", slack_channel="product-micromasters"
     ),


### PR DESCRIPTION
### What are the relevant tickets?

Part of the release-workflow rollout under mitodl/hq#7185. First app after ol-analytics-api.

### Description (What does it do?)

Sets `release_resource_workflow=True` on learn-ai in `src/bridge/settings/apps.py`. That one field switches both control surfaces: `k8s-apps-meta` regenerates `learn-ai-pipeline` in the release-resource shape, and the release bot stops refusing `/doof` commands for learn-ai.

After this merges, learn-ai releases the way ol-analytics-api does: `/doof release learn-ai` cuts `releases/<calver>`, builds the RC image and deploys QA with a release issue; closing the issue deploys production and merges the branch back to main. The `release-candidate` → `release` flow and Doof stop applying. A companion PR in mitodl/release-script removes learn-ai from Doof.

Why learn-ai first:
- No Doof release in flight: no `release-candidate` branch, no open release PR, and `release` is identical to `v0.36.1`.
- `v0.36.1` is an ancestor of main (14 commits ahead), so the first release's `since` is that tag, not the whole history.
- No calver tags and no `releases/*` branch. odl-video-service and mitxpro both carry leftover June `releases/2026.6.x.1` branches that the first `create` would supersede, so they need cleanup before their own flip.
- No Fastly purge or Sentry sourcemap config to carry over.

Version drift the first bump has to absorb: `main/settings.py` says `0.36.1`, while `pyproject.toml` and `uv.lock` say `0.34.0`, and `[tool.bumpversion]` has no `current_version`. The bump-version task sends that to the transition script (`NEEDS_SEED`). The script matches settings.py against the `v0.36.1` baseline, catches both `0.34.0` strings with its regex fallback, and inserts `current_version`. I traced this in ol-concourse's `bump_version_task`, and the live ol-analytics-api pipeline contains that same script. It has not run against learn-ai yet.

### How can this be tested?

Pipeline generated locally with the flip (`PYTHONPATH=src python src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py learn-ai`):
- Jobs: `build-learn-ai-image-from-main`, `build-learn-ai-release-image`, `abandon-learn-ai-release`, `deploy-ol-application-learn-ai-{ci,qa,production}`.
- With app names normalized, it is identical to ol-analytics-api's generated pipeline except for `refresh_stack: false` (already set for learn-ai) and learn-ai's own Pulumi trigger paths.
- Local generation matches production. Locally generated ol-analytics-api differs from `fly get-pipeline` only in Concourse normalization (`60m` vs `1h`, explicit defaults).

Preconditions checked today:
- ol-release-bot (installation 150138801) is installed on mitodl/learn-ai. Checked with the App-JWT script from #5716, which also shows it installed on all eight app repos.
- Both org rulesets that apply to learn-ai (`baseline-default-branch`, `tier-1-hardening`) list Integration 4437866 as an `always` bypass actor.

After merge:
- `create-learn-ai-pipeline` should fire, since `apps.py` is in `k8s-apps-meta`'s trigger paths. `fly -t odl-inf get-pipeline -p learn-ai-pipeline | grep -c NEEDS_SEED` should then be non-zero.
- The release-bot preview gate has to be closed before the bot accepts learn-ai commands.
- The first real `/doof release learn-ai` is the end-to-end check. The `bump-version` output should show `Inserted pyproject.toml current_version`.

### Additional Context

Not verified: whether the release bot has been invited to `#product-learn-ai`. The earlier release-bot notification outage came from missing channel membership.

This changes how the learn-ai team cuts releases, so they should hear about it before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSvo3NqRuCSJnK4j3DZCfm
